### PR TITLE
fix(telemetry): make Phoenix opt-in so offline runtime stays clean

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -37,7 +37,11 @@ class Settings(BaseSettings):
     # Model for high-quality generation (flashcards, etc).
     # Falls back to DEFAULT_MODEL when empty.
     LITELLM_GENERATION_MODEL: str = ""
-    PHOENIX_ENABLED: bool = True
+    # Opt-in: Phoenix is a dev observability server (launches on :6006, persists
+    # phoenix.db, instruments every LLM call). A local-first/offline runtime
+    # shouldn't pay that cost or its serializer noise by default — set
+    # PHOENIX_ENABLED=true in .env when you want tracing.
+    PHOENIX_ENABLED: bool = False
     OPENAI_API_KEY: str = ""
     ANTHROPIC_API_KEY: str = ""
     GOOGLE_API_KEY: str = ""

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -14,7 +14,7 @@ def test_settings_defaults():
         settings = Settings(_env_file=None)
         assert settings.LOG_LEVEL == "INFO"
         assert settings.LITELLM_DEFAULT_MODEL == "ollama/llama3.2"
-        assert settings.PHOENIX_ENABLED is True
+        assert settings.PHOENIX_ENABLED is False
     finally:
         for var, val in saved_vars.items():
             os.environ[var] = val

--- a/scripts/dev-logs.sh
+++ b/scripts/dev-logs.sh
@@ -9,8 +9,12 @@ set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Start backend with DEBUG logging; prefix each line with cyan [BACKEND]
-(cd "$REPO_ROOT/backend" && LOG_LEVEL=DEBUG uv run uvicorn app.main:app --reload --port 7820 2>&1) \
+# Start backend with DEBUG logging; prefix each line with cyan [BACKEND].
+# PHOENIX_ENABLED=true turns on the dev-only tracing UI (Monitoring view +
+# localhost:6006); the runtime default is off so end users skip it.
+# LITELLM_LOCAL_MODEL_COST_MAP / PHOENIX_TELEMETRY_ENABLED keep dev fully
+# offline-clean: no doomed GitHub cost-map fetch, no Phoenix phone-home.
+(cd "$REPO_ROOT/backend" && LOG_LEVEL=DEBUG PHOENIX_ENABLED=true LITELLM_LOCAL_MODEL_COST_MAP=true PHOENIX_TELEMETRY_ENABLED=false uv run uvicorn app.main:app --reload --port 7820 2>&1) \
     | awk 'BEGIN{p="\033[0;36m[BACKEND]\033[0m "}{print p $0; fflush()}' &
 BACKEND_PID=$!
 

--- a/scripts/luminary.sh
+++ b/scripts/luminary.sh
@@ -91,7 +91,7 @@ if [[ "$USE_DOCKER_BACKEND" == "true" ]]; then
         luminary-backend 2>&1) \
         | awk 'BEGIN{p="\033[0;36m[BACKEND]\033[0m  "}{print p $0; fflush()}' &
 else
-    (cd "$REPO_ROOT/backend" && DATA_DIR="$REPO_ROOT/.luminary" uv run uvicorn app.main:app --reload --port "$BACKEND_PORT" 2>&1) \
+    (cd "$REPO_ROOT/backend" && DATA_DIR="$REPO_ROOT/.luminary" PHOENIX_ENABLED=true LITELLM_LOCAL_MODEL_COST_MAP=true PHOENIX_TELEMETRY_ENABLED=false uv run uvicorn app.main:app --reload --port "$BACKEND_PORT" 2>&1) \
         | awk 'BEGIN{p="\033[0;36m[BACKEND]\033[0m  "}{print p $0; fflush()}' &
 fi
 BACKEND_PIPE_PID=$!


### PR DESCRIPTION
Phoenix's LiteLLMInstrumentor was the sole source of the pydantic "serializer warnings" seen offline: it serializes each completion onto a trace span, and on an empty Ollama completion falls back to ModelResponse.model_dump_json(), which litellm's own Choices/Message union schema can't serialize cleanly. Offline access itself was never broken (routing falls back to local Ollama correctly).

Phoenix is a dev observability server (launches :6006, persists phoenix.db, instruments every LLM call), so default it off — a local-first/offline end user shouldn't pay that cost or its noise. Developers opt in via PHOENIX_ENABLED=true.

- config: PHOENIX_ENABLED default True -> False; update test
- dev runners (dev-logs.sh, luminary.sh): export PHOENIX_ENABLED=true plus LITELLM_LOCAL_MODEL_COST_MAP=true and PHOENIX_TELEMETRY_ENABLED=false so dev keeps tracing and avoids doomed network calls when offline

**Description**
Include a summary of the changes and which issue is fixed. List any dependencies that are required for this change.

Fixes # (issue)

**Type of change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
