### PR TITLE
Personal recommender + Study-tab overhaul

### DIFF
--- a/backend/app/db_init.py
+++ b/backend/app/db_init.py
@@ -287,6 +287,9 @@ async def create_all_tables(engine: AsyncEngine) -> None:
             "ALTER TABLE eval_runs ADD COLUMN status TEXT NOT NULL DEFAULT 'complete'",
             "ALTER TABLE eval_runs ADD COLUMN error_message TEXT",
             "ALTER TABLE review_events ADD COLUMN predicted_rating TEXT",
+            # misconception lifecycle: open -> resolved (docs/recommender-spec.md)
+            "ALTER TABLE misconceptions ADD COLUMN status TEXT NOT NULL DEFAULT 'open'",
+            "ALTER TABLE misconceptions ADD COLUMN resolved_at DATETIME",
         ]:
             try:
                 await conn.execute(text(ddl))

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -318,6 +318,10 @@ class MisconceptionModel(Base):
     error_type: Mapped[str] = mapped_column(String, nullable=False)
     correction_note: Mapped[str] = mapped_column(Text, nullable=False)
     detected_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
+    # open|resolved -- resolved deterministically by a later good review / passing
+    # teach-back on the same flashcard, never by an LLM (docs/recommender-spec.md)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="open")
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
 
 class NoteModel(Base):
@@ -1048,6 +1052,22 @@ class ChatSuggestionHistoryModel(Base):
         DateTime, nullable=False, default=lambda: datetime.now(UTC)
     )
     session_id: Mapped[str | None] = mapped_column(String, nullable=True)
+
+
+class RecommendationFeedbackModel(Base):
+    __tablename__ = "recommendation_feedback"
+    __table_args__ = (
+        UniqueConstraint("kind", "target_type", "target_ref", name="uq_reco_kind_target"),
+    )
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    kind: Mapped[str] = mapped_column(String, nullable=False)
+    target_type: Mapped[str] = mapped_column(String, nullable=False)
+    target_ref: Mapped[str] = mapped_column(String, nullable=False)
+    shown_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_shown_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    dismissed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    acted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
 
 

--- a/backend/app/repos/flashcard_repo.py
+++ b/backend/app/repos/flashcard_repo.py
@@ -14,12 +14,29 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from fastapi import Depends
-from sqlalchemy import delete, select
+from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.models import ChunkModel, FlashcardModel
+from app.models import ChunkModel, CollectionMemberModel, FlashcardModel
 from app.services.repo_helpers import get_or_404
+
+
+def collection_card_filter(collection_id: str):
+    """A collection's flashcards are those sourced from its document members OR
+    its note members. Shared by search and delete so both target the same set."""
+    doc_members = select(CollectionMemberModel.member_id).where(
+        CollectionMemberModel.collection_id == collection_id,
+        CollectionMemberModel.member_type == "document",
+    )
+    note_members = select(CollectionMemberModel.member_id).where(
+        CollectionMemberModel.collection_id == collection_id,
+        CollectionMemberModel.member_type == "note",
+    )
+    return or_(
+        FlashcardModel.document_id.in_(doc_members),
+        FlashcardModel.note_id.in_(note_members),
+    )
 
 
 class FlashcardRepo:
@@ -85,6 +102,12 @@ class FlashcardRepo:
     async def list_ids_for_document(self, document_id: str) -> list[str]:
         result = await self.session.execute(
             select(FlashcardModel.id).where(FlashcardModel.document_id == document_id)
+        )
+        return list(result.scalars().all())
+
+    async def list_ids_for_collection(self, collection_id: str) -> list[str]:
+        result = await self.session.execute(
+            select(FlashcardModel.id).where(collection_card_filter(collection_id))
         )
         return list(result.scalars().all())
 

--- a/backend/app/routers/flashcards.py
+++ b/backend/app/routers/flashcards.py
@@ -682,6 +682,27 @@ async def delete_all_document_flashcards(
     )
 
 
+@router.delete("/collection/{collection_id}", response_model=BulkDeleteResponse)
+async def delete_all_collection_flashcards(
+    collection_id: str,
+    session: AsyncSession = Depends(get_db),
+    repo: FlashcardRepo = Depends(get_flashcard_repo),
+) -> BulkDeleteResponse:
+    """Delete every flashcard sourced from a collection's documents and notes.
+
+    Returns the deleted count so the UI can confirm. Keeps FTS in sync per I-4.
+    """
+    ids = await repo.list_ids_for_collection(collection_id)
+    for card_id in ids:
+        await _delete_flashcard_fts(card_id, session)
+    await repo.delete_by_ids(ids)
+    logger.info(
+        "Deleted all flashcards for collection",
+        extra={"collection_id": collection_id, "count": len(ids)},
+    )
+    return BulkDeleteResponse(deleted=len(ids))
+
+
 @router.post("/{card_id}/review", response_model=FlashcardResponse)
 async def review_flashcard(
     card_id: str,

--- a/backend/app/routers/home.py
+++ b/backend/app/routers/home.py
@@ -4,14 +4,16 @@ GET /home/overview is the single-fetch contract for the hub UI. It composes
 recent-activity, active-collections, recent-tags, and a today_action CTA so
 the hub never makes a follow-up call per section.
 
-Reads only -- the only writer of content_activity is ActivityService.
+Content tables are read-only here (the only writer of content_activity is
+ActivityService); the recommender upserts its own recommendation_feedback
+shown-counts as a side effect of the overview fetch.
 """
 
 from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,6 +28,7 @@ from app.schemas.home import (
     TodayAction,
     WeeklyStats,
 )
+from app.services import recommender_service
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +58,24 @@ async def get_home_overview(
     continue_reading = await _fetch_continue_reading(session)
     fading_items = await _fetch_fading_items(session)
     weekly_stats = await _fetch_weekly_stats(session)
-    today_action = await _pick_today_action(session, recent_items)
+
+    recommendations = await recommender_service.get_recommendations(session)
+    today_action: TodayAction | None = None
+    if recommendations:
+        top = recommendations[0]
+        if top.kind == "overdue_reviews":
+            # the legacy picker produces the same review_cards action enriched
+            # with collection context the hero renders -- reuse it, attach evidence
+            today_action = await _pick_today_action(session, recent_items)
+            if today_action is not None:
+                today_action.reasons = top.reasons
+                today_action.recommendation_id = top.id
+        else:
+            today_action = recommender_service.to_today_action(top)
+    if today_action is None:
+        # no candidate fired: degrade to the original heuristic floor
+        today_action = await _pick_today_action(session, recent_items, include_due_cards=False)
+
     return HomeOverviewResponse(
         today_action=today_action,
         recent_items=recent_items,
@@ -64,7 +84,26 @@ async def get_home_overview(
         continue_reading=continue_reading,
         fading_items=fading_items,
         weekly_stats=weekly_stats,
+        recommendations=recommendations[1:],
     )
+
+
+@router.post("/recommendations/{feedback_id}/dismiss", status_code=204)
+async def dismiss_recommendation(
+    feedback_id: str, session: AsyncSession = Depends(get_db)
+) -> Response:
+    if not await recommender_service.mark_dismissed(session, feedback_id):
+        raise HTTPException(status_code=404, detail="recommendation not found")
+    return Response(status_code=204)
+
+
+@router.post("/recommendations/{feedback_id}/acted", status_code=204)
+async def act_on_recommendation(
+    feedback_id: str, session: AsyncSession = Depends(get_db)
+) -> Response:
+    if not await recommender_service.mark_acted(session, feedback_id):
+        raise HTTPException(status_code=404, detail="recommendation not found")
+    return Response(status_code=204)
 
 
 async def _fetch_recent_items(session: AsyncSession, limit: int) -> list[RecentItem]:
@@ -217,22 +256,27 @@ async def _fetch_recent_tags(session: AsyncSession) -> list[RecentTag]:
 
 
 async def _pick_today_action(
-    session: AsyncSession, recent_items: list[RecentItem]
+    session: AsyncSession, recent_items: list[RecentItem], *, include_due_cards: bool = True
 ) -> TodayAction | None:
     """Heuristic priority: review-cards > continue-reading > resume-note > None.
 
     The hub renders whatever wins; it never has to pick between options.
+    include_due_cards=False when called as the recommender's fallback floor:
+    due cards are the recommender's signal there, and re-emitting them here
+    would resurrect a dismissed recommendation.
     """
     # 1. Due flashcards beat everything -- spaced repetition is time-sensitive.
-    due_row = (
-        await session.execute(
-            text(
-                "SELECT COUNT(*) FROM flashcards "
-                "WHERE due_date IS NOT NULL AND due_date <= datetime('now')"
+    due_count = 0
+    if include_due_cards:
+        due_row = (
+            await session.execute(
+                text(
+                    "SELECT COUNT(*) FROM flashcards "
+                    "WHERE due_date IS NOT NULL AND due_date <= datetime('now')"
+                )
             )
-        )
-    ).first()
-    due_count = int(due_row[0]) if due_row else 0
+        ).first()
+        due_count = int(due_row[0]) if due_row else 0
     if due_count > 0:
         top_col = (
             await session.execute(

--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -58,6 +58,7 @@ from app.schemas.study import (
     DocumentTopicsResponse,
     DueCountResponse,
     GapResult,
+    MisconceptionStatsResponse,
     RubricCompletenessResponse,
     RubricDimensionResponse,
     SectionHeatmapItem,
@@ -95,6 +96,13 @@ from app.services import study_assembler
 from app.services.fsrs_service import get_fsrs_service
 from app.services.llm import get_llm_service
 from app.services.mastery_service import get_mastery_service
+from app.services.misconceptions import (
+    PASSING_TEACHBACK_SCORE,
+    resolve_for_flashcard,
+)
+from app.services.misconceptions import (
+    get_stats as get_misconception_stats,
+)
 from app.services.settings_service import get_labs_enabled
 from app.services.study_path_service import StudyPathService
 from app.services.study_session_service import (
@@ -1311,6 +1319,11 @@ async def teachback(
             session=session,
         )
 
+    # this legacy path skips FSRS scheduling, so the resolve-on-good-review hook
+    # in fsrs_service never fires here -- resolve passing scores explicitly
+    if score >= PASSING_TEACHBACK_SCORE:
+        await resolve_for_flashcard(session, card.id)
+
     await session.commit()
     logger.info(
         "Teachback evaluated",
@@ -1999,6 +2012,13 @@ async def get_decay_debt(
     items.sort(key=lambda x: x.avg_retention)
     total_at_risk = sum(i.card_count for i in items)
     return DecayDebtResponse(items=items[:limit], total_at_risk=total_at_risk)
+
+
+@router.get("/misconception-stats", response_model=MisconceptionStatsResponse)
+async def misconception_stats(
+    session: AsyncSession = Depends(get_db),
+) -> MisconceptionStatsResponse:
+    return MisconceptionStatsResponse(**await get_misconception_stats(session))
 
 
 @router.get("/calibration-stats", response_model=CalibrationStatsResponse)

--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -50,7 +50,7 @@ from app.schemas.study import (
     CalibrationWeekItem,
     CardStabilityItem,
     CollectionSource,
-    CollectionSubEnclave,
+    CollectionSubCollection,
     CollectionTopic,
     DailyHistoryItem,
     DecayDebtItem,
@@ -919,27 +919,45 @@ async def get_collection_study_dashboard(
     # over the wire only to slice the first line.
     sources: list[CollectionSource] = []
     if doc_ids:
-        doc_title_rows = (
+        # Weight documents by CHUNK COUNT, not word_count: word_count is 0 on many
+        # large imported books (e.g. DDIA), which would starve the biggest source
+        # to zero cards when splitting a collection-wide generation total.
+        chunk_count_subq = (
+            select(func.count(ChunkModel.id))
+            .where(ChunkModel.document_id == DocumentModel.id)
+            .scalar_subquery()
+        )
+        doc_rows = (
             await session.execute(
-                select(DocumentModel.id, DocumentModel.title).where(
-                    DocumentModel.id.in_(list(doc_ids))
-                )
+                select(
+                    DocumentModel.id, DocumentModel.title, chunk_count_subq.label("chunks")
+                ).where(DocumentModel.id.in_(list(doc_ids)))
             )
         ).all()
-        for did, dtitle in doc_title_rows:
-            sources.append(CollectionSource(id=did, title=dtitle, type="document"))
+        for did, dtitle, dchunks in doc_rows:
+            sources.append(
+                CollectionSource(
+                    id=did, title=dtitle, type="document", weight=int(dchunks or 0)
+                )
+            )
     if note_ids:
         note_snippet_rows = (
             await session.execute(
                 select(
                     NoteModel.id,
                     func.substr(NoteModel.content, 1, 120).label("snippet"),
+                    func.length(NoteModel.content).label("chars"),
                 ).where(NoteModel.id.in_(list(note_ids)))
             )
         ).all()
-        for nid, snippet in note_snippet_rows:
+        for nid, snippet, chars in note_snippet_rows:
             ntitle = (snippet or "").split("\n")[0][:60] or "Untitled Note"
-            sources.append(CollectionSource(id=nid, title=ntitle, type="note"))
+            # express note size in chunk-equivalents (~1500 chars/chunk) so notes
+            # share a unit with documents; never 0 for a non-empty note.
+            note_weight = max(1, int((chars or 0) / 1500)) if chars else 0
+            sources.append(
+                CollectionSource(id=nid, title=ntitle, type="note", weight=note_weight)
+            )
 
     # 7. Sub-enclaves: for each direct child we already know its full descendant set.
     # Map descendant collection ID -> sub-enclave root, then bucket the members rows
@@ -1008,13 +1026,13 @@ async def get_collection_study_dashboard(
         ).all()
         child_name_map = {cid: name for cid, name in name_rows}
 
-    sub_collections: list[CollectionSubEnclave] = []
+    sub_collections: list[CollectionSubCollection] = []
     for child_id in direct_children:
         count = sum(cards_per_doc.get(d, 0) for d in sub_doc_ids.get(child_id, ())) + sum(
             cards_per_note.get(n, 0) for n in sub_note_ids.get(child_id, ())
         )
         sub_collections.append(
-            CollectionSubEnclave(
+            CollectionSubCollection(
                 id=child_id,
                 name=child_name_map.get(child_id, ""),
                 card_count=count,

--- a/backend/app/schemas/home.py
+++ b/backend/app/schemas/home.py
@@ -11,13 +11,50 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+RecommendationKind = Literal[
+    "overdue_reviews",
+    "weak_concept",
+    "open_misconception",
+    "calibration_blind_spot",
+    "stalled_reading",
+]
+
+
+class RecommendationReason(BaseModel):
+    """One evidence line behind a recommendation -- never asserted without one
+    (docs/recommender-spec.md)."""
+
+    signal: str
+    detail: str
+
+
+class Recommendation(BaseModel):
+    id: str  # recommendation_feedback row id -- the dismiss/acted handle
+    kind: RecommendationKind
+    target_type: Literal["study", "concept", "flashcard", "document"]
+    target_ref: str
+    label: str
+    score: float
+    reasons: list[RecommendationReason]
+    count: int | None = None
+    # navigation context; target_ref alone is not always routable
+    document_id: str | None = None
+    concept_slug: str | None = None
+
 
 class TodayAction(BaseModel):
     """Single, dominant CTA on the hub. Picked by the backend so the UI
     has one shape regardless of which signal was strongest."""
 
-    kind: Literal["review_cards", "continue_reading", "resume_note"]
-    target_id: str | None = None  # document_id for read; note_id for resume
+    kind: Literal[
+        "review_cards",
+        "continue_reading",
+        "resume_note",
+        "drill_concept",
+        "fix_misconception",
+        "confidence_check",
+    ]
+    target_id: str | None = None  # document_id for read; note_id for resume; slug for concepts
     label: str
     count: int | None = None  # total due-card count for kind='review_cards'
     # Focused collection context for review_cards — the most active project
@@ -26,6 +63,11 @@ class TodayAction(BaseModel):
     collection_name: str | None = None
     collection_color: str | None = None
     scoped_count: int | None = None  # due cards scoped to that collection
+    # evidence + feedback handle when the recommender picked this action
+    reasons: list[RecommendationReason] = []
+    recommendation_id: str | None = None
+    # doc fallback for fix_misconception when the card has no concept slug
+    document_id: str | None = None
 
 
 class RecentItem(BaseModel):
@@ -98,6 +140,8 @@ class HomeOverviewResponse(BaseModel):
     continue_reading: list[ContinueReadingItem] = []
     fading_items: list[FadingItem] = []
     weekly_stats: WeeklyStats | None = None
+    # evidence-scored next-best-actions after the hero (docs/recommender-spec.md)
+    recommendations: list[Recommendation] = []
 
 
 class CollectionTagChip(BaseModel):

--- a/backend/app/schemas/study.py
+++ b/backend/app/schemas/study.py
@@ -232,6 +232,12 @@ class CalibrationStatsResponse(BaseModel):
     weeks: list[CalibrationWeekItem]
 
 
+class MisconceptionStatsResponse(BaseModel):
+    open_count: int
+    resolved_count: int
+    resolved_last_30d: int
+
+
 # Collection dashboard
 
 

--- a/backend/app/schemas/study.py
+++ b/backend/app/schemas/study.py
@@ -251,9 +251,12 @@ class CollectionSource(BaseModel):
     id: str
     title: str
     type: str  # "document" | "note"
+    # approximate content size in words -- used to split a collection-wide
+    # generation total across sources proportionally (a book outweighs a note).
+    weight: int = 0
 
 
-class CollectionSubEnclave(BaseModel):
+class CollectionSubCollection(BaseModel):
     id: str
     name: str
     card_count: int
@@ -267,7 +270,7 @@ class StudyCollectionDashboardResponse(BaseModel):
     mastery_pct: float
     topics: list[CollectionTopic]
     sources: list[CollectionSource]
-    sub_collections: list[CollectionSubEnclave] = []
+    sub_collections: list[CollectionSubCollection] = []
 
 
 # Per-document session API (start/review)

--- a/backend/app/services/flashcard.py
+++ b/backend/app/services/flashcard.py
@@ -26,7 +26,6 @@ from app.services.flashcard_parsers import (
     _parse_llm_response,
 )
 from app.services.flashcard_prompts import (
-    _BLOOM_L3_INSTRUCTION,
     _BOOK_CONTENT_GUIDELINE,
     _DIFFICULTY_GUIDELINES,
     _TECH_TITLE_KEYWORDS,
@@ -77,7 +76,6 @@ __all__ = [
     "NOTES_CONCEPT_EXTRACT_TMPL",
     "TECH_FLASHCARD_SYSTEM",
     "TECH_FLASHCARD_USER_TMPL",
-    "_BLOOM_L3_INSTRUCTION",
     "_BOOK_CONTENT_GUIDELINE",
     "_CLOZE_BLANK_RE",
     "_DIFFICULTY_GUIDELINES",

--- a/backend/app/services/flashcard_generators.py
+++ b/backend/app/services/flashcard_generators.py
@@ -38,9 +38,9 @@ from app.services.flashcard_parsers import (
     _parse_llm_response,
     card_field,
     card_rejection_reason,
+    strip_source_ref,
 )
 from app.services.flashcard_prompts import (
-    _BLOOM_L3_INSTRUCTION,
     _BOOK_CONTENT_GUIDELINE,
     _DIFFICULTY_GUIDELINES,
     CLOZE_SYSTEM,
@@ -328,7 +328,7 @@ def _gate_cards(parsed: list) -> list[dict]:
         if not isinstance(item, dict):
             continue
         q = card_field(item, "question", "front", "q", "term", "prompt")
-        a = card_field(item, "answer", "back", "a", "definition", "response")
+        a = strip_source_ref(card_field(item, "answer", "back", "a", "definition", "response"))
         reason = card_rejection_reason(q, a)
         if reason:
             logger.info("flashcard: dropped low-quality card (%s): %r", reason, q[:80])
@@ -498,8 +498,6 @@ async def generate(
         first_sec = eligible_chunks[0].section_id if eligible_chunks else None
         if first_sec and first_sec in section_ctx:
             resolved_section_heading = _resolve_section_heading(eligible_chunks[0], section_ctx)
-
-    system_prompt += _BLOOM_L3_INSTRUCTION
 
     extra_instructions = ""
     if content_type == "book":

--- a/backend/app/services/flashcard_generators.py
+++ b/backend/app/services/flashcard_generators.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import logging
 import uuid
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import Literal
 
@@ -36,6 +37,7 @@ from app.services.flashcard_parsers import (
     _parse_concept_extract,
     _parse_llm_response,
     card_field,
+    card_rejection_reason,
 )
 from app.services.flashcard_prompts import (
     _BLOOM_L3_INSTRUCTION,
@@ -120,13 +122,19 @@ async def generate_technical(
     if not combined_text:
         return []
 
-    prompt = TECH_FLASHCARD_USER_TMPL.format(
-        count=count,
-        section_heading=section_heading or "(none)",
-        has_code=str(has_code),
-        admonition_type=admonition_type or "(none)",
-        text=combined_text,
-    )
+    async def _batch(want: int, avoid: list[str]) -> list[dict]:
+        prompt = TECH_FLASHCARD_USER_TMPL.format(
+            count=want,
+            section_heading=section_heading or "(none)",
+            has_code=str(has_code),
+            admonition_type=admonition_type or "(none)",
+            text=combined_text,
+        ) + _avoid_suffix(avoid)
+        raw = await llm.generate(
+            prompt, system=TECH_FLASHCARD_SYSTEM,
+            model=_generation_model(), stream=False,
+        )
+        return _gate_cards(_parse_llm_response(raw, document_id))
 
     await session.commit()  # Release read locks to prevent WAL deadlocks during LLM call
 
@@ -139,18 +147,12 @@ async def generate_technical(
         span.set_attribute("flashcard.requested_count", count)
         span.set_attribute("flashcard.mode", "technical")
 
-        raw = await llm.generate(
-            prompt, system=TECH_FLASHCARD_SYSTEM,
-            model=_generation_model(), stream=False,
-        )
-        cards_data = _parse_llm_response(raw, document_id)
+        cards_data = await _collect_with_backfill(count, _batch)
         span.set_attribute("flashcard.generated_count", len(cards_data))
 
     now = datetime.now(UTC)
     flashcards: list[FlashcardModel] = []
     for item in cards_data:
-        if not isinstance(item, dict):
-            continue
         question = str(item.get("question", "")).strip()
         answer = str(item.get("answer", "")).strip()
         source_excerpt = str(item.get("source_excerpt", "")).strip()
@@ -163,8 +165,6 @@ async def generate_technical(
             bloom_level = int(raw_bloom)
         else:
             bloom_level = None
-        if not question or not answer:
-            continue
         card = FlashcardModel(
             id=str(uuid.uuid4()),
             document_id=document_id,
@@ -306,6 +306,106 @@ async def generate_cloze(
     return flashcards
 
 
+# Extra LLM passes to backfill cards lost to the quality gate / parse failures,
+# so a request for N cards returns N rather than silently fewer.
+_MAX_GENERATION_RETRIES = 2
+
+
+def _avoid_suffix(avoid: list[str]) -> str:
+    """Prompt fragment steering a retry pass away from questions already kept."""
+    if not avoid:
+        return ""
+    listed = "; ".join(q[:120] for q in avoid[:20])
+    return f"\nDo NOT repeat or paraphrase these already-written questions: {listed}\n"
+
+
+def _gate_cards(parsed: list) -> list[dict]:
+    """Normalize parsed LLM items to {question, answer, source_excerpt, ...} and
+    drop any that fail the quality gate. Extra fields (bloom_level,
+    flashcard_type) pass through untouched for the caller to persist."""
+    kept: list[dict] = []
+    for item in parsed:
+        if not isinstance(item, dict):
+            continue
+        q = card_field(item, "question", "front", "q", "term", "prompt")
+        a = card_field(item, "answer", "back", "a", "definition", "response")
+        reason = card_rejection_reason(q, a)
+        if reason:
+            logger.info("flashcard: dropped low-quality card (%s): %r", reason, q[:80])
+            continue
+        kept.append({
+            **item,
+            "question": q,
+            "answer": a,
+            "source_excerpt": card_field(item, "source_excerpt", "source", "excerpt"),
+        })
+    return kept
+
+
+async def _collect_with_backfill(
+    count: int,
+    generate_batch: Callable[[int, list[str]], Awaitable[list[dict]]],
+) -> list[dict]:
+    """Run `generate_batch(want, avoid)` until `count` gate-passing cards are
+    collected or a pass stops making progress. Each retry is told which
+    questions are already accepted so it adds new cards instead of repeats.
+    Returns at most `count` cards."""
+    candidates: list[dict] = []
+    seen: set[str] = set()
+    attempts = 0
+    while len(candidates) < count and attempts <= _MAX_GENERATION_RETRIES:
+        batch = await generate_batch(count - len(candidates), [c["question"] for c in candidates])
+        attempts += 1
+        added = 0
+        for c in batch:
+            key = c["question"].lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            candidates.append(c)
+            added += 1
+        if added == 0:
+            break
+    if len(candidates) < count:
+        logger.info(
+            "flashcard: %d/%d usable cards after %d attempt(s) (model=%s)",
+            len(candidates), count, attempts, _generation_model() or "default",
+        )
+    return candidates[:count]
+
+
+async def _generate_concept_cards(
+    llm,
+    domain: str,
+    concepts: list,
+    combined_text: str,
+    difficulty: str,
+    parse_ctx: str,
+    count: int,
+) -> list[dict]:
+    """Concept-grounded card generation with quality-gate backfill. Shared by
+    the note-tag and collection-per-note paths. Parameters (not loop variables)
+    are captured by the inner batch closure, so it is safe to call in a loop."""
+
+    async def _batch(_want: int, avoid: list[str]) -> list[dict]:
+        prompt = NOTES_CARD_FROM_CONCEPTS_TMPL.format(
+            domain=domain,
+            difficulty=difficulty,
+            difficulty_guidelines=_DIFFICULTY_GUIDELINES.get(difficulty, ""),
+            concepts_json=json.dumps(concepts, ensure_ascii=False),
+            text=combined_text,
+        ) + _avoid_suffix(avoid)
+        raw = await llm.generate(
+            prompt, system=NOTES_CARD_FROM_CONCEPTS_SYSTEM,
+            model=_generation_model(), stream=False,
+        )
+        return _gate_cards(_parse_llm_response(raw, parse_ctx))
+
+    # cards are grounded one-per-concept, so the achievable count is bounded by
+    # how many concepts were extracted -- never retry past that
+    return await _collect_with_backfill(min(count, len(concepts)), _batch)
+
+
 async def generate(
     document_id: str,
     scope: Literal["full", "section"],
@@ -425,13 +525,22 @@ async def generate(
                 "Include code examples in questions where appropriate.\n"
             )
 
-    prompt = FLASHCARD_USER_TMPL.format(
-        count=count,
-        difficulty=difficulty,
-        difficulty_guidelines=_DIFFICULTY_GUIDELINES.get(difficulty, ""),
-        extra_instructions=extra_instructions,
-        text=combined_text,
-    )
+    async def _batch(want: int, avoid: list[str]) -> list[dict]:
+        batch_prompt = FLASHCARD_USER_TMPL.format(
+            count=want,
+            difficulty=difficulty,
+            difficulty_guidelines=_DIFFICULTY_GUIDELINES.get(difficulty, ""),
+            extra_instructions=extra_instructions,
+            text=combined_text,
+        ) + _avoid_suffix(avoid)
+        raw = await llm.generate(
+            batch_prompt, system=system_prompt,
+            model=_generation_model(), stream=False,
+            # force valid JSON; num_ctx: 2048 truncates the section text into junk
+            response_format={"type": "json_object"},
+            num_ctx=get_settings().OLLAMA_GENERATION_NUM_CTX,
+        )
+        return _gate_cards(_parse_llm_response(raw, document_id))
 
     await session.commit()  # Release read locks to prevent WAL deadlocks during LLM call
 
@@ -446,16 +555,8 @@ async def generate(
         if section_heading:
             span.set_attribute("flashcard.section_heading", section_heading)
 
-        raw = await llm.generate(
-            prompt, system=system_prompt,
-            model=_generation_model(), stream=False,
-            # force valid JSON; the prompt + one-shot example steer it to {"flashcards": [...]}.
-            # num_ctx: at the default 2048 the section text is truncated and the model emits junk.
-            response_format={"type": "json_object"},
-            num_ctx=get_settings().OLLAMA_GENERATION_NUM_CTX,
-        )
-        cards_data = _parse_llm_response(raw, document_id)
-        span.set_attribute("flashcard.generated_count", len(cards_data))
+        candidates = await _collect_with_backfill(count, _batch)
+        span.set_attribute("flashcard.generated_count", len(candidates))
 
     now = datetime.now(UTC)
 
@@ -465,28 +566,9 @@ async def generate(
 
     _existing_qs, existing_vecs = await _fetch_existing_embeddings("default", session)
 
-    candidates: list[dict] = []
-    for item in cards_data:
-        if not isinstance(item, dict):
-            continue
-        q = card_field(item, "question", "front", "q", "term", "prompt")
-        a = card_field(item, "answer", "back", "a", "definition", "response")
-        if q and a:
-            candidates.append({
-                **item,
-                "question": q,
-                "answer": a,
-                "source_excerpt": card_field(item, "source_excerpt", "source", "excerpt"),
-            })
-
     if not candidates:
         logger.warning(
-            "flashcard.generate: %d parsed items but 0 usable Q/A (model=%s); first-item keys=%s; "
-            "raw=%r",
-            len(cards_data),
-            _generation_model() or "default",
-            list(cards_data[0].keys()) if cards_data and isinstance(cards_data[0], dict) else None,
-            raw[:300],
+            "flashcard.generate: 0 usable cards (model=%s)", _generation_model() or "default"
         )
 
     if candidates and existing_vecs is not None:
@@ -615,31 +697,17 @@ async def generate_from_notes(
         if not concepts:
             return []
 
-        card_prompt = NOTES_CARD_FROM_CONCEPTS_TMPL.format(
-            domain=domain,
-            difficulty=difficulty,
-            difficulty_guidelines=_DIFFICULTY_GUIDELINES.get(difficulty, ""),
-            concepts_json=json.dumps(concepts, ensure_ascii=False),
-            text=combined_text,
+        cards_data = await _generate_concept_cards(
+            llm, domain, concepts, combined_text, difficulty, "notes", count
         )
-        raw = await llm.generate(
-            card_prompt,
-            system=NOTES_CARD_FROM_CONCEPTS_SYSTEM,
-            model=_generation_model(), stream=False,
-        )
-        cards_data = _parse_llm_response(raw, "notes")
         span.set_attribute("flashcard.generated_count", len(cards_data))
 
     now = datetime.now(UTC)
     flashcards: list[FlashcardModel] = []
     for item in cards_data:
-        if not isinstance(item, dict):
-            continue
         question = str(item.get("question", "")).strip()
         answer = str(item.get("answer", "")).strip()
         source_excerpt = str(item.get("source_excerpt", "")).strip()
-        if not question or not answer:
-            continue
         card = FlashcardModel(
             id=str(uuid.uuid4()),
             document_id=None,
@@ -746,29 +814,15 @@ async def generate_from_collection(
         if not concepts:
             continue
 
-        raw = await llm.generate(
-            NOTES_CARD_FROM_CONCEPTS_TMPL.format(
-                domain=domain,
-                difficulty=difficulty,
-                difficulty_guidelines=_DIFFICULTY_GUIDELINES.get(difficulty, ""),
-                concepts_json=json.dumps(concepts, ensure_ascii=False),
-                text=combined_text,
-            ),
-            system=NOTES_CARD_FROM_CONCEPTS_SYSTEM,
-            model=_generation_model(),
-            stream=False,
+        cards_data = await _generate_concept_cards(
+            llm, domain, concepts, combined_text, difficulty, note_id, count_per_note
         )
-        cards_data = _parse_llm_response(raw, note_id)
 
         now = datetime.now(UTC)
         for item in cards_data:
-            if not isinstance(item, dict):
-                continue
             question = str(item.get("question", "")).strip()
             answer = str(item.get("answer", "")).strip()
             source_excerpt = str(item.get("source_excerpt", "")).strip()
-            if not question or not answer:
-                continue
             card = FlashcardModel(
                 id=str(uuid.uuid4()),
                 document_id=None,
@@ -867,7 +921,11 @@ async def generate_from_graph(
                 question = str(item.get("question", "")).strip()
                 answer = str(item.get("answer", "")).strip()
                 source_excerpt = str(item.get("source_excerpt", "")).strip()
-                if not question or not answer:
+                reason = card_rejection_reason(question, answer)
+                if reason:
+                    logger.info(
+                        "flashcard: dropped low-quality card (%s): %r", reason, question[:80]
+                    )
                     continue
                 cards.append(
                     FlashcardModel(

--- a/backend/app/services/flashcard_parsers.py
+++ b/backend/app/services/flashcard_parsers.py
@@ -114,6 +114,27 @@ def card_field(item: dict, *names: str) -> str:
     return ""
 
 
+# A trailing source pointer the model sometimes appends despite instructions,
+# e.g. "... rather than assuming independence. In Part I. Foundations of Data
+# Systems." The source is tracked separately, so strip it from the answer.
+_TRAILING_SOURCE_REF = re.compile(
+    r"[\s.]*(?:In|See)\s+(?:Part|Chapter|Section|Ch\.?|Sec\.?)\b.*$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def strip_source_ref(answer: str) -> str:
+    """Remove a trailing 'In Part/Chapter/Section ...' citation from an answer.
+
+    Conservative: only fires when such a pointer starts a clause at the very end,
+    and only when a real answer remains before it (never strips the whole thing).
+    """
+    stripped = _TRAILING_SOURCE_REF.sub("", answer).strip()
+    if len(stripped.split()) >= _MIN_ANSWER_WORDS:
+        return stripped if stripped[-1:] in ".!?" or not stripped else stripped + "."
+    return answer.strip()
+
+
 # Quality gate for generated Q/A cards. FLASHCARD_SYSTEM already forbids these
 # shapes, but small local models still emit them; this is the deterministic
 # backstop so a weak card never reaches the deck regardless of model.

--- a/backend/app/services/flashcard_parsers.py
+++ b/backend/app/services/flashcard_parsers.py
@@ -114,6 +114,69 @@ def card_field(item: dict, *names: str) -> str:
     return ""
 
 
+# Quality gate for generated Q/A cards. FLASHCARD_SYSTEM already forbids these
+# shapes, but small local models still emit them; this is the deterministic
+# backstop so a weak card never reaches the deck regardless of model.
+_MIN_ANSWER_WORDS = 2
+_BLOATED_QUESTION_WORDS = 22
+_TRIVIAL_ANSWER_WORDS = 3
+
+# Source-referencing / deictic phrases that make no sense on a standalone card.
+_LEADING_PHRASES = (
+    "in this passage",
+    "in this text",
+    "in this excerpt",
+    "in this book",
+    "in this document",
+    "according to the text",
+    "as described",
+    "as stated",
+    "this scenario",
+    "the scenario",
+    "this situation",
+    "this case",
+    "this context",
+    "this example",
+    "the author",
+    "the writer",
+)
+
+
+def _word_count(text: str) -> int:
+    return len(re.findall(r"\b\w+\b", text))
+
+
+def card_rejection_reason(question: str, answer: str) -> str | None:
+    """Why this Q/A card is low quality, or None if it passes the gate.
+
+    Catches the failure modes the generation prompt forbids but weak models
+    still produce: empty fields, one-word answers (which includes bare yes/no),
+    source-referencing/leading questions, and bloated leading questions paired
+    with a trivial answer. Cloze cards use a separate builder and are
+    intentionally not run through this gate.
+    """
+    q = question.strip()
+    a = answer.strip()
+    if not q or not a:
+        return "empty question or answer"
+
+    q_words = _word_count(q)
+    a_words = _word_count(a)
+
+    if a_words < _MIN_ANSWER_WORDS:
+        return f"answer too short ({a_words} word)"
+
+    q_lower = q.lower()
+    for phrase in _LEADING_PHRASES:
+        if phrase in q_lower:
+            return f"leading/deictic phrase in question ({phrase!r})"
+
+    if q_words >= _BLOATED_QUESTION_WORDS and a_words <= _TRIVIAL_ANSWER_WORDS:
+        return f"bloated question ({q_words}w) with trivial answer ({a_words}w)"
+
+    return None
+
+
 def _parse_gap_flashcard(raw: str, gap: str) -> dict | None:
     """Parse a single {front, back} JSON object from LLM response for one gap."""
     raw = raw.strip()

--- a/backend/app/services/flashcard_prompts.py
+++ b/backend/app/services/flashcard_prompts.py
@@ -14,50 +14,36 @@ if TYPE_CHECKING:
 
 
 FLASHCARD_SYSTEM = (
-    "You are a learning assistant creating flashcards for active recall. "
-    "Generate questions that test understanding, not surface recall. "
-    "Match the question structure to the type of knowledge being tested: "
-    "causal knowledge -> ask why or what causes; "
-    "comparative knowledge -> ask how two things differ or what distinguishes them; "
-    "process or role knowledge -> ask what role X plays in Y or how X enables Y; "
-    "definitional knowledge -> ask what X is or what characterises X; "
-    "speculative or argued knowledge -> ask what the argument or evidence for X is. "
-    "AVOID: list-regurgitation questions whose answer is just an enumeration of items; "
-    "trivia about exact wording; yes/no questions; "
-    "questions whose answer is not derivable from the provided text. "
-    "CRITICAL -- NEVER use deictic or source-referencing words in a question: "
-    "'in this passage', 'in this text', 'in this excerpt', 'in this book', "
-    "'in this document', 'according to the text', 'as described', 'as stated', "
-    "'this scenario', 'the scenario', 'this situation', 'this case', 'this context', "
-    "'this example', 'the author', 'the writer'. "
-    "These make no sense on a flashcard viewed without the source. "
-    "Instead, name the specific concept, entity, technology, or idea directly in the question. "
-    "CRITICAL -- question framing must match the answer exactly: "
-    "if the answer explains a cause, the question must ask for that cause; "
-    "if the answer describes a role, the question must ask for that role. "
-    "The answer must be a concise explanation in 1-3 sentences -- never a bare list of items. "
-    "Before writing each question, verify: does someone without the source text understand "
-    "exactly what is being asked, and does the answer directly satisfy the question? "
-    "Output a JSON array starting with [ and ending with ]. "
-    "Write no explanation, preamble, or markdown fences."
+    "You are a learning assistant that writes flashcards for active recall. Each card is a "
+    "self-contained question testing understanding of one idea, plus a concise, complete "
+    "answer -- both grounded only in the provided text.\n"
+    "QUESTION: match it to the knowledge type -- causal knowledge asks why or what causes; a "
+    "comparison asks how two things differ; a role/process asks what X enables in Y; a "
+    "definition asks what X is. Name the concept directly and prefer why/how/apply over recall. "
+    "AVOID trivia about wording, yes/no questions, answers that are a bare list, and asking "
+    "which specific example or analogy the text used. The question must stand alone -- never "
+    "say 'in this passage', 'according to the text', or 'the author'; it must make sense "
+    "without the source.\n"
+    "ANSWER: lead with one sentence that directly answers the question, then add a short "
+    "markdown bullet list ('- ...') only when it has several distinct points. Keep it tight -- "
+    "no filler, and no chapter/section reference.\n"
+    'Include a "bloom_level" integer 1-6 (1=remember ... 6=create); aim for level 3+ '
+    "(apply/analyze/evaluate) where the material allows."
 )
 
 FLASHCARD_USER_TMPL = (
-    "Write {count} {difficulty}-level question/answer flashcards from the text below. "
-    "Each flashcard is a QUESTION a learner answers from memory, plus its ANSWER. "
-    "Do NOT summarise, outline, or analyse the text.\n"
-    "Difficulty guidelines: {difficulty_guidelines}\n"
+    "Write {count} {difficulty}-level flashcards from the text below.\n"
+    "Difficulty: {difficulty_guidelines}\n"
     "{extra_instructions}"
-    "Each card must be answerable from the provided text only.\n"
-    "Output EXACTLY this JSON shape:\n"
-    '{{"flashcards": [{{"question": "...", "answer": "...", "source_excerpt": "...",'
-    ' "bloom_level": N}}]}}\n'
-    "bloom_level is an integer 1-6 (1=remember, 2=understand, 3=apply, "
-    "4=analyze, 5=evaluate, 6=create).\n\n"
-    "Example for a text about replication:\n"
-    '{{"flashcards": [{{"question": "Why does leader-based replication need a replication log?", '
-    '"answer": "So followers can apply the same writes in the same order and stay consistent '
-    'with the leader.", "source_excerpt": "", "bloom_level": 2}}]}}\n\n'
+    "Return a JSON object, using '\\n' for line breaks inside a string:\n"
+    '{{"flashcards": [{{"question": "...", "answer": "...", "source_excerpt": "...", '
+    '"bloom_level": N}}]}}\n'
+    "Example card with a multi-point answer:\n"
+    '{{"flashcards": [{{"question": "How do random hardware faults and systematic software '
+    'errors differ for fault tolerance?", "answer": "They fail differently, so they need '
+    'different defences.\\n- Hardware faults are largely independent -- redundancy masks '
+    'them.\\n- Software errors are correlated and can fail many nodes at once -- they need '
+    'testing and isolation.", "source_excerpt": "", "bloom_level": 4}}]}}\n\n'
     "Text:\n{text}\n\n"
     "JSON object:"
 )
@@ -109,7 +95,8 @@ NOTES_CARD_FROM_CONCEPTS_SYSTEM = (
     "'this case', 'this context', 'this example', 'the author', 'the text', 'these notes', "
     "'the man', 'the person', 'the writer'. "
     "The question must stand alone -- understandable without the notes. "
-    "The answer must be derived from the notes in 1-3 sentences. "
+    "Answer from the notes: lead with one direct sentence, then add short markdown bullets "
+    "('- ...') only for several distinct points. Never a bare list; never filler. "
     "For process-role: explain what the collective activity achieves or why it matters -- "
     "never enumerate the individual components as the answer. "
     'Output ONLY a JSON array: [{{"question": "...", "answer": "...", "source_excerpt": ""}}]. '
@@ -150,17 +137,6 @@ _BOOK_CONTENT_GUIDELINE = (
     "If the provided text starts with publisher boilerplate or editorial notes, "
     "skip past them entirely and generate questions only from the actual narrative or subject.\n"
 )
-
-# Bloom L3+ instruction appended to the genre system prompt
-_BLOOM_L3_INSTRUCTION = (
-    "\nBLOOM LEVEL TARGETING: Generate questions at Bloom's Taxonomy Level 3 or higher "
-    "(application, analysis, synthesis, evaluation). At least 50% of questions must require "
-    "the learner to apply, analyze, or evaluate -- not merely recall or describe. "
-    'For each card, include a "bloom_level" integer (1-6) indicating the cognitive level. '
-    "ANSWER CITATION: Each answer must reference the section or chapter where the concept "
-    "appears (e.g., 'In Chapter XII...', 'In the section on X...'). "
-)
-
 
 TECH_FLASHCARD_SYSTEM = (
     "You are a technical learning assistant creating flashcards based on Bloom's Taxonomy. "
@@ -292,34 +268,10 @@ def _infer_genre(doc: DocumentModel | None) -> str:
 
 
 def _build_genre_system_prompt(genre: str) -> str:
-    """Build a genre-aware flashcard generation system prompt."""
-    genre_hint = f"This is a {genre} document. " if genre != "narrative" else ""
-    quality_rules = (
-        "QUALITY RULES for concept-focused questions:\n"
-        "- Do NOT write questions whose answer is a proper noun drawn from an analogy or "
-        "illustrative story used to explain a concept (e.g., do not ask 'What animal did the "
-        "author compare X to?').\n"
-        "- Questions must be answerable by someone who understands the underlying concept but "
-        "has NOT read the specific analogy or illustration.\n"
-        "- Prefer 'Explain X in your own words' and 'What is the practical implication of Y' "
-        "over 'According to the text, what does Z do'.\n"
-        "- Frame questions in terms of WHY or HOW, not WHAT was mentioned in an example.\n"
-    )
-    return (
-        genre_hint + "You are a learning assistant creating flashcards for active recall. "
-        "Generate questions that test understanding of core concepts and principles. "
-        "Prefer questions that: (1) ask the learner to explain a concept in their own words, "
-        "(2) apply a concept to a new situation, "
-        "(3) distinguish between similar concepts, "
-        "or (4) evaluate a claim or argument. "
-        "AVOID: trivia questions about exact wording, hypothetical questions not grounded "
-        "in the content, questions whose answer is not in the text, yes/no questions. "
-        "CRITICAL -- questions must be fully self-contained. "
-        "NEVER use phrases like 'in this passage', 'according to this text', 'in this excerpt', "
-        "'in this book', 'in this document', or any similar reference to the source material. "
-        "A flashcard question must make complete sense on its own without seeing the original"
-        " text. " + quality_rules + 'Output ONLY a JSON object of the form '
-        '{"flashcards": [{"question": "...", "answer": "..."}]}. '
-        "Each item MUST be a question/answer pair. Do NOT output a summary, outline, analysis, or "
-        "table. Write no explanation, preamble, or markdown fences."
-    )
+    """The single flashcard system prompt, prefixed with a one-line genre hint.
+
+    One source of truth (FLASHCARD_SYSTEM) drives generation; the hint just nudges
+    tone for technical/academic/non-fiction material.
+    """
+    hint = f"This is a {genre} document. " if genre != "narrative" else ""
+    return hint + FLASHCARD_SYSTEM

--- a/backend/app/services/flashcard_search.py
+++ b/backend/app/services/flashcard_search.py
@@ -15,7 +15,6 @@ from app.models import FlashcardModel
 
 logger = logging.getLogger(__name__)
 
-
 _FTS5_SPECIAL = re.compile(r'[(){}*:^~"\[\]<>]')
 
 
@@ -94,7 +93,7 @@ class FlashcardSearchService:
         """
         from sqlalchemy import or_  # noqa: PLC0415
 
-        from app.models import CollectionMemberModel, NoteTagIndexModel  # noqa: PLC0415
+        from app.models import NoteTagIndexModel  # noqa: PLC0415
 
         stmt = select(FlashcardModel)
         _fts_query_used = False
@@ -123,11 +122,9 @@ class FlashcardSearchService:
             stmt = stmt.where(FlashcardModel.document_id == document_id)
 
         if collection_id:
-            member_sub = select(CollectionMemberModel.member_id).where(
-                CollectionMemberModel.collection_id == collection_id,
-                CollectionMemberModel.member_type == "note",
-            )
-            stmt = stmt.where(FlashcardModel.note_id.in_(member_sub))
+            from app.repos.flashcard_repo import collection_card_filter  # noqa: PLC0415
+
+            stmt = stmt.where(collection_card_filter(collection_id))
 
         if tag:
             tag_sub = select(NoteTagIndexModel.note_id).where(
@@ -181,11 +178,9 @@ class FlashcardSearchService:
             if document_id:
                 stmt_fallback = stmt_fallback.where(FlashcardModel.document_id == document_id)
             if collection_id:
-                member_sub2 = select(CollectionMemberModel.member_id).where(
-                    CollectionMemberModel.collection_id == collection_id,
-                    CollectionMemberModel.member_type == "note",
-                )
-                stmt_fallback = stmt_fallback.where(FlashcardModel.note_id.in_(member_sub2))
+                from app.repos.flashcard_repo import collection_card_filter  # noqa: PLC0415
+
+                stmt_fallback = stmt_fallback.where(collection_card_filter(collection_id))
             if tag:
                 tag_sub2 = select(NoteTagIndexModel.note_id).where(
                     or_(

--- a/backend/app/services/fsrs_service.py
+++ b/backend/app/services/fsrs_service.py
@@ -13,6 +13,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import ChunkModel, FlashcardModel, ReviewEventModel
+from app.services.misconceptions import resolve_on_review
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +107,10 @@ class FSRSService:
         db_card.reps = (db_card.reps or 0) + 1
         if rating == "again":
             db_card.lapses = (db_card.lapses or 0) + 1
+
+        # successful recall closes any open misconceptions recorded for this card
+        # (docs/recommender-spec.md); rides the same commit as the review itself
+        await resolve_on_review(session, card_id, rating)
 
         await session.commit()
         await session.refresh(db_card)

--- a/backend/app/services/misconceptions.py
+++ b/backend/app/services/misconceptions.py
@@ -1,0 +1,54 @@
+import logging
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import MisconceptionModel
+
+logger = logging.getLogger(__name__)
+
+PASSING_TEACHBACK_SCORE = 60
+_RESOLVING_RATINGS = frozenset({"good", "easy"})
+
+
+async def resolve_for_flashcard(session: AsyncSession, flashcard_id: str) -> int:
+    result = await session.execute(
+        update(MisconceptionModel)
+        .where(MisconceptionModel.flashcard_id == flashcard_id)
+        .where(MisconceptionModel.status == "open")
+        .values(status="resolved", resolved_at=datetime.now(UTC))
+    )
+    resolved = result.rowcount or 0
+    if resolved:
+        logger.info(
+            "Resolved misconceptions",
+            extra={"flashcard_id": flashcard_id, "count": resolved},
+        )
+    return resolved
+
+
+async def resolve_on_review(session: AsyncSession, flashcard_id: str, rating: str) -> int:
+    if rating not in _RESOLVING_RATINGS:
+        return 0
+    return await resolve_for_flashcard(session, flashcard_id)
+
+
+async def _count(session: AsyncSession, *conditions) -> int:
+    result = await session.execute(
+        select(func.count()).select_from(MisconceptionModel).where(*conditions)
+    )
+    return int(result.scalar_one())
+
+
+async def get_stats(session: AsyncSession) -> dict:
+    cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=30)
+    return {
+        "open_count": await _count(session, MisconceptionModel.status == "open"),
+        "resolved_count": await _count(session, MisconceptionModel.status == "resolved"),
+        "resolved_last_30d": await _count(
+            session,
+            MisconceptionModel.status == "resolved",
+            MisconceptionModel.resolved_at >= cutoff,
+        ),
+    }

--- a/backend/app/services/recommender_service.py
+++ b/backend/app/services/recommender_service.py
@@ -1,0 +1,467 @@
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import RecommendationFeedbackModel
+from app.schemas.home import Recommendation, RecommendationReason, TodayAction
+
+logger = logging.getLogger(__name__)
+
+RECOMMENDATION_LIMIT = 4
+
+# scoring weights -- deliberately module constants, not settings; tune via tests
+# and real use (docs/recommender-spec.md)
+_W_URGENCY = 0.40
+_W_IMPACT = 0.35
+_W_RECENCY = 0.25
+_W_FATIGUE = 0.15
+
+_MASTERY_FLOOR = 0.5
+_BAD_REVIEW_DAYS = 14
+_MIN_BAD_REVIEWS = 2
+_CALIBRATION_DAYS = 30
+_MIN_OVERCONFIDENT = 2
+_STALLED_MIN_DAYS = 7
+_STALLED_MAX_DAYS = 45
+_FATIGUE_SATURATION_SHOWS = 5
+# cap per generator so one signal family cannot flood the whole stack
+_MAX_PER_KIND = 2
+
+_ERROR_TYPE_IMPACT = {
+    "misconception": 1.0,
+    "incomplete": 0.7,
+    "memory_lapse": 0.5,
+    "unrelated": 0.3,
+}
+
+_TODAY_KIND = {
+    "overdue_reviews": "review_cards",
+    "stalled_reading": "continue_reading",
+    "weak_concept": "drill_concept",
+    "open_misconception": "fix_misconception",
+    "calibration_blind_spot": "confidence_check",
+}
+
+
+@dataclass
+class _Candidate:
+    kind: str
+    target_type: str
+    target_ref: str
+    label: str
+    urgency: float
+    impact: float
+    recency: float
+    reasons: list[RecommendationReason] = field(default_factory=list)
+    # newest event backing this candidate; evidence newer than a dismissal re-arms it
+    evidence_at: datetime | None = None
+    count: int | None = None
+    document_id: str | None = None
+    concept_slug: str | None = None
+
+
+def _naive_now() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _as_naive(value) -> datetime | None:
+    # raw text() rows return DATETIME expressions as ISO strings on aiosqlite
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value)
+    return value.replace(tzinfo=None) if value.tzinfo else value
+
+
+def _age_days(dt: datetime | None) -> float:
+    if dt is None:
+        return 0.0
+    return max(0.0, (_naive_now() - dt).total_seconds() / 86400)
+
+
+def _clamp(v: float) -> float:
+    return max(0.0, min(1.0, v))
+
+
+async def _overdue_reviews(session: AsyncSession) -> list[_Candidate]:
+    row = (
+        await session.execute(
+            text(
+                "SELECT COUNT(*), MIN(due_date), MAX(due_date) FROM flashcards "
+                "WHERE due_date IS NOT NULL AND due_date <= datetime('now')"
+            )
+        )
+    ).first()
+    count = int(row[0] or 0) if row else 0
+    if count == 0:
+        return []
+    oldest_days = int(_age_days(_as_naive(row[1])))
+    detail = f"{count} {'card' if count == 1 else 'cards'} due"
+    if oldest_days > 0:
+        detail += f", oldest {oldest_days} {'day' if oldest_days == 1 else 'days'} overdue"
+    return [
+        _Candidate(
+            kind="overdue_reviews",
+            target_type="study",
+            target_ref="daily",
+            label=f"Review {count} {'card' if count == 1 else 'cards'} due",
+            urgency=_clamp(0.5 + oldest_days / 7),
+            impact=_clamp(count / 20),
+            recency=1.0,
+            reasons=[RecommendationReason(signal="due_cards", detail=detail)],
+            evidence_at=_as_naive(row[2]),
+            count=count,
+        )
+    ]
+
+
+async def _weak_concepts(session: AsyncSession) -> list[_Candidate]:
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT c.slug, c.label, c.mastery,
+                       COUNT(re.id) AS bad_count, MAX(re.reviewed_at) AS last_bad
+                FROM concepts c
+                JOIN flashcards f ON f.concept_slug = c.slug
+                JOIN review_events re ON re.flashcard_id = f.id
+                WHERE re.rating IN ('again', 'hard')
+                  AND re.reviewed_at >= datetime('now', :cutoff)
+                  AND c.mastery < :floor
+                  AND c.kind = 'concept'
+                  AND c.status != 'candidate'
+                GROUP BY c.slug, c.label, c.mastery
+                HAVING COUNT(re.id) >= :min_bad
+                ORDER BY COUNT(re.id) * (1.0 - c.mastery) DESC
+                LIMIT :lim
+                """
+            ),
+            {
+                "cutoff": f"-{_BAD_REVIEW_DAYS} days",
+                "floor": _MASTERY_FLOOR,
+                "min_bad": _MIN_BAD_REVIEWS,
+                "lim": _MAX_PER_KIND,
+            },
+        )
+    ).all()
+    out: list[_Candidate] = []
+    for slug, label, mastery, bad_count, last_bad in rows:
+        last_bad_dt = _as_naive(last_bad)
+        out.append(
+            _Candidate(
+                kind="weak_concept",
+                target_type="concept",
+                target_ref=slug,
+                label=f"Shore up: {label}",
+                urgency=_clamp(bad_count / 5),
+                impact=_clamp(1.0 - float(mastery or 0.0)),
+                recency=_clamp(1.0 - _age_days(last_bad_dt) / _BAD_REVIEW_DAYS),
+                reasons=[
+                    RecommendationReason(
+                        signal="struggling_reviews",
+                        detail=(
+                            f"{bad_count} {'review' if bad_count == 1 else 'reviews'} rated "
+                            f"again/hard in the last {_BAD_REVIEW_DAYS} days; "
+                            f"mastery {int(float(mastery or 0.0) * 100)}%"
+                        ),
+                    )
+                ],
+                evidence_at=last_bad_dt,
+                concept_slug=slug,
+            )
+        )
+    return out
+
+
+async def _open_misconceptions(session: AsyncSession) -> list[_Candidate]:
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT m.flashcard_id, m.error_type, m.correction_note, m.detected_at,
+                       f.concept_slug, f.document_id, f.question, c.label
+                FROM misconceptions m
+                JOIN flashcards f ON f.id = m.flashcard_id
+                LEFT JOIN concepts c ON c.slug = f.concept_slug
+                WHERE m.status = 'open'
+                ORDER BY m.detected_at DESC
+                LIMIT 10
+                """
+            )
+        )
+    ).all()
+    out: list[_Candidate] = []
+    seen: set[str] = set()
+    for card_id, error_type, note, detected_at, slug, doc_id, question, concept_label in rows:
+        if card_id in seen:
+            continue
+        seen.add(card_id)
+        detected_dt = _as_naive(detected_at)
+        age = int(_age_days(detected_dt))
+        topic = concept_label or (question or "")[:60]
+        out.append(
+            _Candidate(
+                kind="open_misconception",
+                target_type="flashcard",
+                target_ref=card_id,
+                label=f"Fix a misconception: {topic}",
+                urgency=_clamp(age / 14),
+                impact=_ERROR_TYPE_IMPACT.get(error_type, 0.7),
+                recency=0.5,
+                reasons=[
+                    RecommendationReason(
+                        signal="open_misconception",
+                        detail=(
+                            f"{error_type} recorded "
+                            f"{age} {'day' if age == 1 else 'days'} ago: "
+                            f'"{(note or "").strip()[:90]}"'
+                        ),
+                    )
+                ],
+                evidence_at=detected_dt,
+                document_id=doc_id,
+                concept_slug=slug,
+            )
+        )
+        if len(out) >= _MAX_PER_KIND:
+            break
+    return out
+
+
+async def _calibration_blind_spots(session: AsyncSession) -> list[_Candidate]:
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT f.concept_slug, c.label, COUNT(*) AS n, MAX(re.reviewed_at) AS last_evt
+                FROM review_events re
+                JOIN flashcards f ON f.id = re.flashcard_id
+                JOIN concepts c ON c.slug = f.concept_slug
+                WHERE re.predicted_rating IN ('good', 'easy')
+                  AND re.rating = 'again'
+                  AND re.reviewed_at >= datetime('now', :cutoff)
+                GROUP BY f.concept_slug, c.label
+                HAVING COUNT(*) >= :min_over
+                ORDER BY COUNT(*) DESC
+                LIMIT :lim
+                """
+            ),
+            {
+                "cutoff": f"-{_CALIBRATION_DAYS} days",
+                "min_over": _MIN_OVERCONFIDENT,
+                "lim": _MAX_PER_KIND,
+            },
+        )
+    ).all()
+    out: list[_Candidate] = []
+    for slug, label, n, last_evt in rows:
+        last_evt_dt = _as_naive(last_evt)
+        out.append(
+            _Candidate(
+                kind="calibration_blind_spot",
+                target_type="concept",
+                target_ref=slug,
+                label=f"Confidence check: {label}",
+                urgency=_clamp(n / 4),
+                impact=0.8,
+                recency=_clamp(1.0 - _age_days(last_evt_dt) / _CALIBRATION_DAYS),
+                reasons=[
+                    RecommendationReason(
+                        signal="overconfidence",
+                        detail=(
+                            f"predicted good/easy but rated again {n} times "
+                            f"in the last {_CALIBRATION_DAYS} days"
+                        ),
+                    )
+                ],
+                evidence_at=last_evt_dt,
+                concept_slug=slug,
+            )
+        )
+    return out
+
+
+async def _stalled_reading(session: AsyncSession) -> list[_Candidate]:
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT d.id, d.title, ca.last_meaningful_at,
+                  (SELECT COUNT(*) FROM sections WHERE document_id = d.id) AS total,
+                  (SELECT COUNT(*) FROM reading_progress WHERE document_id = d.id) AS read
+                FROM content_activity ca
+                JOIN documents d ON d.id = ca.member_id
+                WHERE ca.member_type = 'document'
+                  AND ca.last_meaningful_at <= datetime('now', :min_days)
+                  AND ca.last_meaningful_at >= datetime('now', :max_days)
+                ORDER BY ca.last_meaningful_at DESC
+                LIMIT 10
+                """
+            ),
+            {
+                "min_days": f"-{_STALLED_MIN_DAYS} days",
+                "max_days": f"-{_STALLED_MAX_DAYS} days",
+            },
+        )
+    ).all()
+    out: list[_Candidate] = []
+    for doc_id, title, last_at, total_raw, read_raw in rows:
+        total = int(total_raw or 0)
+        read = int(read_raw or 0)
+        if total <= 0 or read <= 0 or read >= total:
+            continue
+        last_at_dt = _as_naive(last_at)
+        days = int(_age_days(last_at_dt))
+        pct = read / total
+        out.append(
+            _Candidate(
+                kind="stalled_reading",
+                target_type="document",
+                target_ref=doc_id,
+                label=f"Pick back up: {title or '(untitled)'}",
+                urgency=_clamp(days / 21),
+                impact=_clamp(pct),
+                recency=_clamp(1.0 - days / _STALLED_MAX_DAYS),
+                reasons=[
+                    RecommendationReason(
+                        signal="stalled_reading",
+                        detail=f"{int(pct * 100)}% read, untouched for {days} days",
+                    )
+                ],
+                evidence_at=last_at_dt,
+                document_id=doc_id,
+            )
+        )
+        if len(out) >= _MAX_PER_KIND:
+            break
+    return out
+
+
+_GENERATORS = (
+    _overdue_reviews,
+    _weak_concepts,
+    _open_misconceptions,
+    _calibration_blind_spots,
+    _stalled_reading,
+)
+
+
+async def _load_feedback(
+    session: AsyncSession,
+) -> dict[tuple[str, str, str], RecommendationFeedbackModel]:
+    rows = (await session.execute(select(RecommendationFeedbackModel))).scalars().all()
+    return {(r.kind, r.target_type, r.target_ref): r for r in rows}
+
+
+def _score(cand: _Candidate, fb: RecommendationFeedbackModel | None) -> float:
+    fatigue = 0.0
+    if fb is not None and fb.acted_at is None:
+        fatigue = _clamp((fb.shown_count or 0) / _FATIGUE_SATURATION_SHOWS)
+    return (
+        _W_URGENCY * cand.urgency
+        + _W_IMPACT * cand.impact
+        + _W_RECENCY * cand.recency
+        - _W_FATIGUE * fatigue
+    )
+
+
+def _dismissal_active(cand: _Candidate, fb: RecommendationFeedbackModel | None) -> bool:
+    if fb is None or fb.dismissed_at is None:
+        return False
+    if cand.evidence_at is None:
+        return True
+    return _as_naive(fb.dismissed_at) >= cand.evidence_at
+
+
+async def get_recommendations(
+    session: AsyncSession, limit: int = RECOMMENDATION_LIMIT
+) -> list[Recommendation]:
+    candidates: list[_Candidate] = []
+    # sequential on the one request session (I-1) -- never asyncio.gather here
+    for gen in _GENERATORS:
+        try:
+            candidates.extend(await gen(session))
+        except Exception:  # noqa: BLE001 -- one bad generator must not blank the hub
+            logger.warning("recommendation generator %s failed", gen.__name__, exc_info=True)
+    if not candidates:
+        return []
+
+    feedback = await _load_feedback(session)
+    scored = [
+        (_score(c, feedback.get((c.kind, c.target_type, c.target_ref))), c)
+        for c in candidates
+        if not _dismissal_active(c, feedback.get((c.kind, c.target_type, c.target_ref)))
+    ]
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+
+    now = _naive_now()
+    out: list[Recommendation] = []
+    for score, cand in scored[:limit]:
+        fb = feedback.get((cand.kind, cand.target_type, cand.target_ref))
+        if fb is None:
+            fb = RecommendationFeedbackModel(
+                id=str(uuid.uuid4()),
+                kind=cand.kind,
+                target_type=cand.target_type,
+                target_ref=cand.target_ref,
+            )
+            session.add(fb)
+        fb.shown_count = (fb.shown_count or 0) + 1
+        fb.last_shown_at = now
+        out.append(
+            Recommendation(
+                id=fb.id,
+                kind=cand.kind,
+                target_type=cand.target_type,
+                target_ref=cand.target_ref,
+                label=cand.label,
+                score=round(score, 4),
+                reasons=cand.reasons,
+                count=cand.count,
+                document_id=cand.document_id,
+                concept_slug=cand.concept_slug,
+            )
+        )
+    await session.commit()
+    return out
+
+
+def to_today_action(rec: Recommendation) -> TodayAction:
+    kind = _TODAY_KIND[rec.kind]
+    if kind == "continue_reading":
+        target_id = rec.document_id or rec.target_ref
+    elif kind == "fix_misconception":
+        target_id = rec.concept_slug
+    else:
+        target_id = rec.target_ref
+    return TodayAction(
+        kind=kind,
+        target_id=target_id,
+        label=rec.label,
+        count=rec.count,
+        reasons=rec.reasons,
+        recommendation_id=rec.id,
+        document_id=rec.document_id,
+    )
+
+
+async def mark_dismissed(session: AsyncSession, feedback_id: str) -> bool:
+    row = await session.get(RecommendationFeedbackModel, feedback_id)
+    if row is None:
+        return False
+    row.dismissed_at = _naive_now()
+    await session.commit()
+    return True
+
+
+async def mark_acted(session: AsyncSession, feedback_id: str) -> bool:
+    row = await session.get(RecommendationFeedbackModel, feedback_id)
+    if row is None:
+        return False
+    row.acted_at = _naive_now()
+    await session.commit()
+    return True

--- a/backend/tests/stubs.py
+++ b/backend/tests/stubs.py
@@ -45,6 +45,25 @@ class MockLLMService:
             yield t
 
 
+class SequenceLLMService(MockLLMService):
+    """Returns a different response per generate() call, in order.
+
+    The last response repeats once the sequence is exhausted. Useful for
+    exercising retry/backfill logic where successive LLM passes must differ.
+    """
+
+    def __init__(self, responses: list[str]):
+        super().__init__(response=responses[-1] if responses else "")
+        self._responses = list(responses)
+
+    async def generate(
+        self, prompt: str, system: str = "", stream: bool = False, model=None, **kwargs
+    ):
+        self.call_count += 1
+        idx = min(self.call_count - 1, len(self._responses) - 1)
+        return self._responses[idx]
+
+
 class CapturingLLMService(MockLLMService):
     """Extends MockLLMService to record arguments passed to the LLM."""
 

--- a/backend/tests/test_flashcard_collection_manage.py
+++ b/backend/tests/test_flashcard_collection_manage.py
@@ -1,0 +1,91 @@
+"""Collection flashcard management: collection-scoped search covers both
+document- and note-sourced cards, and DELETE /flashcards/collection/{id}
+removes exactly that set."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+import app.database as db_module
+from app.database import make_engine
+from app.db_init import create_all_tables
+from app.main import app
+from app.models import CollectionMemberModel, CollectionModel, FlashcardModel
+
+
+@pytest.fixture
+async def test_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    await create_all_tables(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    orig_engine, orig_factory = db_module._engine, db_module._session_factory
+    db_module._engine, db_module._session_factory = engine, factory
+    yield factory
+    db_module._engine, db_module._session_factory = orig_engine, orig_factory
+    get_settings.cache_clear()
+    await engine.dispose()
+
+
+def _card(cid: str, *, document_id=None, note_id=None, source="document", deck="default"):
+    return FlashcardModel(
+        id=cid, question=f"Q {cid}?", answer="A real multi-word answer here.",
+        source_excerpt="s", document_id=document_id, note_id=note_id,
+        source=source, deck=deck,
+    )
+
+
+async def _seed(factory) -> str:
+    coll_id = str(uuid.uuid4())
+    doc_id, note_id, other_doc = "doc-in", "note-in", "doc-out"
+    async with factory() as s:
+        s.add(CollectionModel(id=coll_id, name="Data Architecture", color="#6366F1", sort_order=0))
+        s.add(CollectionMemberModel(
+            id=str(uuid.uuid4()), collection_id=coll_id, member_id=doc_id, member_type="document"))
+        s.add(CollectionMemberModel(
+            id=str(uuid.uuid4()), collection_id=coll_id, member_id=note_id, member_type="note"))
+        s.add(_card("c-doc", document_id=doc_id))
+        s.add(_card("c-note", note_id=note_id, source="note", deck="Data Architecture"))
+        s.add(_card("c-outside", document_id=other_doc))
+        await s.commit()
+    return coll_id
+
+
+@pytest.mark.asyncio
+async def test_collection_search_includes_document_and_note_cards(test_db):
+    coll_id = await _seed(test_db)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/flashcards/search", params={"collection_id": coll_id})
+        assert resp.status_code == 200
+        ids = {c["id"] for c in resp.json()["items"]}
+        assert ids == {"c-doc", "c-note"}  # document + note cards, not the outsider
+
+
+@pytest.mark.asyncio
+async def test_delete_all_collection_flashcards(test_db):
+    coll_id = await _seed(test_db)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete(f"/flashcards/collection/{coll_id}")
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] == 2
+
+        # collection cards gone, the outsider survives
+        remaining = (await client.get("/flashcards/search", params={"collection_id": coll_id}))
+        assert remaining.json()["items"] == []
+        outsider = await client.get("/flashcards/search", params={"document_id": "doc-out"})
+        assert {c["id"] for c in outsider.json()["items"]} == {"c-outside"}
+
+
+@pytest.mark.asyncio
+async def test_delete_empty_collection_is_noop(test_db):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete(f"/flashcards/collection/{uuid.uuid4()}")
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] == 0

--- a/backend/tests/test_flashcard_quality_gate.py
+++ b/backend/tests/test_flashcard_quality_gate.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from app.services.flashcard_parsers import card_rejection_reason
+from app.services.flashcard_parsers import card_rejection_reason, strip_source_ref
 
 
 def test_good_card_passes() -> None:
@@ -79,3 +79,32 @@ def test_reasoned_answer_to_polar_question_passes() -> None:
         )
         is None
     )
+
+
+def test_strip_source_ref_removes_trailing_citation() -> None:
+    a = (
+        "Random hardware faults are independent while software errors are correlated, "
+        "so they need different defences. In Part I. Foundations of Data Systems."
+    )
+    out = strip_source_ref(a)
+    assert "In Part I" not in out
+    assert "Foundations of Data Systems" not in out
+    assert out.endswith("different defences.")
+
+
+def test_strip_source_ref_handles_chapter_forms() -> None:
+    assert strip_source_ref("The log keeps replicas in sync. In Chapter 3.").endswith(
+        "in sync."
+    )
+    out = strip_source_ref("Quorums overlap reads and writes. See Section 5.2")
+    assert "See Section" not in out
+
+
+def test_strip_source_ref_leaves_clean_answers_untouched() -> None:
+    a = "A write-ahead log records changes before applying them, enabling crash recovery."
+    assert strip_source_ref(a) == a
+
+
+def test_strip_source_ref_never_empties_a_short_answer() -> None:
+    # if stripping would leave nothing meaningful, keep the original
+    assert strip_source_ref("In Chapter 1.") == "In Chapter 1."

--- a/backend/tests/test_flashcard_quality_gate.py
+++ b/backend/tests/test_flashcard_quality_gate.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.flashcard_parsers import card_rejection_reason
+
+
+def test_good_card_passes() -> None:
+    assert (
+        card_rejection_reason(
+            "Why does leader-based replication need a replication log?",
+            "So followers can apply the same writes in the same order and stay "
+            "consistent with the leader.",
+        )
+        is None
+    )
+
+
+def test_two_word_answer_passes() -> None:
+    # a concise definitional answer is legitimate; only 1-word answers are cut
+    assert card_rejection_reason("What partitions a Kafka topic?", "Consumer groups") is None
+
+
+@pytest.mark.parametrize("field", ["", "   "])
+def test_empty_fields_rejected(field: str) -> None:
+    assert card_rejection_reason(field, "an answer") is not None
+    assert card_rejection_reason("a question?", field) is not None
+
+
+def test_one_word_answer_rejected() -> None:
+    # the reported failure: bloated leading question, one-word answer
+    reason = card_rejection_reason(
+        "When analytic teams need to fine-tune operational performance, what type of "
+        "customer-provided input is essential for closing the loop and making "
+        "continuous improvements?",
+        "Feedback",
+    )
+    assert reason is not None
+    assert "too short" in reason
+
+
+def test_bloated_question_with_trivial_answer_rejected() -> None:
+    reason = card_rejection_reason(
+        "When a distributed system needs to coordinate agreement across many nodes "
+        "despite failures and network partitions, what fundamental problem must the "
+        "underlying protocol reliably solve for correctness?",
+        "The consensus problem",
+    )
+    assert reason is not None
+    assert "bloated" in reason
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    ["in this passage", "according to the text", "the author", "this scenario"],
+)
+def test_leading_deictic_question_rejected(phrase: str) -> None:
+    reason = card_rejection_reason(
+        f"What does {phrase} say about quorum reads and write consistency guarantees?",
+        "A quorum read overlaps with a quorum write so at least one node has the latest value.",
+    )
+    assert reason is not None
+    assert "leading" in reason
+
+
+def test_bare_yes_no_answer_rejected_as_too_short() -> None:
+    reason = card_rejection_reason("Is Kafka a message broker?", "Yes")
+    assert reason is not None
+    assert "too short" in reason
+
+
+def test_reasoned_answer_to_polar_question_passes() -> None:
+    # a yes/no-framed question is fine when the answer actually explains
+    assert (
+        card_rejection_reason(
+            "Is eventual consistency ever preferable to strong consistency, and why?",
+            "Yes, when availability and low latency matter more than reading the "
+            "very latest write, such as in a shopping cart.",
+        )
+        is None
+    )

--- a/backend/tests/test_flashcards.py
+++ b/backend/tests/test_flashcards.py
@@ -10,6 +10,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import async_sessionmaker
 from stubs import CapturingLLMService as _CapturingLLMService
 from stubs import MockLLMService as _MockLLMService
+from stubs import SequenceLLMService as _SequenceLLMService
 
 import app.database as db_module
 from app.database import make_engine
@@ -156,7 +157,11 @@ async def test_service_strips_markdown_fences(test_db):
         session.add(_make_chunk(chunk_id, doc_id=doc_id))
         await session.commit()
 
-    llm_json = '```json\n[{"question": "Q1?", "answer": "A1.", "source_excerpt": "src."}]\n```'
+    llm_json = (
+        '```json\n[{"question": "What does a replication log record?", '
+        '"answer": "The ordered sequence of writes followers replay to stay '
+        'consistent with the leader.", "source_excerpt": "src."}]\n```'
+    )
     mock_llm = _MockLLMService(response=llm_json)
 
     with patch("app.services.flashcard.get_llm_service", return_value=mock_llm):
@@ -171,7 +176,7 @@ async def test_service_strips_markdown_fences(test_db):
             )
 
     assert len(cards) == 1
-    assert cards[0].question == "Q1?"
+    assert cards[0].question == "What does a replication log record?"
 
 
 async def test_service_returns_empty_when_no_chunks(test_db):
@@ -432,7 +437,12 @@ async def test_generate_endpoint_returns_201(test_db):
 
     llm_json = json.dumps(
         [
-            {"question": "Q?", "answer": "A.", "source_excerpt": "src."},
+            {
+                "question": "What problem does quorum consistency solve?",
+                "answer": "It ensures a read overlaps a recent write so at least one "
+                "queried replica returns the latest value.",
+                "source_excerpt": "src.",
+            },
         ]
     )
     mock_llm = _MockLLMService(response=llm_json)
@@ -449,8 +459,64 @@ async def test_generate_endpoint_returns_201(test_db):
     assert isinstance(data, list)
     assert len(data) == 1
     assert data[0]["fsrs_state"] == "new"
-    assert data[0]["question"] == "Q?"
+    assert data[0]["question"] == "What problem does quorum consistency solve?"
     assert data[0]["is_user_edited"] is False
+
+
+async def test_generate_retries_to_backfill_gated_cards(test_db):
+    """When some cards fail the quality gate, extra LLM passes backfill the
+    shortfall so the requested count is met."""
+    _, factory, _ = test_db
+    doc_id = str(uuid.uuid4())
+    chunk_id = str(uuid.uuid4())
+
+    async with factory() as session:
+        session.add(_make_doc(doc_id))
+        session.add(_make_chunk(chunk_id, doc_id=doc_id))
+        await session.commit()
+
+    # first pass: 2 good cards + 2 one-word answers (gated out); second pass
+    # supplies 2 fresh good cards to reach the requested 4.
+    first = json.dumps(
+        {
+            "flashcards": [
+                {"question": "What is a write-ahead log?",
+                 "answer": "A durable append-only record written before applying changes."},
+                {"question": "What is a follower replica?",
+                 "answer": "A replica that applies the leader's writes to serve reads."},
+                {"question": "What input closes the analytics loop?", "answer": "Feedback"},
+                {"question": "What names a data partition?", "answer": "Shard"},
+            ]
+        }
+    )
+    second = json.dumps(
+        {
+            "flashcards": [
+                {"question": "What does a quorum guarantee?",
+                 "answer": "That a read and a write overlap on at least one replica."},
+                {"question": "What is eventual consistency?",
+                 "answer": "Replicas converge to the same value once writes stop."},
+            ]
+        }
+    )
+    seq_llm = _SequenceLLMService([first, second])
+
+    with patch("app.services.flashcard.get_llm_service", return_value=seq_llm):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/flashcards/generate",
+                json={"document_id": doc_id, "scope": "full", "count": 4},
+            )
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert len(data) == 4
+    # the backfill actually ran a second pass
+    assert seq_llm.call_count == 2
+    # no gated card survived, and every answer is a real explanation
+    questions = {c["question"] for c in data}
+    assert "What input closes the analytics loop?" not in questions
+    assert all(len(c["answer"].split()) >= 2 for c in data)
 
 
 async def test_list_flashcards_returns_all_for_document(test_db):

--- a/backend/tests/test_flashcards_technical.py
+++ b/backend/tests/test_flashcards_technical.py
@@ -8,6 +8,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import async_sessionmaker
 from stubs import MockLLMService as _MockLLMService
+from stubs import SequenceLLMService as _SequenceLLMService
 
 import app.database as db_module
 from app.database import make_engine
@@ -362,7 +363,7 @@ async def test_generate_technical_endpoint_returns_201_with_type_fields(test_db)
         [
             {
                 "question": "What is the output of print(2 ** 3)?",
-                "answer": "8",
+                "answer": "8 -- the ** operator raises 2 to the power 3.",
                 "source_excerpt": "2 ** 3",
                 "flashcard_type": "trace",
                 "bloom_level": 4,
@@ -384,6 +385,50 @@ async def test_generate_technical_endpoint_returns_201_with_type_fields(test_db)
     assert len(data) == 1
     assert data[0]["flashcard_type"] is not None
     assert data[0]["bloom_level"] is not None
+
+
+async def test_generate_technical_backfills_gated_cards(test_db):
+    """The technical path also retries to replace cards lost to the quality
+    gate, reaching the requested count."""
+    _, factory, _ = test_db
+    doc_id = str(uuid.uuid4())
+    chunk_id = str(uuid.uuid4())
+
+    async with factory() as session:
+        session.add(_make_doc(doc_id))
+        session.add(_make_chunk(chunk_id, doc_id=doc_id))
+        await session.commit()
+
+    first = json.dumps(
+        [
+            {"question": "What does the ** operator do in Python?",
+             "answer": "It raises the left operand to the power of the right operand.",
+             "flashcard_type": "definition", "bloom_level": 2},
+            {"question": "What is the output of print(2 ** 3)?", "answer": "8",
+             "flashcard_type": "trace", "bloom_level": 4},
+        ]
+    )
+    second = json.dumps(
+        [
+            {"question": "How does floor division // differ from / in Python?",
+             "answer": "// discards the fractional part and returns an integer-valued result.",
+             "flashcard_type": "definition", "bloom_level": 2},
+        ]
+    )
+    seq_llm = _SequenceLLMService([first, second])
+
+    with patch("app.services.flashcard.get_llm_service", return_value=seq_llm):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/flashcards/generate-technical",
+                json={"document_id": doc_id, "scope": "full", "count": 2},
+            )
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert len(data) == 2
+    assert seq_llm.call_count == 2
+    assert all(len(c["answer"].split()) >= 2 for c in data)
 
 
 # bloom_level string coercion

--- a/backend/tests/test_home_recommendations_api.py
+++ b/backend/tests/test_home_recommendations_api.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+import app.database as db_module
+from app.database import make_engine
+from app.db_init import create_all_tables
+from app.main import app
+from app.models import ConceptModel, FlashcardModel, ReviewEventModel
+
+
+@pytest.fixture
+async def test_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    await create_all_tables(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    orig_engine = db_module._engine
+    orig_factory = db_module._session_factory
+    db_module._engine = engine
+    db_module._session_factory = factory
+
+    yield engine, factory, tmp_path
+
+    db_module._engine = orig_engine
+    db_module._session_factory = orig_factory
+    get_settings.cache_clear()
+    await engine.dispose()
+
+
+def _naive(days_ago: float = 0.0) -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None) - timedelta(days=days_ago)
+
+
+async def _seed_due_card(factory) -> None:
+    async with factory() as session:
+        session.add(
+            FlashcardModel(
+                id="card-due", question="q", answer="a", source_excerpt="s",
+                due_date=_naive(2),
+            )
+        )
+        await session.commit()
+
+
+async def _seed_weak_concept(factory) -> None:
+    async with factory() as session:
+        session.add(
+            ConceptModel(
+                id=str(uuid.uuid4()), slug="btree-splits", label="btree splits",
+                mastery=0.2, status="confirmed",
+            )
+        )
+        session.add(
+            FlashcardModel(
+                id="card-weak", question="q", answer="a", source_excerpt="s",
+                concept_slug="btree-splits",
+            )
+        )
+        session.add_all(
+            ReviewEventModel(
+                id=str(uuid.uuid4()), session_id="s1", flashcard_id="card-weak",
+                rating="again", is_correct=False, reviewed_at=_naive(1),
+            )
+            for _ in range(2)
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_overview_hero_carries_recommender_evidence(test_db) -> None:
+    _, factory, _ = test_db
+    await _seed_due_card(factory)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/home/overview")
+        assert resp.status_code == 200
+        body = resp.json()
+        action = body["today_action"]
+        assert action["kind"] == "review_cards"
+        assert action["recommendation_id"] is not None
+        assert action["reasons"] and action["reasons"][0]["signal"] == "due_cards"
+        # hero item is excluded from the secondary stack
+        assert all(r["kind"] != "overdue_reviews" for r in body["recommendations"])
+
+
+@pytest.mark.asyncio
+async def test_overview_hero_drill_concept(test_db) -> None:
+    _, factory, _ = test_db
+    await _seed_weak_concept(factory)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        body = (await client.get("/home/overview")).json()
+        action = body["today_action"]
+        assert action["kind"] == "drill_concept"
+        assert action["target_id"] == "btree-splits"
+        assert "mastery 20%" in action["reasons"][0]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_overview_empty_db_degrades_gracefully(test_db) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        body = (await client.get("/home/overview")).json()
+        assert body["today_action"] is None
+        assert body["recommendations"] == []
+
+
+@pytest.mark.asyncio
+async def test_dismiss_endpoint_hides_recommendation(test_db) -> None:
+    _, factory, _ = test_db
+    await _seed_due_card(factory)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        body = (await client.get("/home/overview")).json()
+        rec_id = body["today_action"]["recommendation_id"]
+
+        resp = await client.post(f"/home/recommendations/{rec_id}/dismiss")
+        assert resp.status_code == 204
+
+        body = (await client.get("/home/overview")).json()
+        assert body["today_action"] is None or body["today_action"]["kind"] != "review_cards"
+
+
+@pytest.mark.asyncio
+async def test_acted_endpoint_and_unknown_id(test_db) -> None:
+    _, factory, _ = test_db
+    await _seed_due_card(factory)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        body = (await client.get("/home/overview")).json()
+        rec_id = body["today_action"]["recommendation_id"]
+
+        assert (await client.post(f"/home/recommendations/{rec_id}/acted")).status_code == 204
+        assert (await client.post("/home/recommendations/nope/acted")).status_code == 404
+        assert (await client.post("/home/recommendations/nope/dismiss")).status_code == 404

--- a/backend/tests/test_misconception_lifecycle.py
+++ b/backend/tests/test_misconception_lifecycle.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.database import make_engine
+from app.db_init import create_all_tables
+from app.models import FlashcardModel, MisconceptionModel
+from app.services.fsrs_service import FSRSService
+from app.services.misconceptions import get_stats, resolve_for_flashcard, resolve_on_review
+
+
+@pytest.fixture
+async def session_factory():
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    await create_all_tables(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+def _card(card_id: str = "card-1") -> FlashcardModel:
+    return FlashcardModel(id=card_id, question="q", answer="a", source_excerpt="s")
+
+
+def _misconception(card_id: str = "card-1", status: str = "open") -> MisconceptionModel:
+    return MisconceptionModel(
+        id=str(uuid.uuid4()),
+        document_id="doc-1",
+        flashcard_id=card_id,
+        user_answer="wrong",
+        error_type="misconception",
+        correction_note="note",
+        status=status,
+    )
+
+
+async def _open_count(session, card_id: str) -> int:
+    rows = (
+        (
+            await session.execute(
+                select(MisconceptionModel).where(
+                    MisconceptionModel.flashcard_id == card_id,
+                    MisconceptionModel.status == "open",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return len(rows)
+
+
+@pytest.mark.asyncio
+async def test_good_review_resolves_open_misconceptions(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_card())
+        session.add(_misconception())
+        session.add(_misconception())
+        await session.commit()
+
+        await FSRSService().schedule("card-1", "good", session)
+
+        rows = (
+            (
+                await session.execute(
+                    select(MisconceptionModel).where(MisconceptionModel.flashcard_id == "card-1")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 2
+        assert all(r.status == "resolved" for r in rows)
+        assert all(r.resolved_at is not None for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_again_review_keeps_misconceptions_open(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_card())
+        session.add(_misconception())
+        await session.commit()
+
+        await FSRSService().schedule("card-1", "again", session)
+
+        assert await _open_count(session, "card-1") == 1
+
+
+@pytest.mark.asyncio
+async def test_resolution_scoped_to_flashcard(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_card("card-1"))
+        session.add(_card("card-2"))
+        session.add(_misconception("card-1"))
+        session.add(_misconception("card-2"))
+        await session.commit()
+
+        await FSRSService().schedule("card-1", "easy", session)
+
+        assert await _open_count(session, "card-1") == 0
+        assert await _open_count(session, "card-2") == 1
+
+
+@pytest.mark.asyncio
+async def test_hard_rating_does_not_resolve(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_card())
+        session.add(_misconception())
+        await session.commit()
+
+        assert await resolve_on_review(session, "card-1", "hard") == 0
+        assert await _open_count(session, "card-1") == 1
+
+
+@pytest.mark.asyncio
+async def test_already_resolved_rows_untouched(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_card())
+        session.add(_misconception(status="resolved"))
+        await session.commit()
+
+        assert await resolve_for_flashcard(session, "card-1") == 0
+
+
+@pytest.mark.asyncio
+async def test_get_stats_counts_by_status_and_recency(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_card())
+        session.add(_misconception())
+        old = _misconception(status="resolved")
+        old.resolved_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=60)
+        recent = _misconception(status="resolved")
+        recent.resolved_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=2)
+        session.add_all([old, recent])
+        await session.commit()
+
+        assert await get_stats(session) == {
+            "open_count": 1,
+            "resolved_count": 2,
+            "resolved_last_30d": 1,
+        }

--- a/backend/tests/test_recommender_service.py
+++ b/backend/tests/test_recommender_service.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.database import make_engine
+from app.db_init import create_all_tables
+from app.models import (
+    ConceptModel,
+    ContentActivityModel,
+    DocumentModel,
+    FlashcardModel,
+    MisconceptionModel,
+    ReadingProgressModel,
+    RecommendationFeedbackModel,
+    ReviewEventModel,
+    SectionModel,
+)
+from app.services import recommender_service as svc
+
+
+@pytest.fixture
+async def session_factory():
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    await create_all_tables(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+def _naive(days_ago: float = 0.0) -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None) - timedelta(days=days_ago)
+
+
+def _card(card_id: str, *, slug: str | None = None, due_days_ago: float | None = None):
+    return FlashcardModel(
+        id=card_id,
+        question="q",
+        answer="a",
+        source_excerpt="s",
+        concept_slug=slug,
+        due_date=_naive(due_days_ago) if due_days_ago is not None else None,
+        document_id="doc-1",
+    )
+
+
+def _concept(slug: str, mastery: float, *, status: str = "confirmed", kind: str = "concept"):
+    return ConceptModel(
+        id=str(uuid.uuid4()), slug=slug, label=slug.replace("-", " "),
+        mastery=mastery, status=status, kind=kind,
+    )
+
+
+def _review(card_id: str, rating: str, *, days_ago: float = 1.0, predicted: str | None = None):
+    return ReviewEventModel(
+        id=str(uuid.uuid4()),
+        session_id="sess-1",
+        flashcard_id=card_id,
+        rating=rating,
+        is_correct=rating != "again",
+        reviewed_at=_naive(days_ago),
+        predicted_rating=predicted,
+    )
+
+
+def _misconception(card_id: str, *, days_ago: float = 3.0, status: str = "open"):
+    return MisconceptionModel(
+        id=str(uuid.uuid4()),
+        document_id="doc-1",
+        flashcard_id=card_id,
+        user_answer="wrong",
+        error_type="misconception",
+        correction_note="actually it works the other way",
+        detected_at=_naive(days_ago),
+        status=status,
+    )
+
+
+def _stalled_doc(doc_id: str, *, days_ago: float, read: int, total: int):
+    rows = [
+        DocumentModel(id=doc_id, title="Stalled Book", format="txt",
+                      content_type="book", file_path="/x"),
+        ContentActivityModel(member_type="document", member_id=doc_id,
+                             last_meaningful_at=_naive(days_ago)),
+    ]
+    rows += [
+        SectionModel(id=f"{doc_id}-s{i}", document_id=doc_id, heading=f"h{i}",
+                     level=1, section_order=i)
+        for i in range(total)
+    ]
+    rows += [
+        ReadingProgressModel(id=f"{doc_id}-rp{i}", document_id=doc_id,
+                             section_id=f"{doc_id}-s{i}")
+        for i in range(read)
+    ]
+    return rows
+
+
+@pytest.mark.asyncio
+async def test_overdue_reviews_candidate(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_card("c1", due_days_ago=3))
+        session.add(_card("c2", due_days_ago=0.5))
+        await session.commit()
+
+        recs = await svc.get_recommendations(session)
+        assert [r.kind for r in recs] == ["overdue_reviews"]
+        assert recs[0].count == 2
+        assert recs[0].target_type == "study"
+        assert "2 cards due" in recs[0].reasons[0].detail
+
+
+@pytest.mark.asyncio
+async def test_weak_concept_needs_recent_bad_reviews_and_low_mastery(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_concept("btree-splits", 0.2))
+        session.add(_concept("mastered-thing", 0.9))
+        session.add(_card("c1", slug="btree-splits"))
+        session.add(_card("c2", slug="mastered-thing"))
+        session.add_all([_review("c1", "again"), _review("c1", "hard")])
+        session.add_all([_review("c2", "again"), _review("c2", "again")])
+        await session.commit()
+
+        recs = await svc.get_recommendations(session)
+        kinds = {(r.kind, r.target_ref) for r in recs}
+        assert ("weak_concept", "btree-splits") in kinds
+        assert ("weak_concept", "mastered-thing") not in kinds
+        weak = next(r for r in recs if r.kind == "weak_concept")
+        assert "2 reviews rated again/hard" in weak.reasons[0].detail
+        assert "mastery 20%" in weak.reasons[0].detail
+
+
+@pytest.mark.asyncio
+async def test_weak_concept_ignores_junk_and_single_lapse(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_concept("junk-thing", 0.1, status="candidate"))
+        session.add(_concept("one-lapse", 0.1))
+        session.add(_card("c1", slug="junk-thing"))
+        session.add(_card("c2", slug="one-lapse"))
+        session.add_all([_review("c1", "again"), _review("c1", "again")])
+        session.add(_review("c2", "again"))
+        await session.commit()
+
+        recs = await svc.get_recommendations(session)
+        assert all(r.kind != "weak_concept" for r in recs)
+
+
+@pytest.mark.asyncio
+async def test_open_misconception_candidate_and_resolved_excluded(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_card("c1"))
+        session.add(_card("c2"))
+        session.add(_misconception("c1", days_ago=5))
+        session.add(_misconception("c2", status="resolved"))
+        await session.commit()
+
+        recs = await svc.get_recommendations(session)
+        miscon = [r for r in recs if r.kind == "open_misconception"]
+        assert [r.target_ref for r in miscon] == ["c1"]
+        assert miscon[0].document_id == "doc-1"
+        assert "actually it works the other way" in miscon[0].reasons[0].detail
+
+
+@pytest.mark.asyncio
+async def test_calibration_blind_spot_requires_confident_misses(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_concept("raft-elections", 0.7))
+        session.add(_card("c1", slug="raft-elections"))
+        session.add_all(
+            [
+                _review("c1", "again", predicted="good"),
+                _review("c1", "again", predicted="easy"),
+                _review("c1", "again", predicted="hard"),
+            ]
+        )
+        await session.commit()
+
+        recs = await svc.get_recommendations(session)
+        cal = [r for r in recs if r.kind == "calibration_blind_spot"]
+        assert [r.target_ref for r in cal] == ["raft-elections"]
+        assert "2 times" in cal[0].reasons[0].detail
+
+
+@pytest.mark.asyncio
+async def test_stalled_reading_candidate(session_factory) -> None:
+    async with session_factory() as session:
+        session.add_all(_stalled_doc("doc-stall", days_ago=10, read=4, total=10))
+        session.add_all(_stalled_doc("doc-warm", days_ago=2, read=4, total=10))
+        session.add_all(_stalled_doc("doc-done", days_ago=10, read=5, total=5))
+        await session.commit()
+
+        recs = await svc.get_recommendations(session)
+        stalled = [r for r in recs if r.kind == "stalled_reading"]
+        assert [r.target_ref for r in stalled] == ["doc-stall"]
+        assert "40% read" in stalled[0].reasons[0].detail
+
+
+@pytest.mark.asyncio
+async def test_overdue_outranks_stalled_reading(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_card("c1", due_days_ago=5))
+        session.add_all(_stalled_doc("doc-stall", days_ago=10, read=2, total=10))
+        await session.commit()
+
+        recs = await svc.get_recommendations(session)
+        assert recs[0].kind == "overdue_reviews"
+        assert {r.kind for r in recs} == {"overdue_reviews", "stalled_reading"}
+
+
+@pytest.mark.asyncio
+async def test_shown_feedback_upserted_and_incremented(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_card("c1", due_days_ago=1))
+        await session.commit()
+
+        first = await svc.get_recommendations(session)
+        second = await svc.get_recommendations(session)
+        assert first[0].id == second[0].id
+
+        rows = (await session.execute(select(RecommendationFeedbackModel))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].shown_count == 2
+        assert rows[0].last_shown_at is not None
+
+
+@pytest.mark.asyncio
+async def test_dismissal_hides_until_new_evidence(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_card("c1", due_days_ago=1))
+        await session.commit()
+
+        recs = await svc.get_recommendations(session)
+        assert await svc.mark_dismissed(session, recs[0].id)
+        assert await svc.get_recommendations(session) == []
+
+        # evidence newer than the dismissal re-arms the candidate: backdate the
+        # dismissal so the standing due-card evidence postdates it
+        fb = await session.get(RecommendationFeedbackModel, recs[0].id)
+        fb.dismissed_at = _naive(days_ago=2)
+        await session.commit()
+        rearmed = await svc.get_recommendations(session)
+        assert [r.kind for r in rearmed] == ["overdue_reviews"]
+
+
+@pytest.mark.asyncio
+async def test_fatigue_penalizes_repeatedly_ignored(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_card("c1", due_days_ago=1))
+        await session.commit()
+
+        baseline = (await svc.get_recommendations(session))[0].score
+        for _ in range(5):
+            await svc.get_recommendations(session)
+        fatigued = (await svc.get_recommendations(session))[0].score
+        assert fatigued < baseline
+
+        # acting on it clears the fatigue penalty
+        rec_id = (await svc.get_recommendations(session))[0].id
+        assert await svc.mark_acted(session, rec_id)
+        after_acted = (await svc.get_recommendations(session))[0].score
+        assert after_acted > fatigued
+
+
+@pytest.mark.asyncio
+async def test_to_today_action_mapping(session_factory) -> None:
+    async with session_factory() as session:
+        session.add(_concept("btree-splits", 0.2))
+        session.add(_card("c1", slug="btree-splits"))
+        session.add_all([_review("c1", "again"), _review("c1", "hard")])
+        await session.commit()
+
+        recs = await svc.get_recommendations(session)
+        action = svc.to_today_action(recs[0])
+        assert action.kind == "drill_concept"
+        assert action.target_id == "btree-splits"
+        assert action.recommendation_id == recs[0].id
+        assert action.reasons == recs[0].reasons
+
+
+@pytest.mark.asyncio
+async def test_empty_database_yields_no_recommendations(session_factory) -> None:
+    async with session_factory() as session:
+        assert await svc.get_recommendations(session) == []

--- a/docs/recommender-spec.md
+++ b/docs/recommender-spec.md
@@ -1,0 +1,149 @@
+---
+description: Personal recommender spec -- deterministic, evidence-grounded next-best-action on the hub plus misconception lifecycle. Read before implementing on feat/personal-recommender.
+---
+
+# Personal Recommender
+
+Branch: `feat/personal-recommender`. Status: approved scope, ready to implement.
+
+## The value, in one sentence
+
+The hub answers "what should I do next, and why?" from evidence the app has actually
+measured, and when the learner closes a gap the app notices and says so.
+
+## Scope decisions (locked 2026-07-06)
+
+- **In**: hub recommender (hero + up to 3 secondary cards, each with a because-line and a
+  dismiss control), misconception lifecycle (open -> resolved), persistent
+  dismiss/acted feedback table.
+- **Out -- do not let these creep back in**: `learner_facts` table, LLM consolidation
+  jobs, Ask/chat learner-context injection, study-assembler re-weighting, acceptance-rate
+  dashboards. Some may become follow-up branches; none are designed into this one.
+
+Two hard rules:
+
+1. **Deterministic at request time.** Candidate generation and scoring are plain DB reads.
+   No LLM anywhere in this feature.
+2. **Document-agnostic.** No subject, corpus, or document special-casing in generators,
+   weights, or thresholds.
+
+## Current state
+
+`_pick_today_action` in `routers/home.py` is a fixed 3-rule priority (due cards >
+continue-reading > resume-note). It ignores mastery, `again` streaks, misconceptions, and
+calibration deltas -- all of which are already collected. `misconceptions` rows are
+write-only today (written in `routers/study.py` answer grading, never read back).
+`fsrs_service.py` already computes struggling cards (`again_count >= threshold` over
+recent `review_events`).
+
+## Design
+
+### `recommender_service`
+
+`backend/app/services/recommender_service.py`, one entry point:
+
+```
+async def get_recommendations(session: AsyncSession, limit: int = 4) -> list[Recommendation]
+```
+
+`Recommendation` (Pydantic, in the home schemas module): `kind`, `target_type`,
+`target_ref`, `label`, `score`, `reasons: list[Reason]`, `action` (deep-link payload for
+`luminary:navigate`). `Reason` = `{signal, value, detail}` -- enough to render an honest
+because-line, e.g. "3 reviews rated 'again' this week on *B-tree splits*".
+
+Five generators, each a small async function over existing tables, run **sequentially on
+the one request session** (I-1 -- no gather):
+
+| Generator | Signal source | Deep link |
+|---|---|---|
+| `overdue_reviews` | due count + max days overdue on `flashcards` | Study daily scope |
+| `weak_concept` | `concepts.mastery` below floor joined with recent `again`/`hard` `review_events` via `flashcards.concept_slug` (reuse the fsrs_service struggling query) | concept-scoped study |
+| `open_misconception` | `misconceptions` where `status='open'`, ranked by age x error_type | re-quiz that flashcard's concept |
+| `calibration_blind_spot` | `review_events.predicted_rating` >> actual, aggregated per concept over last N reviews | confidence-check drill on concept |
+| `stalled_reading` | `reading_progress` in (0,1) with no `content_activity` for N days | continue reading |
+
+Scoring is a transparent weighted sum:
+
+```
+score = w_u * urgency + w_i * impact + w_r * recency - w_f * fatigue
+```
+
+urgency = time-sensitivity (FSRS overdue days, misconception age); impact = mastery
+deficit / error severity; recency = warm context bonus (recently touched doc or concept);
+fatigue = penalty from prior un-acted `shown` rows in `recommendation_feedback`.
+Weights and thresholds are module constants with unit tests, not settings. Dismissed
+targets are excluded outright while their dismissal is active.
+
+The top-scored candidate becomes `today_action` (same `TodayAction` contract, extended
+with optional `reasons`); the next up-to-3 fill a new `recommendations` list on the
+overview response. When no generator fires, behaviour degrades to exactly today's
+heuristics (continue-reading / resume-note fallbacks stay as the floor).
+
+### Table: `recommendation_feedback`
+
+```
+id TEXT PK, kind TEXT, target_type TEXT, target_ref TEXT,
+shown_count INTEGER DEFAULT 0, last_shown_at DATETIME,
+dismissed_at DATETIME NULL, acted_at DATETIME NULL
+```
+
+One row per (kind, target) -- upserted on show, stamped on dismiss/act. Serves anti-nag
+(dismiss persists; fatigue grows with un-acted shows) and leaves an honest usage record.
+Dismissal expires when the underlying signal materially changes (e.g. new `again` review
+after dismissal re-arms the target); expiry rule lives in the generator, not the table.
+
+Endpoints (on the existing `home` router -- no new router, no surface-manifest churn):
+
+```
+POST /home/recommendations/{id}/dismiss
+POST /home/recommendations/{id}/acted     (fired by the frontend on click-through)
+```
+
+### Misconception lifecycle
+
+- `ALTER TABLE misconceptions ADD COLUMN status TEXT NOT NULL DEFAULT 'open'` and
+  `ADD COLUMN resolved_at DATETIME` via the existing idempotent migration list in
+  `db_init.py`.
+- **Resolution is deterministic, no LLM**: when a review event with rating good/easy or a
+  passing teach-back lands on a flashcard that has open misconceptions, mark them
+  resolved. Hook = the existing review-write path in `routers/study.py` /
+  `repos/study_repo.py` (single call into the service; keep the router thin).
+- Resolved misconceptions stop feeding `open_misconception` and surface on Progress as a
+  simple "gaps closed" count (one stat, reuse an existing Progress stat slot -- not a new
+  widget system).
+
+### Hub UI (`frontend/src/pages/Hub.tsx`)
+
+- TodayHero keeps its layout; gains a one-line muted because-line under the CTA.
+- New "Recommended next" stack under the hero: up to 3 compact cards -- icon per kind,
+  label, because-line, dismiss (x). Click-through fires `acted` then navigates via
+  `luminary:navigate` (I-11).
+- States per I-10: skeleton while loading, inline error, and when empty the section
+  disappears entirely (the hero fallback always renders something).
+- Data rides the existing `GET /home/overview` single-fetch contract -- no extra hub
+  query beyond the two mutation calls.
+
+## Implementation order
+
+1. **Schema**: `recommendation_feedback` model + DDL; `misconceptions` status columns via
+   the `db_init.py` ALTER list.
+2. **Misconception resolution** in the review/teach-back write path + tests (open ->
+   resolved on good review; stays open on `again`).
+3. **`recommender_service`**: generators + scoring + fatigue/dismiss filtering. Unit
+   tests per generator (seeded SQLite fixtures) + scoring-order tests.
+4. **Router**: extend `/home/overview` response (`today_action.reasons`,
+   `recommendations`), add dismiss/acted endpoints. API contract tests.
+5. **Frontend**: types, hub stack + hero because-line, dismiss/acted wiring, I-10 states.
+6. **Progress**: "gaps closed" stat.
+7. **Gates**: ruff -> pytest -> tsc (I-13), then a live drive of the hub with a seeded DB
+   (due cards + an open misconception + a calibration gap) verifying ranking, dismiss
+   persistence across reload, and resolution flow end to end.
+
+Each step lands green before the next starts; the feature is inert until step 4-5 exposes
+it, so there is no broken intermediate state.
+
+## Invariants in play
+
+I-1 (generators share the request session sequentially, never across `gather`), I-10/I-11
+(hub UI), I-13/I-14 (gates before done), I-19 (read `concepts.mastery`, never recompute),
+six-layer rule (SQL in service/repo, router stays thin).

--- a/frontend/src/components/SessionManager.tsx
+++ b/frontend/src/components/SessionManager.tsx
@@ -1,7 +1,7 @@
 /**
  * SessionManager -- active (in-progress) and completed session lists on the
  * Study landing page. Completed rows use the shared SessionHistoryRow so the
- * landing page and the scoped per-doc/per-enclave history stay in sync.
+ * landing page and the scoped per-doc/per-collection history stay in sync.
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"

--- a/frontend/src/components/StudySession.tsx
+++ b/frontend/src/components/StudySession.tsx
@@ -277,10 +277,13 @@ interface FlashCardProps {
 }
 
 function FlashCard({ card, showAnswer, onFlip }: FlashCardProps) {
+  // Card grows to fit its content -- long answers used to overflow a fixed-height
+  // 3D-flip container and overlap the rating buttons below. We reveal the answer
+  // beneath the question (Anki-style) and left-align it so multi-point answers
+  // and markdown bullets read cleanly.
   return (
     <div
-      className="relative min-h-64 w-full max-w-2xl cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      style={{ perspective: "1000px", position: "relative" }}
+      className="w-full max-w-2xl cursor-pointer rounded-xl border border-border bg-card p-8 shadow-md transition-shadow hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       onClick={onFlip}
       role="button"
       tabIndex={0}
@@ -288,33 +291,35 @@ function FlashCard({ card, showAnswer, onFlip }: FlashCardProps) {
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault()
-          // Handle the flip here and stop the event before it reaches the
-          // session-level window listener, which would otherwise also fire.
+          // Stop the event before it reaches the session-level window listener,
+          // which would otherwise also fire.
           e.stopPropagation()
           onFlip?.()
         }
       }}
     >
-      <motion.div
-        className="absolute flex min-h-64 w-full flex-col items-center justify-center overflow-auto rounded-xl border border-border bg-card p-8 text-center shadow-md"
-        animate={{ rotateY: showAnswer ? -180 : 0 }}
-        transition={{ duration: 0.4, ease: "easeInOut" }}
-        style={{ backfaceVisibility: "hidden" }}
-      >
-        <MarkdownRenderer className="text-xl font-semibold text-foreground">{card.question}</MarkdownRenderer>
-      </motion.div>
-
-      <motion.div
-        className="absolute flex min-h-64 w-full flex-col items-center justify-center gap-4 overflow-auto rounded-xl border border-border bg-card p-8 text-center shadow-md"
-        initial={{ rotateY: 180 }}
-        animate={{ rotateY: showAnswer ? 0 : 180 }}
-        transition={{ duration: 0.4, ease: "easeInOut" }}
-        style={{ backfaceVisibility: "hidden" }}
-      >
-        <MarkdownRenderer className="text-sm text-muted-foreground">{card.question}</MarkdownRenderer>
-        <hr className="w-3/4 border-border" />
-        <MarkdownRenderer className="text-lg font-medium text-foreground">{card.answer}</MarkdownRenderer>
-      </motion.div>
+      {!showAnswer ? (
+        <div className="flex min-h-48 items-center justify-center">
+          <MarkdownRenderer className="text-center text-xl font-semibold text-foreground">
+            {card.question}
+          </MarkdownRenderer>
+        </div>
+      ) : (
+        <motion.div
+          initial={{ opacity: 0, y: 6 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.2 }}
+          className="flex flex-col gap-4"
+        >
+          <MarkdownRenderer className="text-center text-sm text-muted-foreground">
+            {card.question}
+          </MarkdownRenderer>
+          <hr className="border-border" />
+          <MarkdownRenderer className="text-left text-base leading-relaxed text-foreground prose-p:my-2 prose-ul:my-2 prose-li:my-0.5">
+            {card.answer}
+          </MarkdownRenderer>
+        </motion.div>
+      )}
     </div>
   )
 }
@@ -457,7 +462,12 @@ export function StudySession({ initial, scopeForBeginNew, onExit }: StudySession
     beginNew,
   } = useStudySession({ initial, scopeForBeginNew })
 
+  // `showAnswer` = which card face is displayed (the flip). `revealed` = a
+  // one-way latch, set once the learner commits to seeing the answer (predict or
+  // skip). Controls key off `revealed` so flipping the card back to the question
+  // no longer regresses to the confidence picker -- the rating buttons stay put.
   const [showAnswer, setShowAnswer] = useState(false)
+  const [revealed, setRevealed] = useState(false)
   const [correct, setCorrect] = useState(0)
   const [isRating, setIsRating] = useState(false)
   const [lastRating, setLastRating] = useState<Rating | null>(null)
@@ -533,6 +543,7 @@ export function StudySession({ initial, scopeForBeginNew, onExit }: StudySession
           } else {
             setCurrentIndex(nextIdx)
             setShowAnswer(false)
+            setRevealed(false)
             setLastRating(null)
             setPredictedRating(null)
           }
@@ -547,6 +558,7 @@ export function StudySession({ initial, scopeForBeginNew, onExit }: StudySession
       } else {
         setCurrentIndex(nextIdx)
         setShowAnswer(false)
+        setRevealed(false)
         setLastRating(null)
         setPredictedRating(null)
       }
@@ -565,6 +577,7 @@ export function StudySession({ initial, scopeForBeginNew, onExit }: StudySession
     } else {
       setCurrentIndex(nextIdx)
       setShowAnswer(false)
+      setRevealed(false)
       setLastRating(null)
       setPredictedRating(null)
     }
@@ -613,9 +626,10 @@ export function StudySession({ initial, scopeForBeginNew, onExit }: StudySession
         card.cloze_text !== null &&
         /\{\{.+?\}\}/.test(card.cloze_text)
       if (isClozeCard) return
-      if (!showAnswer) {
+      if (!revealed) {
         if (e.key === " " || e.key === "Enter") {
           e.preventDefault()
+          setRevealed(true)
           setShowAnswer(true)
           return
         }
@@ -626,6 +640,7 @@ export function StudySession({ initial, scopeForBeginNew, onExit }: StudySession
         if (predicted) {
           e.preventDefault()
           setPredictedRating(predicted)
+          setRevealed(true)
           setShowAnswer(true)
         }
         return
@@ -636,16 +651,17 @@ export function StudySession({ initial, scopeForBeginNew, onExit }: StudySession
         if (rating) {
           e.preventDefault()
           void handleRate(rating)
-        } else if (e.key === " ") {
-          // prevent the page from scrolling while the answer is shown
+        } else if (e.key === " " || e.key === "Enter") {
+          // after the reveal, Space/Enter flips the face to peek at the question
           e.preventDefault()
+          setShowAnswer((prev) => !prev)
         }
       }
     }
     window.addEventListener("keydown", onKeyDown)
     return () => window.removeEventListener("keydown", onKeyDown)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [queue, currentIndex, showAnswer, lastRating, isRating, sourceContext, onExit])
+  }, [queue, currentIndex, showAnswer, revealed, lastRating, isRating, sourceContext, onExit])
 
   if (sessionState === "loading") {
     return (
@@ -685,6 +701,7 @@ export function StudySession({ initial, scopeForBeginNew, onExit }: StudySession
             setLastRating(null)
             setPredictedRating(null)
             setShowAnswer(false)
+            setRevealed(false)
             setNextReviewDate(null)
             setSourceContext(null)
             setCalibrationInline(null)
@@ -753,12 +770,21 @@ export function StudySession({ initial, scopeForBeginNew, onExit }: StudySession
               <FlashCard
                 card={currentCard}
                 showAnswer={showAnswer}
-                onFlip={() => setShowAnswer((prev) => !prev)}
+                onFlip={() => {
+                  // First interaction reveals the answer (and commits to grading);
+                  // afterwards a click just flips the face to peek at the question.
+                  if (!revealed) {
+                    setRevealed(true)
+                    setShowAnswer(true)
+                  } else {
+                    setShowAnswer((prev) => !prev)
+                  }
+                }}
               />
             </motion.div>
           </AnimatePresence>
 
-          {!showAnswer ? (
+          {!revealed ? (
             <div className="flex flex-col items-center gap-3">
               <p className="text-xs text-muted-foreground">How confident are you?</p>
               <div className="flex gap-2">
@@ -773,6 +799,7 @@ export function StudySession({ initial, scopeForBeginNew, onExit }: StudySession
                     key={value}
                     onClick={() => {
                       setPredictedRating(value)
+                      setRevealed(true)
                       setShowAnswer(true)
                     }}
                     className={`rounded border px-4 py-1.5 text-xs font-medium transition-colors ${
@@ -787,7 +814,10 @@ export function StudySession({ initial, scopeForBeginNew, onExit }: StudySession
                 ))}
               </div>
               <button
-                onClick={() => setShowAnswer(true)}
+                onClick={() => {
+                  setRevealed(true)
+                  setShowAnswer(true)
+                }}
                 className="text-xs text-muted-foreground underline-offset-2 hover:underline"
               >
                 Skip prediction → Show Answer

--- a/frontend/src/components/study/CollectionCardManager.tsx
+++ b/frontend/src/components/study/CollectionCardManager.tsx
@@ -1,0 +1,252 @@
+// Card management for a collection: view, edit, and delete the flashcards
+// generated across a collection's documents and notes -- the collection
+// counterpart to the per-document FlashcardManager. Self-contained so the
+// CollectionStudyDashboard just drops it in.
+
+import { useState } from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { AlertCircle, Layers, Loader2 } from "lucide-react"
+import { toast } from "sonner"
+
+import {
+  bulkDeleteFlashcards,
+  deleteAllFlashcardsForCollection,
+  deleteFlashcard,
+  fetchFlashcardSearch,
+  updateFlashcard,
+} from "@/pages/Study/api"
+import type { FlashcardSearchResponse } from "@/pages/Study/types"
+import { FlashcardCard } from "@/pages/Study/FlashcardCard"
+import { endOpenSessionsForScope } from "@/lib/studySessionService"
+
+const PAGE_SIZE = 20
+
+export function CollectionCardManager({ collectionId }: { collectionId: string }) {
+  const qc = useQueryClient()
+  const [page, setPage] = useState(1)
+  const [selectionMode, setSelectionMode] = useState(false)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [confirmDelete, setConfirmDelete] = useState<null | "selected" | "all">(null)
+
+  const { data, isLoading, isError } = useQuery<FlashcardSearchResponse>({
+    queryKey: ["collection-cards", collectionId, page],
+    queryFn: () =>
+      fetchFlashcardSearch({ collection_id: collectionId, page, page_size: PAGE_SIZE }),
+  })
+
+  const cards = data?.items ?? []
+  const total = data?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ["collection-cards", collectionId] })
+    qc.invalidateQueries({ queryKey: ["collection-dashboard", collectionId] })
+  }
+
+  const clearSelection = () => setSelectedIds(new Set())
+  const toggleSelect = (id: string) =>
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+
+  const updateMutation = useMutation({
+    mutationFn: (a: { id: string; data: { question?: string; answer?: string } }) =>
+      updateFlashcard(a.id, a.data),
+    onSuccess: invalidate,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteFlashcard,
+    onSuccess: invalidate,
+  })
+
+  const bulkDeleteMutation = useMutation({
+    mutationFn: bulkDeleteFlashcards,
+    onSuccess: (res) => {
+      invalidate()
+      clearSelection()
+      setSelectionMode(false)
+      setConfirmDelete(null)
+      toast.success(`Deleted ${res.deleted} card${res.deleted === 1 ? "" : "s"}`)
+    },
+    onError: () => toast.error("Failed to delete selected cards"),
+  })
+
+  const deleteAllMutation = useMutation({
+    mutationFn: async () => {
+      const res = await deleteAllFlashcardsForCollection(collectionId)
+      // Drop any in-progress session so it can't resume with deleted cards.
+      await endOpenSessionsForScope(null, collectionId)
+      return res
+    },
+    onSuccess: (res) => {
+      invalidate()
+      clearSelection()
+      setSelectionMode(false)
+      setConfirmDelete(null)
+      setPage(1)
+      toast.success(`Deleted ${res.deleted} card${res.deleted === 1 ? "" : "s"} from this collection`)
+    },
+    onError: () => toast.error("Failed to delete collection cards"),
+  })
+
+  const deleting = bulkDeleteMutation.isPending || deleteAllMutation.isPending
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h3 className="flex items-center gap-2 font-semibold text-foreground">
+          <Layers size={18} className="text-primary" />
+          Manage cards
+          <span className="text-xs font-normal text-muted-foreground">
+            {total} card{total === 1 ? "" : "s"} in this collection
+          </span>
+        </h3>
+      </div>
+
+      {/* Selection + delete toolbar (parity with the per-document manager) */}
+      {total > 0 && (
+        <div className="flex flex-wrap items-center gap-3 rounded-md border border-border bg-muted/30 px-4 py-2 text-sm">
+          {!selectionMode ? (
+            <button
+              onClick={() => setSelectionMode(true)}
+              className="rounded border border-border bg-background px-3 py-1 text-xs font-medium text-foreground hover:bg-accent"
+            >
+              Select cards
+            </button>
+          ) : (
+            <>
+              <span className="text-xs font-medium text-muted-foreground">
+                {selectedIds.size} selected
+              </span>
+              <button
+                onClick={() => setSelectedIds(new Set(cards.map((c) => c.id)))}
+                className="rounded border border-border bg-background px-3 py-1 text-xs font-medium text-foreground hover:bg-accent"
+              >
+                Select all on page
+              </button>
+              <button
+                onClick={clearSelection}
+                className="rounded border border-border bg-background px-3 py-1 text-xs font-medium text-foreground hover:bg-accent"
+              >
+                Clear
+              </button>
+              <button
+                onClick={() => setConfirmDelete("selected")}
+                disabled={selectedIds.size === 0 || deleting}
+                className="rounded bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                Delete selected ({selectedIds.size})
+              </button>
+              <button
+                onClick={() => {
+                  setSelectionMode(false)
+                  clearSelection()
+                }}
+                className="rounded border border-border bg-background px-3 py-1 text-xs font-medium text-foreground hover:bg-accent"
+              >
+                Done
+              </button>
+            </>
+          )}
+          <button
+            onClick={() => setConfirmDelete("all")}
+            disabled={deleting}
+            className="ml-auto rounded border border-red-300 bg-red-50 px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-100 disabled:opacity-50 dark:border-red-900 dark:bg-red-950/30 dark:text-red-400"
+          >
+            Delete all ({total})
+          </button>
+        </div>
+      )}
+
+      {/* Confirmation banner -- destructive, so it always asks first */}
+      {confirmDelete && (
+        <div className="flex items-center gap-3 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/30 dark:text-red-200">
+          <AlertCircle size={16} />
+          <span className="flex-1">
+            {confirmDelete === "selected"
+              ? `Permanently delete ${selectedIds.size} selected card${selectedIds.size === 1 ? "" : "s"}? This cannot be undone.`
+              : `Permanently delete ALL ${total} cards in this collection? This cannot be undone.`}
+          </span>
+          <button
+            onClick={() =>
+              confirmDelete === "selected"
+                ? bulkDeleteMutation.mutate(Array.from(selectedIds))
+                : deleteAllMutation.mutate()
+            }
+            disabled={deleting}
+            className="flex items-center gap-1 rounded bg-red-600 px-3 py-1 text-xs font-semibold text-white hover:bg-red-700 disabled:opacity-50"
+          >
+            {deleting && <Loader2 size={12} className="animate-spin" />}
+            Confirm delete
+          </button>
+          <button
+            onClick={() => setConfirmDelete(null)}
+            className="rounded border border-red-300 px-3 py-1 text-xs font-medium hover:bg-red-100 dark:hover:bg-red-900/40"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {/* Card grid with loading / error / empty states (I-10) */}
+      {isLoading ? (
+        <div className="flex justify-center py-10">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      ) : isError ? (
+        <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-950/30 dark:text-amber-300">
+          Could not load this collection's cards.
+        </div>
+      ) : cards.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-card/20 py-12 text-center">
+          <Layers size={28} className="text-muted-foreground opacity-30" />
+          <p className="text-sm text-muted-foreground">
+            No cards yet. Use the generator to create some for this collection.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {cards.map((c) => (
+            <FlashcardCard
+              key={c.id}
+              card={c}
+              onUpdate={(id, d) => updateMutation.mutate({ id, data: d })}
+              onDelete={(id) => deleteMutation.mutate(id)}
+              isUpdating={updateMutation.isPending}
+              isDeleting={deleteMutation.isPending}
+              selectionMode={selectionMode}
+              selected={selectedIds.has(c.id)}
+              onToggleSelect={toggleSelect}
+            />
+          ))}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="mt-2 flex justify-center gap-2">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="rounded-full bg-secondary px-3 py-1 text-xs font-bold uppercase text-primary hover:bg-secondary/80 disabled:opacity-40"
+          >
+            Prev
+          </button>
+          <span className="flex items-center text-xs font-bold">
+            {page} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages}
+            className="rounded-full bg-secondary px-3 py-1 text-xs font-bold uppercase text-primary hover:bg-secondary/80 disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/study/CollectionStudyDashboard.tsx
+++ b/frontend/src/components/study/CollectionStudyDashboard.tsx
@@ -8,6 +8,7 @@ import {
   Loader2,
   MessageSquare,
   Play,
+  RefreshCw,
   Search,
   Sparkles,
   Tag as TagIcon,
@@ -24,7 +25,10 @@ import {
   generateCollectionFlashcards,
   generateDocumentFlashcards,
 } from "@/lib/studyApi"
+import { deleteAllFlashcardsForCollection } from "@/pages/Study/api"
+import { endOpenSessionsForScope } from "@/lib/studySessionService"
 import { SessionHistory } from "@/components/study/SessionHistory"
+import { CollectionCardManager } from "@/components/study/CollectionCardManager"
 
 interface CollectionTopic {
   tag: string
@@ -36,6 +40,7 @@ interface CollectionSource {
   id: string
   title: string
   type: "document" | "note"
+  weight?: number
 }
 
 interface SubCollection {
@@ -81,28 +86,25 @@ export function CollectionStudyDashboard({
 
   const [selectedTopic, setSelectedTopic] = useState<string | null>(null)
   const [selectedSources, setSelectedSources] = useState<Set<string>>(new Set())
-  const [genCount, setGenCount] = useState<number>(10)
+  const [genCount, setGenCount] = useState<number>(20)
   const [genDifficulty, setGenDifficulty] = useState<Difficulty>("medium")
   const [generatingDocId, setGeneratingDocId] = useState<string | null>(null)
+  const [confirmReplace, setConfirmReplace] = useState(false)
 
   const invalidateAll = () => {
     queryClient.invalidateQueries({ queryKey: ["collection-dashboard", collectionId] })
+    queryClient.invalidateQueries({ queryKey: ["collection-cards", collectionId] })
     queryClient.invalidateQueries({ queryKey: ["flashcards"] })
     queryClient.invalidateQueries({ queryKey: ["deck-list"] })
   }
 
   const collectionGenMutation = useMutation({
     mutationFn: () =>
-      generateCollectionFlashcards(
-        collectionId,
-        data?.sources ?? [],
-        genCount,
-        genDifficulty,
-      ),
+      generateCollectionFlashcards(data?.sources ?? [], genCount, genDifficulty),
     onSuccess: (result) => {
       if (result.totalCreated > 0) {
         toast.success(
-          `Generated ${result.totalCreated} card${result.totalCreated === 1 ? "" : "s"} for this enclave`,
+          `Generated ${result.totalCreated} card${result.totalCreated === 1 ? "" : "s"} for this collection`,
         )
       } else if (result.noteSkipped > 0) {
         toast.info(
@@ -118,6 +120,33 @@ export function CollectionStudyDashboard({
     },
     onError: (e) => {
       toast.error(e instanceof Error ? e.message : "Generation failed")
+    },
+  })
+
+  // Regenerate (replace): wipe this collection's cards, then generate a fresh
+  // set across all its sources. Fresh slate -- old cards + review history go.
+  const collectionReplaceMutation = useMutation({
+    mutationFn: async () => {
+      await deleteAllFlashcardsForCollection(collectionId)
+      // Fresh cards -> fresh review: drop the stale in-progress session.
+      await endOpenSessionsForScope(null, collectionId)
+      return generateCollectionFlashcards(data?.sources ?? [], genCount, genDifficulty)
+    },
+    onSuccess: (result) => {
+      setConfirmReplace(false)
+      toast.success(
+        result.totalCreated > 0
+          ? `Replaced with ${result.totalCreated} fresh card${result.totalCreated === 1 ? "" : "s"}`
+          : "Cleared -- no new cards were generated",
+      )
+      if (result.errors.length > 0) {
+        toast.error(`${result.errors.length} source${result.errors.length === 1 ? "" : "s"} failed`)
+      }
+      invalidateAll()
+    },
+    onError: (e) => {
+      setConfirmReplace(false)
+      toast.error(e instanceof Error ? e.message : "Regenerate failed")
     },
   })
 
@@ -360,7 +389,7 @@ export function CollectionStudyDashboard({
                     <Grid size={24} />
                   </div>
                   <h4 className="text-sm font-semibold text-foreground">No studies available yet</h4>
-                  <p className="mt-1 text-xs text-muted-foreground">Use the synthesis engine to generate flashcards for this enclave.</p>
+                  <p className="mt-1 text-xs text-muted-foreground">Use the generator to create flashcards for this collection.</p>
                 </div>
               )}
 
@@ -477,9 +506,10 @@ export function CollectionStudyDashboard({
               )}
             </div>
             <div>
-              <p className="font-bold text-base text-foreground">Synthesis Engine</p>
+              <p className="font-bold text-base text-foreground">Generate cards</p>
               <p className="text-xs text-muted-foreground mt-2 leading-relaxed">
-                Generate fresh questions across every document and note in this enclave.
+                A total for the whole collection, split across its sources by size — a
+                book earns more questions than a short note.
               </p>
             </div>
 
@@ -494,9 +524,10 @@ export function CollectionStudyDashboard({
                   disabled={collectionGenMutation.isPending || docGenMutation.isPending}
                   className="rounded-md border border-border bg-background px-2 py-1 text-xs font-medium disabled:opacity-50"
                 >
-                  <option value={5}>5 per source</option>
-                  <option value={10}>10 per source</option>
-                  <option value={20}>20 per source</option>
+                  <option value={10}>10 questions</option>
+                  <option value={20}>20 questions</option>
+                  <option value={30}>30 questions</option>
+                  <option value={50}>50 questions</option>
                 </select>
               </div>
               <div className="flex items-center justify-between gap-2">
@@ -520,7 +551,7 @@ export function CollectionStudyDashboard({
               onClick={() => {
                 if (collectionGenMutation.isPending || docGenMutation.isPending) return
                 if (data.sources.length === 0) {
-                  toast.info("Add at least one source to this enclave first")
+                  toast.info("Add at least one source to this collection first")
                   return
                 }
                 collectionGenMutation.mutate()
@@ -528,6 +559,7 @@ export function CollectionStudyDashboard({
               disabled={
                 collectionGenMutation.isPending ||
                 docGenMutation.isPending ||
+                collectionReplaceMutation.isPending ||
                 data.sources.length === 0
               }
               className="flex items-center justify-center gap-2 rounded-xl bg-primary py-3 text-sm font-semibold text-primary-foreground shadow-md transition-all hover:bg-primary/90 disabled:opacity-50"
@@ -540,7 +572,7 @@ export function CollectionStudyDashboard({
               ) : (
                 <>
                   <Sparkles size={14} />
-                  Generate for enclave
+                  Generate for collection
                 </>
               )}
             </button>
@@ -549,11 +581,68 @@ export function CollectionStudyDashboard({
                 LLM calls run sequentially per source -- this may take a minute or two.
               </p>
             )}
+
+            {/* Regenerate (replace): fresh set, discards existing cards + history */}
+            {!confirmReplace ? (
+              <button
+                onClick={() => {
+                  if (data.sources.length === 0) {
+                    toast.info("Add at least one source to this collection first")
+                    return
+                  }
+                  setConfirmReplace(true)
+                }}
+                disabled={
+                  collectionGenMutation.isPending ||
+                  docGenMutation.isPending ||
+                  collectionReplaceMutation.isPending ||
+                  data.sources.length === 0
+                }
+                className="flex items-center justify-center gap-2 rounded-xl border border-border bg-background/60 py-2 text-xs font-semibold text-foreground transition-all hover:bg-accent disabled:opacity-50"
+              >
+                {collectionReplaceMutation.isPending ? (
+                  <Loader2 size={12} className="animate-spin" />
+                ) : (
+                  <RefreshCw size={12} />
+                )}
+                Regenerate (replace)
+              </button>
+            ) : (
+              <div className="flex flex-col gap-2 rounded-lg border border-primary/30 bg-primary/5 p-3">
+                <p className="text-xs text-foreground">
+                  Delete all existing cards in this collection and generate a fresh set?
+                  Their review history is lost.
+                </p>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => collectionReplaceMutation.mutate()}
+                    disabled={collectionReplaceMutation.isPending}
+                    className="flex items-center gap-1 rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                  >
+                    {collectionReplaceMutation.isPending && (
+                      <Loader2 size={12} className="animate-spin" />
+                    )}
+                    Replace
+                  </button>
+                  <button
+                    onClick={() => setConfirmReplace(false)}
+                    disabled={collectionReplaceMutation.isPending}
+                    className="rounded-lg border border-border px-3 py-1.5 text-xs font-medium hover:bg-accent disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
           </Card>
         </div>
       </div>
 
-      {/* Session history (teach-back + flashcard) scoped to this enclave */}
+      {/* Card management: view + delete this collection's cards, like documents.
+          Keyed by collection so switching collections resets its local state. */}
+      <CollectionCardManager key={collectionId} collectionId={collectionId} />
+
+      {/* Session history (teach-back + flashcard) scoped to this collection */}
       <SessionHistory
         scope={{ kind: "collection", id: collectionId }}
         onResumeTeachback={(sid) => onStartTeachback(undefined, sid)}

--- a/frontend/src/components/study/SessionHistory.tsx
+++ b/frontend/src/components/study/SessionHistory.tsx
@@ -94,7 +94,7 @@ export function SessionHistory({
   const sessions = data?.items ?? []
   const hasAny = sessions.length > 0
   const scopeLabel =
-    scope.kind === "collection" ? "this enclave" : "this document"
+    scope.kind === "collection" ? "this collection" : "this document"
 
   const allSelected =
     sessions.length > 0 && sessions.every((s) => selectedIds.has(s.id))

--- a/frontend/src/lib/studyApi.ts
+++ b/frontend/src/lib/studyApi.ts
@@ -5,6 +5,7 @@
  */
 
 import { API_BASE } from "@/lib/config"
+import { distributeByWeight } from "@/lib/studyDistribute"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -343,10 +344,13 @@ export interface CollectionGenerationResult {
   errors: string[]
 }
 
+// Generate roughly `totalCount` cards for the WHOLE collection (not per source):
+// the total is split across sources proportionally to their content size, so a
+// book earns most of the questions and a short note a few. Sources allotted 0
+// are skipped.
 export async function generateCollectionFlashcards(
-  collectionId: string,
-  sources: { id: string; type: "document" | "note" }[],
-  count: number = 10,
+  sources: { id: string; type: "document" | "note"; weight?: number }[],
+  totalCount: number = 20,
   difficulty: Difficulty = "medium",
 ): Promise<CollectionGenerationResult> {
   const result: CollectionGenerationResult = {
@@ -356,44 +360,43 @@ export async function generateCollectionFlashcards(
     documentsProcessed: 0,
     errors: [],
   }
+  if (sources.length === 0) return result
 
-  const hasNotes = sources.some((s) => s.type === "note")
-  if (hasNotes) {
+  const targets = distributeByWeight(
+    totalCount,
+    sources.map((s) => s.weight ?? 0),
+  )
+
+  for (let i = 0; i < sources.length; i++) {
+    const source = sources[i]
+    const count = targets[i]
+    if (count <= 0) continue
     try {
-      const res = await fetch(`${API_BASE}/notes/flashcards/generate`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          collection_id: collectionId,
-          count,
-          difficulty,
-        }),
-      })
-      if (res.ok) {
-        const data = (await res.json()) as {
-          created?: number
-          skipped?: number
-        }
-        result.noteCreated = data.created ?? 0
-        result.noteSkipped = data.skipped ?? 0
-        result.totalCreated += result.noteCreated
+      if (source.type === "document") {
+        const created = await generateDocumentFlashcards(source.id, count, difficulty)
+        result.totalCreated += created
+        result.documentsProcessed += 1
       } else {
-        result.errors.push(`Notes generation failed (HTTP ${res.status})`)
+        // Per-note call (note_ids path) so each note gets its own share.
+        const res = await fetch(`${API_BASE}/notes/flashcards/generate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ note_ids: [source.id], count, difficulty }),
+        })
+        if (!res.ok) {
+          result.errors.push(`Note generation failed (HTTP ${res.status})`)
+        } else {
+          const data = (await res.json()) as unknown
+          const created = Array.isArray(data)
+            ? data.length
+            : ((data as { created?: number })?.created ?? 0)
+          result.noteCreated += created
+          result.totalCreated += created
+        }
       }
     } catch (e) {
-      result.errors.push(`Notes: ${e instanceof Error ? e.message : String(e)}`)
-    }
-  }
-
-  const docIds = sources.filter((s) => s.type === "document").map((s) => s.id)
-  for (const docId of docIds) {
-    try {
-      const created = await generateDocumentFlashcards(docId, count, difficulty)
-      result.totalCreated += created
-      result.documentsProcessed += 1
-    } catch (e) {
       result.errors.push(
-        `Document ${docId}: ${e instanceof Error ? e.message : String(e)}`,
+        `${source.type} ${source.id}: ${e instanceof Error ? e.message : String(e)}`,
       )
     }
   }

--- a/frontend/src/lib/studyDistribute.test.ts
+++ b/frontend/src/lib/studyDistribute.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+
+import { distributeByWeight, distributeCount } from "./studyDistribute"
+
+describe("distributeCount", () => {
+  it("splits evenly and always sums to total", () => {
+    expect(distributeCount(20, 10)).toEqual(new Array(10).fill(2))
+    const r = distributeCount(20, 3)
+    expect(r.reduce((a, b) => a + b, 0)).toBe(20)
+    expect(r).toEqual([7, 7, 6])
+  })
+
+  it("handles edge cases", () => {
+    expect(distributeCount(0, 4)).toEqual([0, 0, 0, 0])
+    expect(distributeCount(20, 0)).toEqual([])
+  })
+})
+
+describe("distributeByWeight", () => {
+  const sum = (a: number[]) => a.reduce((x, y) => x + y, 0)
+
+  it("always sums to the requested total", () => {
+    expect(sum(distributeByWeight(20, [11424, 44, 149, 2, 1]))).toBe(20)
+    expect(sum(distributeByWeight(30, [60000, 1000, 500]))).toBe(30)
+    expect(sum(distributeByWeight(7, [100, 100, 100]))).toBe(7)
+  })
+
+  it("gives a large source the majority but never starves small ones", () => {
+    // a book (many chunks) beside small notes: book dominates, notes keep >=1
+    const r = distributeByWeight(20, [11424, 44, 149, 2, 1])
+    expect(r[0]).toBeGreaterThan(sum(r.slice(1))) // book gets the majority
+    expect(Math.min(...r)).toBeGreaterThanOrEqual(1) // no content source starved
+  })
+
+  it("never gives a source with zero weight any cards", () => {
+    // DDIA-with-word_count-0 regression: a 0-weight source must not consume slots
+    const r = distributeByWeight(10, [0, 100, 100])
+    expect(r[0]).toBe(0)
+    expect(sum(r)).toBe(10)
+  })
+
+  it("when there are more sources than the total, the largest win", () => {
+    const r = distributeByWeight(5, [9000, 8000, 100, 100, 100, 100])
+    expect(sum(r)).toBe(5)
+    // the two big sources get the most; the tail tiny sources get nothing
+    expect(r[0]).toBeGreaterThanOrEqual(r[2])
+    expect(r[1]).toBeGreaterThanOrEqual(r[2])
+    expect(r[r.length - 1]).toBe(0)
+  })
+
+  it("falls back to an even split when no weights are known", () => {
+    expect(distributeByWeight(20, [0, 0, 0, 0])).toEqual([5, 5, 5, 5])
+  })
+})

--- a/frontend/src/lib/studyDistribute.ts
+++ b/frontend/src/lib/studyDistribute.ts
@@ -1,0 +1,61 @@
+// Pure helpers for splitting a collection-wide generation total across its
+// sources. No imports, no side effects -- unit-tested in studyDistribute.test.ts.
+
+// Split a target TOTAL across N sources as evenly as possible (remainder spread
+// one-per-source from the front). Sum of the result always equals `total`.
+export function distributeCount(total: number, buckets: number): number[] {
+  if (buckets <= 0) return []
+  const base = Math.floor(Math.max(0, total) / buckets)
+  let remainder = Math.max(0, total) - base * buckets
+  return Array.from({ length: buckets }, () => {
+    if (remainder > 0) {
+      remainder -= 1
+      return base + 1
+    }
+    return base
+  })
+}
+
+// Distribute a proportional remainder by the largest-remainder method.
+function largestRemainder(total: number, weights: number[]): number[] {
+  const n = weights.length
+  const sum = weights.reduce((a, b) => a + b, 0)
+  if (n === 0 || total <= 0 || sum <= 0) return new Array(n).fill(0)
+  const ideal = weights.map((w) => (w / sum) * total)
+  const result = ideal.map((x) => Math.floor(x))
+  let remaining = total - result.reduce((a, b) => a + b, 0)
+  const byFrac = ideal
+    .map((x, i) => ({ i, frac: x - Math.floor(x) }))
+    .sort((a, b) => b.frac - a.frac)
+  for (let k = 0; k < byFrac.length && remaining > 0; k++) {
+    result[byFrac[k].i] += 1
+    remaining -= 1
+  }
+  return result
+}
+
+// Split a target TOTAL across sources by content size, but fairly: a big book
+// gets most of the questions while a small note still keeps a real share. We
+// dampen the raw sizes with a square root (so a 200x-larger book isn't 200x the
+// questions) and guarantee every source with content at least one card when the
+// total allows. Sum always equals `total`.
+export function distributeByWeight(total: number, weights: number[]): number[] {
+  const n = weights.length
+  if (n === 0 || total <= 0) return new Array(n).fill(0)
+  const eff = weights.map((w) => Math.sqrt(Math.max(0, w)))
+  const contentIdx = eff.flatMap((e, i) => (e > 0 ? [i] : []))
+  if (contentIdx.length === 0) return distributeCount(total, n)
+
+  const result = new Array<number>(n).fill(0)
+  let remaining = total
+  // Floor of 1 per content source when affordable; below that, pure proportional.
+  if (total >= contentIdx.length) {
+    for (const i of contentIdx) {
+      result[i] = 1
+      remaining -= 1
+    }
+  }
+  const extra = largestRemainder(remaining, eff)
+  for (let i = 0; i < n; i++) result[i] += extra[i]
+  return result
+}

--- a/frontend/src/lib/studySessionService.test.ts
+++ b/frontend/src/lib/studySessionService.test.ts
@@ -145,6 +145,29 @@ describe("prepareStudySession -- invariant: one user action = one session", () =
     expect(outcome.session.answeredCount).toBe(5)
   })
 
+  it("closes a STALE session (planned cards deleted, unreviewed) and starts fresh", async () => {
+    // The reported bug: a session planned 22 cards, 12 answered, but the
+    // remaining planned cards were deleted/regenerated -> 0 live remaining. It
+    // must not resurface as a stuck "complete" screen; close it, start fresh.
+    mocks.fetchOpenSession.mockResolvedValue({ id: "stale-sid" })
+    mocks.fetchSessionTeachbackResults.mockResolvedValue([])
+    mocks.fetchSessionRemainingCards.mockResolvedValue({
+      answered_count: 12,
+      planned_count: 22,
+      cards: [],
+    })
+    mocks.fetchDueCards.mockResolvedValue([{ id: "fresh-card" }])
+    mocks.startSession.mockResolvedValue("fresh-sid")
+
+    const outcome = await prepareStudySession(scope)
+
+    expect(mocks.endSession).toHaveBeenCalledWith("stale-sid")
+    expect(mocks.startSession).toHaveBeenCalledTimes(1)
+    expect(outcome.kind).toBe("studying")
+    if (outcome.kind !== "studying") throw new Error("unreachable")
+    expect(outcome.session.id).toBe("fresh-sid")
+  })
+
   it("explicit resumeSessionId reattaches even when no work remains", async () => {
     mocks.fetchSessionTeachbackResults.mockResolvedValue([])
     mocks.fetchSessionRemainingCards.mockResolvedValue({

--- a/frontend/src/lib/studySessionService.ts
+++ b/frontend/src/lib/studySessionService.ts
@@ -176,6 +176,22 @@ export async function prepareSectionStudyFromCards(
   }
 }
 
+// Close any open flashcard/teach-back session for a scope. Call after deleting
+// or regenerating a scope's cards so the next study run starts fresh instead of
+// resuming a session whose planned cards no longer exist.
+export async function endOpenSessionsForScope(
+  documentId: string | null,
+  collectionId: string | null,
+): Promise<void> {
+  const modes: StudyMode[] = ["flashcard", "teachback"]
+  await Promise.all(
+    modes.map(async (mode) => {
+      const open = await fetchOpenSession({ mode, documentId, collectionId }).catch(() => null)
+      if (open) await endSession(open.id).catch(() => {})
+    }),
+  )
+}
+
 async function reattach(
   sid: string,
   ctx: {
@@ -192,15 +208,28 @@ async function reattach(
 
   const hasPrior = prevResults.length > 0 || remaining.answered_count > 0
   const hasRemaining = remaining.cards.length > 0
-  if (!hasPrior && !hasRemaining && !ctx.allowEmpty) {
+  const answeredCount = Math.max(prevResults.length, remaining.answered_count)
+  // A session is STALE when its planned cards were deleted/regenerated: there's
+  // no live remaining work, yet it never reviewed its whole plan (planned_count
+  // still exceeds what was answered). Such a session must NOT resurface as a
+  // stuck "complete" screen whose "Start Next Set" just re-resumes the same dead
+  // session -- return null so the caller closes it and starts fresh. A genuinely
+  // finished session (everything reviewed) is still adopted so re-entry shows its
+  // results, and the explicit-resume path (allowEmpty) always reattaches.
+  const isStale = !hasRemaining && remaining.planned_count > answeredCount
+  if (!ctx.allowEmpty && ((!hasPrior && !hasRemaining) || isStale)) {
     return null
   }
 
+  // Reconcile the planned total against what's actually live: if cards from the
+  // original plan were later deleted/regenerated, planned_count is stale and
+  // would make the progress bar read e.g. "12 of 22" while only 2 cards remain.
+  // Never exceed answered + live-remaining.
+  const liveTotal = answeredCount + remaining.cards.length
   const plannedTotal =
     remaining.planned_count > 0
-      ? remaining.planned_count
-      : prevResults.length + remaining.cards.length
-  const answeredCount = Math.max(prevResults.length, remaining.answered_count)
+      ? Math.min(remaining.planned_count, liveTotal)
+      : liveTotal
 
   if (hasRemaining) {
     await reopenSession(sid).catch(() => {})

--- a/frontend/src/pages/Hub.tsx
+++ b/frontend/src/pages/Hub.tsx
@@ -1,16 +1,19 @@
-// Luminary home hub -- coach shape (post-2E.7 redesign, polished pass).
+// Luminary home hub -- dashboard shape.
 //
-// One fetch against /home/overview drives everything. Visual language:
-// soft gradient page surface, a single filled hero, two lanes with
-// distinct personalities (Continue = warm, Fading = muted), a backdropped
-// tag cloud, color-anchored project cards, and a slim weekly-stats strip
-// at the foot.
+// One fetch against /home/overview drives everything. A full-width hero anchors
+// the page; below it a two-column magazine layout splits "act now" (primary
+// column: recommendations, continue reading, decay debt) from ambient context
+// (rail: this-week stats, active projects, fading items, tags).
 
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import {
+  AlertTriangle,
   ArrowRight,
   BookOpen,
   Clock,
+  Compass,
+  Crosshair,
+  Dumbbell,
   FileText,
   FolderPlus,
   Hourglass,
@@ -19,14 +22,16 @@ import {
   Sparkles,
   StickyNote,
   Tag,
+  X,
   Zap,
 } from "lucide-react"
+import { useState } from "react"
 import { Link, useNavigate } from "react-router-dom"
 
 import { LuminaryGlyph } from "@/components/icons/LuminaryGlyph"
 import { FirstRunGuide } from "@/components/FirstRunGuide"
 import { Skeleton } from "@/components/ui/skeleton"
-import { apiGet } from "@/lib/apiClient"
+import { apiGet, apiPost } from "@/lib/apiClient"
 import { launchStudy } from "@/lib/studyLauncher"
 import { useAppStore } from "@/store"
 import { cn } from "@/lib/utils"
@@ -46,9 +51,15 @@ type TodayAction = components["schemas"]["TodayAction"] & {
   scoped_count?: number | null
 }
 type WeeklyStats = components["schemas"]["WeeklyStats"]
+type Recommendation = components["schemas"]["Recommendation"]
 
 const fetchHomeOverview = (): Promise<HomeOverview> =>
   apiGet<HomeOverview>("/home/overview")
+
+const markRecommendationActed = (id: string | null | undefined) => {
+  if (!id) return
+  void apiPost<void>(`/home/recommendations/${id}/acted`).catch(() => {})
+}
 
 export default function Hub() {
   const { data, isLoading, isError, refetch } = useQuery({
@@ -70,55 +81,49 @@ export default function Hub() {
 
   if (isEmpty) return <HubEmpty />
 
+  const hasRecommendations = (data.recommendations?.length ?? 0) > 0
+  const hasContinue = (data.continue_reading?.length ?? 0) > 0
+  const hasFading = (data.fading_items?.length ?? 0) > 0
+
   return (
     <PageSurface>
       <HubHeader />
 
       {data.today_action && <TodayHero action={data.today_action} />}
 
-      {((data.continue_reading?.length ?? 0) > 0 || (data.fading_items?.length ?? 0) > 0) && (
-        <div
-          className={cn(
-            "grid grid-cols-1 gap-4",
-            (data.fading_items?.length ?? 0) > 0 && "md:grid-cols-2",
-          )}
-        >
-          <ContinueReadingCard items={data.continue_reading ?? []} />
-          {(data.fading_items?.length ?? 0) > 0 && (
-            <FadingCard items={data.fading_items ?? []} />
-          )}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        {/* Primary column: things to act on now */}
+        <div className="flex flex-col gap-6 lg:col-span-2">
+          {hasRecommendations && <RecommendedNext items={data.recommendations ?? []} />}
+          {hasContinue && <ContinueReadingCard items={data.continue_reading ?? []} />}
+          <DecayDebtWidget />
         </div>
-      )}
 
-      <DecayDebtWidget />
+        {/* Rail: ambient context */}
+        <aside className="flex flex-col gap-6">
+          {data.weekly_stats && <WeekStatsCard stats={data.weekly_stats} />}
 
-      {data.recent_tags.length > 0 && (
-        <Section
-          icon={Tag}
-          title="What you've been into"
-          subtitle="Threaded through your recent activity"
-        >
-          <TagCloud tags={data.recent_tags} />
-        </Section>
-      )}
+          <Section icon={Sparkles} title="Active projects">
+            {data.active_collections.length === 0 ? (
+              <OrganizeCallout />
+            ) : (
+              <div className="flex flex-col gap-3">
+                {data.active_collections.slice(0, 5).map((c) => (
+                  <ActiveCollectionCard key={c.id} collection={c} />
+                ))}
+              </div>
+            )}
+          </Section>
 
-      <Section
-        icon={Sparkles}
-        title="Your active projects"
-        subtitle="Collections you've touched lately"
-      >
-        {data.active_collections.length === 0 ? (
-          <OrganizeCallout />
-        ) : (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            {data.active_collections.slice(0, 4).map((c) => (
-              <ActiveCollectionCard key={c.id} collection={c} />
-            ))}
-          </div>
-        )}
-      </Section>
+          {hasFading && <FadingCard items={data.fading_items ?? []} />}
 
-      {data.weekly_stats && <WeeklyStatsStrip stats={data.weekly_stats} />}
+          {data.recent_tags.length > 0 && (
+            <Section icon={Tag} title="What you've been into">
+              <TagCloud tags={data.recent_tags} />
+            </Section>
+          )}
+        </aside>
+      </div>
     </PageSurface>
   )
 }
@@ -126,12 +131,15 @@ export default function Hub() {
 // -- Layout primitives -------------------------------------------------------
 
 function PageSurface({ children }: { children: React.ReactNode }) {
-  // A soft top-to-bottom wash gives the page a sense of depth without
-  // committing to a heavy gradient. Picked very low alphas so it reads
-  // identically in light and dark modes.
+  // A single soft glow anchored to the top gives depth without a heavy wash;
+  // low alphas read identically in light and dark.
   return (
-    <div className="min-h-full bg-gradient-to-b from-primary/[0.04] via-background to-background">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-8 md:px-6">
+    <div className="relative min-h-full overflow-hidden bg-background">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-80 bg-gradient-to-b from-primary/[0.07] via-primary/[0.02] to-transparent"
+      />
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8 md:px-6 lg:py-10">
         {children}
       </div>
     </div>
@@ -139,28 +147,22 @@ function PageSurface({ children }: { children: React.ReactNode }) {
 }
 
 function HubHeader() {
-  const today = new Date()
-  const dateLabel = today.toLocaleDateString(undefined, {
+  const dateLabel = new Date().toLocaleDateString(undefined, {
     weekday: "long",
     month: "long",
     day: "numeric",
   })
   return (
-    <header className="flex items-end justify-between gap-4">
-      <div className="flex items-center gap-3">
-        <span className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 ring-1 ring-primary/15">
-          <LuminaryGlyph size={48} className="text-primary" />
-        </span>
-        <div className="flex flex-col">
-          <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-            {greeting()}
-          </span>
-          <h1 className="text-2xl font-semibold leading-tight text-foreground">
-            Luminary
-          </h1>
-        </div>
+    <header className="flex items-center gap-4">
+      <span className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-primary/10 ring-1 ring-primary/15">
+        <LuminaryGlyph size={40} className="text-primary" />
+      </span>
+      <div className="flex flex-col">
+        <h1 className="text-2xl font-semibold leading-tight text-foreground sm:text-3xl">
+          {greetingHeadline()}
+        </h1>
+        <span className="text-sm text-muted-foreground">{dateLabel}</span>
       </div>
-      <span className="hidden text-xs text-muted-foreground sm:inline">{dateLabel}</span>
     </header>
   )
 }
@@ -192,15 +194,31 @@ function Section({
   )
 }
 
-function greeting() {
+function greetingHeadline() {
   const h = new Date().getHours()
-  if (h < 5) return "still up — be kind to yourself"
-  if (h < 12) return "good morning"
-  if (h < 17) return "afternoon"
-  return "evening"
+  if (h < 5) return "Still up?"
+  if (h < 12) return "Good morning"
+  if (h < 17) return "Good afternoon"
+  return "Good evening"
 }
 
 // -- Today hero --------------------------------------------------------------
+
+const _HERO_FALLBACK_REASON: Record<string, string> = {
+  continue_reading: "Pick up while the context is still warm — cold restarts cost more.",
+  resume_note: "A quick note while it's fresh tends to stick.",
+  drill_concept: "A focused drill now beats relearning it later.",
+  fix_misconception: "Correcting a wrong model pays more than new material.",
+  confidence_check: "You felt sure and missed — worth a recalibration pass.",
+}
+
+const _HERO_ICON: Record<string, typeof BookOpen> = {
+  continue_reading: BookOpen,
+  resume_note: Pencil,
+  drill_concept: Dumbbell,
+  fix_misconception: AlertTriangle,
+  confidence_check: Crosshair,
+}
 
 function TodayHero({ action }: { action: TodayAction }) {
   const navigate = useNavigate()
@@ -209,25 +227,46 @@ function TodayHero({ action }: { action: TodayAction }) {
     return <ReviewFocusHero action={action} />
   }
 
+  // the recommender's evidence line wins over generic copy (docs/recommender-spec.md)
   const reason =
-    action.kind === "continue_reading"
-      ? "Pick up while the context is still warm — cold restarts cost more."
-      : "A quick note while it's fresh tends to stick."
-  const Icon = action.kind === "continue_reading" ? BookOpen : Pencil
+    action.reasons?.[0]?.detail ?? _HERO_FALLBACK_REASON[action.kind] ?? ""
+  const Icon = _HERO_ICON[action.kind] ?? BookOpen
   const onClick = () => {
-    if (action.kind === "continue_reading" && action.target_id) {
-      navigate(`/library?doc=${encodeURIComponent(action.target_id)}`, { state: { from: "/" } })
-    } else {
-      navigate("/notes", { state: { from: "/" } })
+    markRecommendationActed(action.recommendation_id)
+    switch (action.kind) {
+      case "continue_reading":
+        if (action.target_id) {
+          navigate(`/library?doc=${encodeURIComponent(action.target_id)}`, {
+            state: { from: "/" },
+          })
+        } else {
+          navigate("/library", { state: { from: "/" } })
+        }
+        break
+      case "drill_concept":
+      case "confidence_check":
+        launchStudy({ type: "concept", ref: action.target_id ?? "", label: action.label })
+        break
+      case "fix_misconception":
+        if (action.target_id) {
+          launchStudy({ type: "concept", ref: action.target_id, label: action.label })
+        } else if (action.document_id) {
+          launchStudy({ type: "doc", ref: action.document_id, label: action.label })
+        } else {
+          launchStudy({ type: "daily", label: "Today's pick" })
+        }
+        break
+      default:
+        navigate("/notes", { state: { from: "/" } })
     }
   }
   return (
     <button
       onClick={onClick}
-      className="group relative flex w-full cursor-pointer select-none flex-col gap-2 overflow-hidden rounded-2xl bg-gradient-to-br from-primary via-primary to-primary/75 px-6 py-5 text-left text-primary-foreground shadow-md shadow-primary/15 transition-all hover:shadow-lg hover:shadow-primary/20"
+      className="group relative flex w-full cursor-pointer select-none flex-col gap-2.5 overflow-hidden rounded-3xl bg-gradient-to-br from-primary via-primary to-primary/75 px-7 py-6 text-left text-primary-foreground shadow-lg shadow-primary/20 transition-all hover:shadow-xl hover:shadow-primary/25"
     >
-      <div aria-hidden className="pointer-events-none absolute -right-10 -top-12 h-40 w-40 rounded-full bg-white/15 blur-3xl" />
-      <div aria-hidden className="pointer-events-none absolute -left-8 -bottom-12 h-32 w-32 rounded-full bg-white/10 blur-3xl" />
+      <div aria-hidden className="pointer-events-none absolute -right-10 -top-12 h-44 w-44 rounded-full bg-white/15 blur-3xl" />
+      <div aria-hidden className="pointer-events-none absolute -left-8 -bottom-12 h-36 w-36 rounded-full bg-white/10 blur-3xl" />
       <div className="relative z-10 flex items-center gap-2.5">
         <span className="flex h-7 w-7 items-center justify-center rounded-full bg-white/15 ring-1 ring-white/25">
           <Icon size={14} />
@@ -237,10 +276,10 @@ function TodayHero({ action }: { action: TodayAction }) {
         </span>
       </div>
       <div className="relative z-10 flex items-center justify-between gap-3 pt-0.5">
-        <span className="truncate text-lg font-semibold sm:text-xl">{action.label}</span>
-        <ArrowRight size={20} className="shrink-0 text-primary-foreground/85 transition-transform group-hover:translate-x-0.5" />
+        <span className="truncate text-xl font-semibold sm:text-2xl">{action.label}</span>
+        <ArrowRight size={22} className="shrink-0 text-primary-foreground/85 transition-transform group-hover:translate-x-0.5" />
       </div>
-      <p className="relative z-10 max-w-xl text-xs text-primary-foreground/75">{reason}</p>
+      <p className="relative z-10 max-w-2xl text-sm text-primary-foreground/75">{reason}</p>
     </button>
   )
 }
@@ -259,9 +298,9 @@ function ReviewFocusHero({ action }: { action: TodayAction }) {
   const overflow = total - focusCount
 
   return (
-    <div className="group relative overflow-hidden rounded-2xl bg-gradient-to-br from-primary via-primary to-primary/75 px-6 py-5 shadow-md shadow-primary/15">
-      <div aria-hidden className="pointer-events-none absolute -right-10 -top-12 h-40 w-40 rounded-full bg-white/15 blur-3xl" />
-      <div aria-hidden className="pointer-events-none absolute -left-8 -bottom-12 h-32 w-32 rounded-full bg-white/10 blur-3xl" />
+    <div className="group relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary via-primary to-primary/75 px-7 py-6 shadow-lg shadow-primary/20">
+      <div aria-hidden className="pointer-events-none absolute -right-10 -top-12 h-44 w-44 rounded-full bg-white/15 blur-3xl" />
+      <div aria-hidden className="pointer-events-none absolute -left-8 -bottom-12 h-36 w-36 rounded-full bg-white/10 blur-3xl" />
 
       <div className="relative z-10 flex flex-col gap-3">
         {/* label row */}
@@ -311,6 +350,7 @@ function ReviewFocusHero({ action }: { action: TodayAction }) {
         <div className="flex flex-wrap items-center gap-3 pt-1">
           <button
             onClick={() => {
+              markRecommendationActed(action.recommendation_id)
               setActiveDocument(null)
               setActiveCollectionId(action.collection_id ?? null)
               // route the daily call through the Study Launcher (docs/study-launcher.md)
@@ -334,6 +374,10 @@ function ReviewFocusHero({ action }: { action: TodayAction }) {
           </span>
         </div>
 
+        {action.reasons?.[0]?.detail && (
+          <p className="text-xs text-primary-foreground/60">{action.reasons[0].detail}</p>
+        )}
+
         {/* overflow footnote */}
         {overflow > 0 && (
           <button
@@ -349,6 +393,117 @@ function ReviewFocusHero({ action }: { action: TodayAction }) {
         )}
       </div>
     </div>
+  )
+}
+
+// -- Recommended next stack ---------------------------------------------------
+
+const _REC_ICON: Record<Recommendation["kind"], typeof Zap> = {
+  overdue_reviews: Zap,
+  weak_concept: Dumbbell,
+  open_misconception: AlertTriangle,
+  calibration_blind_spot: Crosshair,
+  stalled_reading: BookOpen,
+}
+
+function RecommendedNext({ items }: { items: Recommendation[] }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [hidden, setHidden] = useState<ReadonlySet<string>>(new Set())
+
+  const dismiss = (rec: Recommendation) => {
+    // optimistic hide; restore on failure
+    setHidden((prev) => new Set(prev).add(rec.id))
+    void apiPost<void>(`/home/recommendations/${rec.id}/dismiss`)
+      .then(() => queryClient.invalidateQueries({ queryKey: ["home-overview"] }))
+      .catch(() => {
+        setHidden((prev) => {
+          const next = new Set(prev)
+          next.delete(rec.id)
+          return next
+        })
+      })
+  }
+
+  const open = (rec: Recommendation) => {
+    markRecommendationActed(rec.id)
+    switch (rec.kind) {
+      case "overdue_reviews":
+        launchStudy({ type: "daily", label: "Today's pick" })
+        break
+      case "weak_concept":
+      case "calibration_blind_spot":
+        launchStudy({ type: "concept", ref: rec.concept_slug ?? rec.target_ref, label: rec.label })
+        break
+      case "open_misconception":
+        if (rec.concept_slug) {
+          launchStudy({ type: "concept", ref: rec.concept_slug, label: rec.label })
+        } else if (rec.document_id) {
+          launchStudy({ type: "doc", ref: rec.document_id, label: rec.label })
+        } else {
+          launchStudy({ type: "daily", label: "Today's pick" })
+        }
+        break
+      case "stalled_reading":
+        navigate(`/library?doc=${encodeURIComponent(rec.document_id ?? rec.target_ref)}`, {
+          state: { from: "/" },
+        })
+        break
+    }
+  }
+
+  const visible = items.filter((r) => !hidden.has(r.id)).slice(0, 3)
+  if (visible.length === 0) return null
+
+  return (
+    <Section
+      icon={Compass}
+      title="Recommended next"
+      subtitle="Backed by your own review record"
+    >
+      <div className="flex flex-col gap-2.5">
+        {visible.map((rec) => {
+          const Icon = _REC_ICON[rec.kind]
+          return (
+            <div
+              key={rec.id}
+              className="group relative flex items-center gap-3.5 overflow-hidden rounded-2xl border border-border/60 bg-card px-4 py-3.5 transition-all hover:border-primary/30 hover:shadow-sm"
+            >
+              <span
+                aria-hidden
+                className="absolute inset-y-0 left-0 w-1 bg-primary/40 opacity-0 transition-opacity group-hover:opacity-100"
+              />
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary ring-1 ring-primary/15">
+                <Icon size={15} />
+              </span>
+              <button
+                onClick={() => open(rec)}
+                className="flex min-w-0 flex-1 cursor-pointer flex-col text-left"
+              >
+                <span className="truncate text-sm font-medium text-foreground">{rec.label}</span>
+                {rec.reasons[0]?.detail && (
+                  <span className="truncate text-xs text-muted-foreground">
+                    {rec.reasons[0].detail}
+                  </span>
+                )}
+              </button>
+              <ArrowRight
+                size={14}
+                className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-60"
+              />
+              <button
+                onClick={() => dismiss(rec)}
+                aria-label="Dismiss recommendation"
+                title="Dismiss"
+                className="shrink-0 rounded-full p-1.5 text-muted-foreground/50 opacity-0 transition-all hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </Section>
   )
 }
 
@@ -508,7 +663,7 @@ function TagCloud({ tags }: { tags: RecentTag[] }) {
   )
   const setActiveTag = useAppStore((s) => s.setActiveTag)
   return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-2xl border border-border/60 bg-card/40 px-5 py-4 backdrop-blur-sm">
+    <div className="flex flex-wrap items-center gap-x-2.5 gap-y-2 rounded-2xl border border-border/60 bg-card/40 px-4 py-4 backdrop-blur-sm">
       {tags.map((t) => {
         const total = t.document_count + t.note_count
         const weight = total / maxTotal
@@ -544,15 +699,13 @@ function TagCloud({ tags }: { tags: RecentTag[] }) {
 // -- Active collection card --------------------------------------------------
 
 function ActiveCollectionCard({ collection }: { collection: ActiveCollection }) {
-  // Use the collection's own color as the visual anchor so the click
-  // through to /collections/:id feels like a thematic continuation, not a
-  // surface break. A vertical color stripe + a faint tinted backdrop using
-  // the same color keeps it consistent across both surfaces.
+  // The collection's own color anchors the card so the click through to
+  // /collections/:id feels like a thematic continuation, not a surface break.
   return (
     <Link
       to={`/collections/${collection.id}`}
       state={{ from: "/" }}
-      className="group relative flex flex-col gap-3 overflow-hidden rounded-2xl border border-border bg-card p-4 transition-all hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-md"
+      className="group relative flex items-center gap-3 overflow-hidden rounded-2xl border border-border bg-card p-4 transition-all hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-md"
     >
       <span
         aria-hidden
@@ -564,16 +717,14 @@ function ActiveCollectionCard({ collection }: { collection: ActiveCollection }) 
         className="pointer-events-none absolute -right-12 -top-12 h-32 w-32 rounded-full opacity-[0.07] blur-2xl transition-opacity group-hover:opacity-15"
         style={{ backgroundColor: collection.color }}
       />
-      <div className="relative z-10 flex items-start gap-2">
-        <span
-          className="mt-1 h-2 w-2 shrink-0 rounded-full"
-          style={{ backgroundColor: collection.color }}
-        />
-        <h3 className="line-clamp-2 text-sm font-semibold text-foreground">
-          {collection.name}
-        </h3>
-      </div>
-      <div className="relative z-10 mt-auto flex items-center gap-1.5 text-[11px] text-muted-foreground">
+      <span
+        className="relative z-10 mt-0.5 h-2.5 w-2.5 shrink-0 rounded-full"
+        style={{ backgroundColor: collection.color }}
+      />
+      <h3 className="relative z-10 line-clamp-1 flex-1 text-sm font-semibold text-foreground">
+        {collection.name}
+      </h3>
+      <div className="relative z-10 flex items-center gap-1.5 text-[11px] text-muted-foreground">
         <StatPill label="d" value={collection.document_count} />
         <StatPill label="n" value={collection.note_count} />
         <StatPill label="c" value={collection.flashcard_count} />
@@ -593,28 +744,32 @@ function StatPill({ label, value }: { label: string; value: number }) {
 
 // -- Weekly stats ------------------------------------------------------------
 
-function WeeklyStatsStrip({ stats }: { stats: WeeklyStats }) {
+function WeekStatsCard({ stats }: { stats: WeeklyStats }) {
   return (
-    <div className="flex flex-wrap items-center gap-x-6 gap-y-2 rounded-2xl border border-border/60 bg-card/40 px-5 py-3 text-sm backdrop-blur-sm">
-      <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-        <Clock size={11} />
-        This week
-      </span>
-      <Stat label="studied" value={`${stats.minutes_studied}m`} accent="primary" />
-      <Stat label="cards" value={stats.cards_reviewed} accent="amber" />
-      <Stat label="notes" value={stats.notes_written} accent="emerald" />
-      <Stat label="docs" value={stats.docs_touched} accent="blue" />
+    <div className="flex flex-col gap-3 rounded-2xl border border-border/60 bg-card/50 p-5 backdrop-blur-sm">
+      <div className="flex items-center gap-2">
+        <Clock size={13} className="text-muted-foreground" />
+        <h2 className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+          This week
+        </h2>
+      </div>
+      <div className="grid grid-cols-2 gap-2.5">
+        <BigStat value={`${stats.minutes_studied}m`} label="studied" accent="primary" />
+        <BigStat value={stats.cards_reviewed} label="cards" accent="amber" />
+        <BigStat value={stats.notes_written} label="notes" accent="emerald" />
+        <BigStat value={stats.docs_touched} label="docs" accent="blue" />
+      </div>
     </div>
   )
 }
 
-function Stat({
-  label,
+function BigStat({
   value,
+  label,
   accent,
 }: {
-  label: string
   value: number | string
+  label: string
   accent: "primary" | "amber" | "emerald" | "blue"
 }) {
   const dot = {
@@ -624,11 +779,13 @@ function Stat({
     blue: "bg-blue-500",
   }[accent]
   return (
-    <span className="flex items-baseline gap-1.5">
-      <span className={cn("h-1.5 w-1.5 rounded-full", dot)} />
-      <span className="text-base font-semibold text-foreground">{value}</span>
+    <div className="flex flex-col gap-0.5 rounded-xl bg-muted/40 px-3 py-2.5">
+      <div className="flex items-center gap-1.5">
+        <span className={cn("h-1.5 w-1.5 rounded-full", dot)} />
+        <span className="text-xl font-semibold text-foreground">{value}</span>
+      </div>
       <span className="text-xs text-muted-foreground">{label}</span>
-    </span>
+    </div>
   )
 }
 
@@ -684,7 +841,7 @@ function OrganizeCallout() {
       <FolderPlus size={16} className="shrink-0 text-primary" />
       <span className="flex-1">No active projects yet.</span>
       <span className="flex items-center gap-1 text-primary">
-        Organize your library
+        Organize
         <ArrowRight size={12} />
       </span>
     </Link>
@@ -694,20 +851,23 @@ function OrganizeCallout() {
 function HubLoading() {
   return (
     <PageSurface>
-      <div className="flex items-center gap-3">
-        <Skeleton className="h-10 w-10 rounded-xl" />
-        <Skeleton className="h-7 w-40" />
+      <div className="flex items-center gap-4">
+        <Skeleton className="h-14 w-14 rounded-2xl" />
+        <div className="flex flex-col gap-1.5">
+          <Skeleton className="h-7 w-44" />
+          <Skeleton className="h-4 w-32" />
+        </div>
       </div>
-      <Skeleton className="h-28 w-full rounded-2xl" />
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <Skeleton className="h-44 rounded-2xl" />
-        <Skeleton className="h-44 rounded-2xl" />
-      </div>
-      <Skeleton className="h-20 w-full rounded-2xl" />
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <Skeleton key={i} className="h-28 rounded-2xl" />
-        ))}
+      <Skeleton className="h-32 w-full rounded-3xl" />
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="flex flex-col gap-6 lg:col-span-2">
+          <Skeleton className="h-40 rounded-2xl" />
+          <Skeleton className="h-40 rounded-2xl" />
+        </div>
+        <div className="flex flex-col gap-6">
+          <Skeleton className="h-44 rounded-2xl" />
+          <Skeleton className="h-32 rounded-2xl" />
+        </div>
       </div>
     </PageSurface>
   )

--- a/frontend/src/pages/Progress.tsx
+++ b/frontend/src/pages/Progress.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useEffect, useState } from "react"
-import { AlertCircle, ArrowLeft, BookOpen, StickyNote, Target, TrendingUp, Sparkles, Loader2, Brain } from "lucide-react"
+import { AlertCircle, ArrowLeft, BookOpen, CheckCircle2, StickyNote, Target, TrendingUp, Sparkles, Loader2, Brain } from "lucide-react"
 import { useBackNavigation } from "@/hooks/useBackNavigation"
 import {
   Bar,
@@ -36,6 +36,7 @@ import type { components } from "@/types/api"
 type DailyHistoryItem = components["schemas"]["DailyHistoryItem"]
 type DueCountResponse = components["schemas"]["DueCountResponse"]
 type SessionListResponse = components["schemas"]["SessionListResponse"]
+type MisconceptionStats = components["schemas"]["MisconceptionStatsResponse"]
 
 // Local-only: minimal subset of /monitoring/overview consumed by the
 // summary stats bar; the full MonitoringOverview has many more fields.
@@ -54,6 +55,9 @@ const fetchStudyHistory = (days: number): Promise<DailyHistoryItem[]> =>
 
 const fetchDueCount = (): Promise<DueCountResponse> =>
   apiGet<DueCountResponse>("/study/due-count")
+
+const fetchMisconceptionStats = (): Promise<MisconceptionStats> =>
+  apiGet<MisconceptionStats>("/study/misconception-stats")
 
 const fetchOverview = (): Promise<MonitoringOverview> =>
   apiGet<MonitoringOverview>("/monitoring/overview")
@@ -388,6 +392,9 @@ export default function Progress() {
   const [dueLoading, setDueLoading] = useState(true)
   const [dueCount, setDueCount] = useState<number>(0)
 
+  const [gapsLoading, setGapsLoading] = useState(true)
+  const [gapsClosed, setGapsClosed] = useState<number>(0)
+
   const [overviewLoading, setOverviewLoading] = useState(true)
   const [overviewError, setOverviewError] = useState(false)
   const [overview, setOverview] = useState<MonitoringOverview | null>(null)
@@ -432,6 +439,18 @@ export default function Progress() {
       .catch((e: unknown) => {
         logger.warn("[Progress] study/due-count failed", e)
         if (!cancelled) setDueLoading(false)
+      })
+
+    fetchMisconceptionStats()
+      .then((d) => {
+        if (!cancelled) {
+          setGapsClosed(d.resolved_count)
+          setGapsLoading(false)
+        }
+      })
+      .catch((e: unknown) => {
+        logger.warn("[Progress] study/misconception-stats failed", e)
+        if (!cancelled) setGapsLoading(false)
       })
 
     fetchOverview()
@@ -583,13 +602,20 @@ export default function Progress() {
             accent="amber"
           />
         </div>
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           <StatCard
             label="Reviews (30d)"
             value={totalReviewed}
             icon={BookOpen}
             loading={historyLoading}
             accent="primary"
+          />
+          <StatCard
+            label="Gaps Closed"
+            value={gapsClosed}
+            icon={CheckCircle2}
+            loading={gapsLoading}
+            accent="emerald"
           />
           <StatCard
             label="Documents"

--- a/frontend/src/pages/Study.tsx
+++ b/frontend/src/pages/Study.tsx
@@ -56,7 +56,7 @@ import { apiGet, apiPost } from "@/lib/apiClient"
 
 import type { DocListItem } from "./Study/types"
 import { fetchDocList } from "./Study/api"
-import { DocPicker } from "./Study/DocPicker"
+import { StudyBrowser, type CollectionNode } from "./Study/StudyBrowser"
 import { DocumentTopics } from "@/components/DocumentTopics"
 import { FlashcardManager } from "./Study/FlashcardManager"
 
@@ -65,8 +65,6 @@ import { FlashcardManager } from "./Study/FlashcardManager"
 export type { DocListItem } from "./Study/types"  // re-exported for Progress.tsx
 
 // SessionHistoryTab replaced by SessionManager component
-
-// DocPicker now lives in pages/Study/DocPicker.tsx.
 
 const _SESSION_SIZE = 15
 
@@ -417,8 +415,10 @@ export default function Study() {
   // ---- Main study dashboard -------------------------------------------------
   return (
     <div className="flex h-full flex-col bg-background">
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-border bg-card/30 px-8 py-3 backdrop-blur-md">
+      {/* Header. relative z-30 lifts this bar (and the StudyBrowser dropdown it
+          contains) above the scrolling content below, so the popover isn't
+          composited under the hero card. */}
+      <div className="relative z-30 flex items-center justify-between border-b border-border bg-card/30 px-8 py-3 backdrop-blur-md">
         <div className="flex items-center gap-8">
           {canGoBack && (
             <button
@@ -439,12 +439,22 @@ export default function Study() {
             Study
           </h1>
 
-          <DocPicker
+          <StudyBrowser
             docs={docList.filter(isDocumentReady)}
-            activeId={studyDocumentId}
-            onSelect={(id) => {
+            collections={collections as CollectionNode[]}
+            activeDocId={studyDocumentId}
+            activeCollectionId={activeCollectionId}
+            onSelectDoc={(id) => {
+              setActiveCollectionId(null)
               setActiveDocument(id)
-              if (id) setActiveCollectionId(null)
+            }}
+            onSelectCollection={(id) => {
+              setActiveDocument(null)
+              setActiveCollectionId(id)
+            }}
+            onClear={() => {
+              setActiveCollectionId(null)
+              setActiveDocument(null)
             }}
           />
         </div>

--- a/frontend/src/pages/Study/FlashcardManager.tsx
+++ b/frontend/src/pages/Study/FlashcardManager.tsx
@@ -21,6 +21,7 @@ import { toast } from "sonner"
 import { Card } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { SessionHistory } from "@/components/study/SessionHistory"
+import { endOpenSessionsForScope } from "@/lib/studySessionService"
 import { useAppStore } from "@/store"
 
 import {
@@ -58,7 +59,9 @@ export function FlashcardManager({
   const [page, setPage] = useState(1)
   const [selectionMode, setSelectionMode] = useState(false)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  const [confirmBulkDelete, setConfirmBulkDelete] = useState<null | "selected" | "all">(null)
+  const [confirmBulkDelete, setConfirmBulkDelete] = useState<
+    null | "selected" | "all" | "replace"
+  >(null)
   // When the user clicks "Study" on a Chapter Goal in the reader,
   // DocumentReader sets `studySectionFilter` and navigates here. We consume
   // it once on mount, copy to local state, and clear the store value so
@@ -177,7 +180,11 @@ export function FlashcardManager({
   })
 
   const deleteAllMutation = useMutation({
-    mutationFn: () => deleteAllFlashcardsForDocument(documentId),
+    mutationFn: async () => {
+      await deleteAllFlashcardsForDocument(documentId)
+      // Drop any in-progress session so it can't resume with deleted cards.
+      await endOpenSessionsForScope(documentId, null)
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["flashcards-search"] })
       qc.invalidateQueries({ queryKey: ["study-stats", documentId] })
@@ -187,6 +194,42 @@ export function FlashcardManager({
       toast.success("All flashcards deleted for this document")
     },
     onError: () => toast.error("Failed to delete flashcards"),
+  })
+
+  // Regenerate (replace): delete the current cards, then generate a fresh set of
+  // the same size. A clean slate -- the old cards and their review history go.
+  const replaceMutation = useMutation({
+    mutationFn: async () => {
+      await deleteAllFlashcardsForDocument(documentId)
+      // Fresh cards -> fresh review: drop the stale in-progress session.
+      await endOpenSessionsForScope(documentId, null)
+      const count = Math.min(Math.max(totalCards || 10, 1), 50)
+      return generateFlashcards({
+        document_id: documentId,
+        scope: "full",
+        section_heading: null,
+        count,
+        difficulty: "medium",
+      })
+    },
+    onSuccess: (created) => {
+      qc.invalidateQueries({ queryKey: ["flashcards-search"] })
+      qc.invalidateQueries({ queryKey: ["study-stats", documentId] })
+      clearSelection()
+      setSelectionMode(false)
+      setConfirmBulkDelete(null)
+      setPage(1)
+      toast.success(
+        `Replaced with ${created.length} fresh card${created.length === 1 ? "" : "s"}`,
+      )
+    },
+    onError: (err: Error) => {
+      const msg =
+        err instanceof GenerateError && err.status === 503
+          ? "Ollama is unavailable. Start it with: ollama serve"
+          : "Failed to regenerate cards"
+      toast.error(msg)
+    },
   })
 
   const generateMutation = useMutation({
@@ -439,48 +482,72 @@ export function FlashcardManager({
             </>
           )}
           <button
+            onClick={() => setConfirmBulkDelete("replace")}
+            disabled={replaceMutation.isPending}
+            className="ml-auto flex items-center gap-1 rounded border border-primary/40 bg-primary/10 px-3 py-1 text-xs font-medium text-primary hover:bg-primary/20 disabled:opacity-50"
+          >
+            {replaceMutation.isPending ? (
+              <Loader2 size={11} className="animate-spin" />
+            ) : (
+              <Zap size={11} />
+            )}
+            Regenerate (replace)
+          </button>
+          <button
             onClick={() => setConfirmBulkDelete("all")}
             disabled={deleteAllMutation.isPending}
-            className="ml-auto rounded border border-red-300 bg-red-50 px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-100 disabled:opacity-50 dark:border-red-900 dark:bg-red-950/30 dark:text-red-400"
+            className="rounded border border-red-300 bg-red-50 px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-100 disabled:opacity-50 dark:border-red-900 dark:bg-red-950/30 dark:text-red-400"
           >
             Delete all ({totalCards})
           </button>
         </div>
       )}
 
-      {/* Bulk delete confirmation */}
-      {confirmBulkDelete && (
-        <div className="flex items-center gap-3 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/30 dark:text-red-200">
-          <AlertCircle size={16} />
-          <span className="flex-1">
-            {confirmBulkDelete === "selected"
-              ? `Permanently delete ${selectedIds.size} selected flashcard${selectedIds.size === 1 ? "" : "s"}? This cannot be undone.`
-              : `Permanently delete ALL ${totalCards} flashcards for this document? This cannot be undone.`}
-          </span>
-          <button
-            onClick={() => {
-              if (confirmBulkDelete === "selected") {
-                bulkDeleteMutation.mutate(Array.from(selectedIds))
-              } else {
-                deleteAllMutation.mutate()
-              }
-            }}
-            disabled={bulkDeleteMutation.isPending || deleteAllMutation.isPending}
-            className="flex items-center gap-1 rounded bg-red-600 px-3 py-1 text-xs font-semibold text-white hover:bg-red-700 disabled:opacity-50"
-          >
-            {(bulkDeleteMutation.isPending || deleteAllMutation.isPending) && (
-              <Loader2 size={12} className="animate-spin" />
-            )}
-            Confirm delete
-          </button>
-          <button
-            onClick={() => setConfirmBulkDelete(null)}
-            className="rounded border border-red-300 px-3 py-1 text-xs font-medium hover:bg-red-100 dark:hover:bg-red-900/40"
-          >
-            Cancel
-          </button>
-        </div>
-      )}
+      {/* Bulk delete / replace confirmation */}
+      {confirmBulkDelete && (() => {
+        const isReplace = confirmBulkDelete === "replace"
+        const busy =
+          bulkDeleteMutation.isPending || deleteAllMutation.isPending || replaceMutation.isPending
+        const tone = isReplace
+          ? "border-primary/30 bg-primary/5 text-foreground"
+          : "border-red-200 bg-red-50 text-red-800 dark:border-red-900 dark:bg-red-950/30 dark:text-red-200"
+        return (
+          <div className={`flex items-center gap-3 rounded-md border px-4 py-3 text-sm ${tone}`}>
+            <AlertCircle size={16} />
+            <span className="flex-1">
+              {confirmBulkDelete === "selected"
+                ? `Permanently delete ${selectedIds.size} selected flashcard${selectedIds.size === 1 ? "" : "s"}? This cannot be undone.`
+                : isReplace
+                  ? `Replace all ${totalCards} flashcard${totalCards === 1 ? "" : "s"} with a freshly generated set? This deletes the current cards and their review history.`
+                  : `Permanently delete ALL ${totalCards} flashcards for this document? This cannot be undone.`}
+            </span>
+            <button
+              onClick={() => {
+                if (confirmBulkDelete === "selected") {
+                  bulkDeleteMutation.mutate(Array.from(selectedIds))
+                } else if (isReplace) {
+                  replaceMutation.mutate()
+                } else {
+                  deleteAllMutation.mutate()
+                }
+              }}
+              disabled={busy}
+              className={`flex items-center gap-1 rounded px-3 py-1 text-xs font-semibold text-white disabled:opacity-50 ${
+                isReplace ? "bg-primary hover:bg-primary/90" : "bg-red-600 hover:bg-red-700"
+              }`}
+            >
+              {busy && <Loader2 size={12} className="animate-spin" />}
+              {isReplace ? "Replace" : "Confirm delete"}
+            </button>
+            <button
+              onClick={() => setConfirmBulkDelete(null)}
+              className="rounded border border-border px-3 py-1 text-xs font-medium hover:bg-accent"
+            >
+              Cancel
+            </button>
+          </div>
+        )
+      })()}
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         <div className="lg:col-span-2 flex flex-col gap-4">

--- a/frontend/src/pages/Study/StudyBrowser.tsx
+++ b/frontend/src/pages/Study/StudyBrowser.tsx
@@ -1,0 +1,246 @@
+// StudyBrowser -- the header picker for the Study page. Replaces the
+// documents-only dropdown with one popover that browses BOTH collections and
+// standalone documents in two clearly separated, labelled sections, so you can
+// jump to either from any state (a doc being open no longer traps you).
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import {
+  BookOpen,
+  Check,
+  ChevronDown,
+  CornerDownRight,
+  Home,
+  Layers,
+  Search,
+  StickyNote,
+} from "lucide-react"
+
+import type { DocListItem } from "./types"
+
+export interface CollectionNode {
+  id: string
+  name: string
+  color?: string
+  document_count?: number
+  note_count?: number
+  children?: CollectionNode[]
+}
+
+interface StudyBrowserProps {
+  docs: DocListItem[]
+  collections: CollectionNode[]
+  activeDocId: string | null
+  activeCollectionId: string | null
+  onSelectDoc: (id: string) => void
+  onSelectCollection: (id: string) => void
+  onClear: () => void
+}
+
+interface FlatCollection extends CollectionNode {
+  _depth: number
+  _parentName: string | null
+}
+
+function flattenCollections(
+  items: CollectionNode[],
+  depth = 0,
+  parentName: string | null = null,
+): FlatCollection[] {
+  const out: FlatCollection[] = []
+  for (const item of items) {
+    out.push({ ...item, _depth: depth, _parentName: parentName })
+    if (item.children?.length) {
+      out.push(...flattenCollections(item.children, depth + 1, item.name))
+    }
+  }
+  return out
+}
+
+export function StudyBrowser({
+  docs,
+  collections,
+  activeDocId,
+  activeCollectionId,
+  onSelectDoc,
+  onSelectCollection,
+  onClear,
+}: StudyBrowserProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Close on outside click or Escape.
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false)
+    document.addEventListener("mousedown", onDown)
+    document.addEventListener("keydown", onKey)
+    return () => {
+      document.removeEventListener("mousedown", onDown)
+      document.removeEventListener("keydown", onKey)
+    }
+  }, [open])
+
+  const flatCollections = useMemo(() => flattenCollections(collections), [collections])
+
+  const q = query.trim().toLowerCase()
+  const filteredCollections = q
+    ? flatCollections.filter((c) => c.name.toLowerCase().includes(q))
+    : flatCollections
+  const filteredDocs = q
+    ? docs.filter((d) => d.title.toLowerCase().includes(q))
+    : docs
+
+  const activeCollection = flatCollections.find((c) => c.id === activeCollectionId)
+  const activeDoc = docs.find((d) => d.id === activeDocId)
+
+  // Trigger label + icon reflect what's currently selected.
+  const triggerIcon = activeCollection ? (
+    <Layers size={16} className="text-primary" />
+  ) : activeDoc ? (
+    <BookOpen size={16} className="text-blue-500" />
+  ) : (
+    <Search size={16} className="text-muted-foreground" />
+  )
+  const triggerLabel =
+    activeCollection?.name ?? activeDoc?.title ?? "Browse collections & documents"
+
+  const choose = (fn: () => void) => {
+    fn()
+    setOpen(false)
+    setQuery("")
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex h-9 min-w-[240px] max-w-[360px] items-center gap-2 rounded-full border border-border bg-card px-4 text-xs font-semibold text-foreground transition-all hover:border-primary/50 focus:border-primary focus:outline-none"
+      >
+        {triggerIcon}
+        <span className="truncate">{triggerLabel}</span>
+        <ChevronDown
+          size={14}
+          className={`ml-auto shrink-0 text-muted-foreground transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-11 z-50 w-[380px] overflow-hidden rounded-xl border border-border bg-popover shadow-xl">
+          {/* Search */}
+          <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+            <Search size={14} className="text-muted-foreground" />
+            <input
+              autoFocus
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search collections and documents..."
+              className="flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+            />
+          </div>
+
+          <div className="max-h-[420px] overflow-y-auto py-1">
+            {/* Home / clear */}
+            <button
+              onClick={() => choose(onClear)}
+              className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm transition-colors hover:bg-accent"
+            >
+              <Home size={15} className="text-muted-foreground" />
+              <span className="text-foreground">Study home</span>
+              {!activeCollectionId && !activeDocId && (
+                <Check size={14} className="ml-auto text-primary" />
+              )}
+            </button>
+
+            {/* Collections section */}
+            <SectionLabel icon={Layers} label="Collections" count={filteredCollections.length} />
+            {filteredCollections.length === 0 ? (
+              <EmptyRow text={q ? "No matching collections" : "No collections yet"} />
+            ) : (
+              filteredCollections.map((c) => (
+                <button
+                  key={c.id}
+                  onClick={() => choose(() => onSelectCollection(c.id))}
+                  className={`group flex w-full items-center gap-2.5 py-2 pr-3 text-left text-sm transition-colors hover:bg-accent ${
+                    c.id === activeCollectionId ? "bg-primary/5" : ""
+                  }`}
+                  style={{ paddingLeft: 12 + c._depth * 16 }}
+                >
+                  {c._depth > 0 && (
+                    <CornerDownRight size={12} className="shrink-0 text-muted-foreground/50" />
+                  )}
+                  <Layers size={15} className="shrink-0 text-primary" />
+                  <span className="truncate text-foreground">{c.name}</span>
+                  <span className="ml-auto flex shrink-0 items-center gap-2 text-[11px] text-muted-foreground">
+                    {(c.document_count ?? 0) > 0 && (
+                      <span className="flex items-center gap-0.5">
+                        <BookOpen size={11} className="text-blue-500/70" />
+                        {c.document_count}
+                      </span>
+                    )}
+                    {(c.note_count ?? 0) > 0 && (
+                      <span className="flex items-center gap-0.5">
+                        <StickyNote size={11} className="text-amber-500/70" />
+                        {c.note_count}
+                      </span>
+                    )}
+                    {c.id === activeCollectionId && <Check size={14} className="text-primary" />}
+                  </span>
+                </button>
+              ))
+            )}
+
+            {/* Documents section */}
+            <SectionLabel icon={BookOpen} label="Documents" count={filteredDocs.length} />
+            {filteredDocs.length === 0 ? (
+              <EmptyRow text={q ? "No matching documents" : "No documents yet"} />
+            ) : (
+              filteredDocs.map((d) => (
+                <button
+                  key={d.id}
+                  onClick={() => choose(() => onSelectDoc(d.id))}
+                  className={`flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm transition-colors hover:bg-accent ${
+                    d.id === activeDocId ? "bg-primary/5" : ""
+                  }`}
+                >
+                  <BookOpen size={15} className="shrink-0 text-blue-500" />
+                  <span className="truncate text-foreground">{d.title}</span>
+                  {d.id === activeDocId && (
+                    <Check size={14} className="ml-auto shrink-0 text-primary" />
+                  )}
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SectionLabel({
+  icon: Icon,
+  label,
+  count,
+}: {
+  icon: typeof Layers
+  label: string
+  count: number
+}) {
+  return (
+    <div className="mt-1 flex items-center gap-1.5 px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+      <Icon size={11} />
+      {label}
+      <span className="text-muted-foreground/60">({count})</span>
+    </div>
+  )
+}
+
+function EmptyRow({ text }: { text: string }) {
+  return <div className="px-3 py-2 text-xs italic text-muted-foreground/70">{text}</div>
+}

--- a/frontend/src/pages/Study/api.ts
+++ b/frontend/src/pages/Study/api.ts
@@ -152,6 +152,18 @@ export async function deleteAllFlashcardsForDocument(
   }
 }
 
+export async function deleteAllFlashcardsForCollection(
+  collectionId: string,
+): Promise<{ deleted: number }> {
+  try {
+    return await apiDelete<{ deleted: number }>(
+      `/flashcards/collection/${encodeURIComponent(collectionId)}`,
+    )
+  } catch {
+    throw new Error("Failed to delete collection flashcards")
+  }
+}
+
 export async function generateFlashcardsFromGraph(
   documentId: string,
   k: number,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -575,6 +575,236 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/concepts/{concept_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Concept */
+        get: operations["get_concept_concepts__concept_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/concepts/{concept_id}/rename": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Rename Concept */
+        post: operations["rename_concept_concepts__concept_id__rename_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/concepts/{concept_id}/reclassify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reclassify Concept */
+        post: operations["reclassify_concept_concepts__concept_id__reclassify_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/concepts/{concept_id}/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Confirm Concept */
+        post: operations["confirm_concept_concepts__concept_id__confirm_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/concepts/{concept_id}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reject Concept */
+        post: operations["reject_concept_concepts__concept_id__reject_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/concepts/merge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Merge Concepts */
+        post: operations["merge_concepts_concepts_merge_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/concepts/apply-overrides": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Apply Overrides
+         * @description Re-apply all stored overrides onto the current concepts (re-parse hook, I-22).
+         */
+        post: operations["apply_overrides_concepts_apply_overrides_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/concepts/purge-junk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Purge Junk Concepts
+         * @description Delete concepts whose label is format-junk (code tokens, CLI flags, unicode garbage).
+         *
+         *     Same predicate the extraction pipeline uses, applied retroactively so existing junk does
+         *     not linger in study/scope. ``dry_run=True`` (default) previews the matches without deleting;
+         *     pass ``dry_run=false`` to actually remove them from all three stores.
+         */
+        post: operations["purge_junk_concepts_concepts_purge_junk_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/concepts/regenerate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Regenerate Concepts
+         * @description Kick off a full concept-layer rebuild in the background. 409 if one is already running.
+         */
+        post: operations["regenerate_concepts_concepts_regenerate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/concepts/regenerate/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Regenerate Concepts Status
+         * @description Poll the current/last rebuild's status.
+         */
+        get: operations["regenerate_concepts_status_concepts_regenerate_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/concepts/for-note/{note_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Concepts For Note
+         * @description Concepts a note touches (docs/03-notes-generation.md).
+         *
+         *     Two signals, unioned: (1) engagement -- concepts the note's mapped cards point at;
+         *     (2) lexical recall -- concepts whose label appears in the note's title/content. This
+         *     is the always-on degraded path; the concept_linker labs feature enriches it later.
+         */
+        get: operations["concepts_for_note_concepts_for_note__note_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/concepts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Concepts
+         * @description List concepts, optionally filtered by status (e.g. ?status=proposed for review).
+         */
+        get: operations["list_concepts_concepts_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/chat/suggestions/{suggestion_id}/asked": {
         parameters: {
             query?: never;
@@ -831,6 +1061,50 @@ export interface paths {
         head?: never;
         /** Patch Document */
         patch: operations["patch_document_documents__document_id__patch"];
+        trace?: never;
+    };
+    "/documents/{document_id}/overview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Document Overview
+         * @description Read-aggregation for the Doc overview page (docs/02-ingest-and-doc-overview.md).
+         *
+         *     Header + collection memberships + tags + reading progress. Study TOPICS (chapters) and
+         *     References are separate frontend calls; the studyable list lives in the Study tab.
+         */
+        get: operations["get_document_overview_documents__document_id__overview_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{document_id}/collections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Assign Document Collections
+         * @description Add a document to one or more collections (ingest + after) and return the
+         *     document's resulting collection set. Idempotent (INSERT OR IGNORE; no duplicates).
+         */
+        post: operations["assign_document_collections_documents__document_id__collections_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/documents/{document_id}/chunks": {
@@ -1562,6 +1836,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/evals/golden/{name}/info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Golden Info
+         * @description Provenance (how the golden was generated) + deterministic quality metrics.
+         *
+         *     Quality is computed structurally (no LLM judge) so it is unbiased and
+         *     reproducible — see golden_dataset_quality.
+         */
+        get: operations["get_golden_info_evals_golden__name__info_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/evals/golden/{name}": {
         parameters: {
             query?: never;
@@ -1639,6 +1936,32 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/evals/datasets/{dataset_id}/relink": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Relink Golden Dataset
+         * @description Repoint a dataset's questions at a live document.
+         *
+         *     Generated goldens pin source_document_id per question; when that document
+         *     is deleted and re-ingested it gets a new id, and every eval run scores an
+         *     honest-looking 0% because scoped retrieval finds nothing. Re-linking
+         *     updates the pins in place. The stale source_chunk_id is cleared — it
+         *     pointed into the dead document and nothing at eval time depends on it.
+         */
+        patch: operations["relink_golden_dataset_evals_datasets__dataset_id__relink_patch"];
         trace?: never;
     };
     "/evals/datasets/{dataset_id}/golden": {
@@ -1733,6 +2056,47 @@ export interface paths {
          *     via asyncio.to_thread so it never blocks the event loop.
          */
         post: operations["run_eval_evals_run_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/evals/models": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Eval Models
+         * @description Models for the generate/run dropdowns: local Ollama + frontier (if keys set).
+         */
+        get: operations["get_eval_models_evals_models_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/evals/golden/generate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Golden File
+         * @description Generate or REPLACE a file-backed golden with the good pipeline (personas +
+         *     cross-model verification), chosen models, and a provenance sidecar.
+         */
+        post: operations["generate_golden_file_evals_golden_generate_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2601,6 +2965,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/home/recommendations/{feedback_id}/dismiss": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Dismiss Recommendation */
+        post: operations["dismiss_recommendation_home_recommendations__feedback_id__dismiss_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/home/recommendations/{feedback_id}/acted": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Act On Recommendation */
+        post: operations["act_on_recommendation_home_recommendations__feedback_id__acted_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/images/notes": {
         parameters: {
             query?: never;
@@ -3333,6 +3731,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/notes/descriptions/backfill": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Backfill Descriptions
+         * @description Manually (re)generate card summaries. Default fills only notes missing
+         *     one; force=True refreshes every eligible note. Runs in the background; the
+         *     response reports how many notes were queued.
+         */
+        post: operations["backfill_descriptions_notes_descriptions_backfill_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/pomodoro/active": {
         parameters: {
             query?: never;
@@ -3483,6 +3903,30 @@ export interface paths {
          * @description Classify the chat route without executing retrieval/LLM graph nodes.
          */
         post: operations["classify_only_qa_classify_only_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/qa/grounded": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Ask Grounded
+         * @description GraphRAG answer over the concept graph (docs/okf.md).
+         *
+         *     Resolve scope -> concepts -> expand the graph + evidence -> one OKF grounding block -> LiteLLM.
+         *     Self-contained (does not touch the streaming chat graph). Degrades: no concepts -> an honest
+         *     "not in your library yet"; model down -> the grounding context is returned as the answer.
+         */
+        post: operations["ask_grounded_qa_grounded_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3792,6 +4236,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/settings/retrieval": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Retrieval Settings */
+        get: operations["get_retrieval_settings_settings_retrieval_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Patch Retrieval Settings */
+        patch: operations["patch_retrieval_settings_settings_retrieval_patch"];
+        trace?: never;
+    };
     "/settings/surface": {
         parameters: {
             query?: never;
@@ -3900,6 +4362,30 @@ export interface paths {
         get: operations["get_due_cards_study_due_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/study/assemble": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Assemble Study
+         * @description Study Launcher backend: resolve a scope -> a valid Study Event (docs/study-launcher.md).
+         *
+         *     Returns the assembled due-card set + an honest preview, and records a StudyEvent row.
+         *     Tier-aware: teachback_available reflects the feynman labs surface. Model-down still
+         *     yields due cards (generation is a separate seam).
+         */
+        post: operations["assemble_study_study_assemble_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4309,6 +4795,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/study/misconception-stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Misconception Stats */
+        get: operations["misconception_stats_study_misconception_stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/study/calibration-stats": {
         parameters: {
             query?: never;
@@ -4432,6 +4935,48 @@ export interface paths {
          * @description Apply FSRS rating to a card, then return the next due card or done=true.
          */
         post: operations["session_review_study_session__document_id__review_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/study/topics/{document_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Document Topics
+         * @description A document's study topics from its authored structure (top-level headings, front/back-matter
+         *     filtered out) -- or an LLM outline when heading detection is messy. Never an INDEX or publisher
+         *     boilerplate.
+         */
+        get: operations["get_document_topics_study_topics__document_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/study/sections/{document_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Document Sections
+         * @description All real sub-sections of a document (junk filtered, searchable) for drill-down.
+         */
+        get: operations["get_document_sections_study_sections__document_id__get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -5036,6 +5581,87 @@ export interface components {
         ArchiveMasteredResponse: {
             /** Archived */
             archived: number;
+        };
+        /** AssemblePreview */
+        AssemblePreview: {
+            /** Due Count */
+            due_count: number;
+            /** Generated Count */
+            generated_count: number;
+            /** Mapped Count */
+            mapped_count: number;
+            /** Unmapped Count */
+            unmapped_count: number;
+            /** Topic Mix */
+            topic_mix: string[];
+            /** Thin Scope Warning */
+            thin_scope_warning?: string | null;
+        };
+        /** AssembleRequest */
+        AssembleRequest: {
+            /**
+             * Scope Type
+             * @enum {string}
+             */
+            scope_type: "daily" | "concept" | "collection" | "doc" | "note" | "tag" | "selection" | "chat" | "planWeek";
+            /** Scope Ref */
+            scope_ref?: string | null;
+            /**
+             * Mode
+             * @default quick_quiz
+             * @enum {string}
+             */
+            mode: "quick_quiz" | "full_session" | "drill" | "checkpoint";
+            /**
+             * Length Min
+             * @default 5
+             */
+            length_min: number;
+            /**
+             * Want Generated
+             * @default true
+             */
+            want_generated: boolean;
+            /**
+             * Keep
+             * @default test
+             * @enum {string}
+             */
+            keep: "test" | "save";
+            /**
+             * Commit
+             * @default true
+             */
+            commit: boolean;
+        };
+        /** AssembleResponse */
+        AssembleResponse: {
+            /** Event Id */
+            event_id: string;
+            /**
+             * Scope Type
+             * @enum {string}
+             */
+            scope_type: "daily" | "concept" | "collection" | "doc" | "note" | "tag" | "selection" | "chat" | "planWeek";
+            /** Scope Ref */
+            scope_ref: string | null;
+            /**
+             * Mode
+             * @enum {string}
+             */
+            mode: "quick_quiz" | "full_session" | "drill" | "checkpoint";
+            /** Concept Ids */
+            concept_ids: string[];
+            /** Cards */
+            cards: components["schemas"]["FlashcardResponse"][];
+            preview: components["schemas"]["AssemblePreview"];
+            /** Teachback Available */
+            teachback_available: boolean;
+        };
+        /** AssignCollectionsRequest */
+        AssignCollectionsRequest: {
+            /** Collection Ids */
+            collection_ids: string[];
         };
         /** BatchAcceptItem */
         BatchAcceptItem: {
@@ -5688,6 +6314,21 @@ export interface components {
             /** Document Ids */
             document_ids: string[];
         };
+        /** ConceptOut */
+        ConceptOut: {
+            /** Id */
+            id: string;
+            /** Slug */
+            slug: string;
+            /** Label */
+            label: string;
+            /** Kind */
+            kind: string;
+            /** Status */
+            status: string;
+            /** Mastery */
+            mastery: number;
+        };
         /**
          * ContinueReadingItem
          * @description A doc the user has momentum on -- started, not finished, recently touched.
@@ -5770,6 +6411,13 @@ export interface components {
             /** Study Time Minutes */
             study_time_minutes: number;
         };
+        /** DatasetRelinkRequest */
+        DatasetRelinkRequest: {
+            /** Document Id */
+            document_id: string;
+            /** From Document Id */
+            from_document_id?: string | null;
+        };
         /** DecayDebtItem */
         DecayDebtItem: {
             /** Document Id */
@@ -5828,6 +6476,11 @@ export interface components {
             document_id: string | null;
             /** Collection Id */
             collection_id: string | null;
+        };
+        /** DescriptionBackfillResponse */
+        DescriptionBackfillResponse: {
+            /** Queued */
+            queued: number;
         };
         /** DocumentDetail */
         DocumentDetail: {
@@ -5972,6 +6625,23 @@ export interface components {
             /** Page Size */
             page_size: number;
         };
+        /** DocumentOverviewResponse */
+        DocumentOverviewResponse: {
+            /** Id */
+            id: string;
+            /** Title */
+            title: string;
+            /** Format */
+            format: string;
+            /** Content Type */
+            content_type: string;
+            /** Tags */
+            tags: string[];
+            /** Reading Progress Pct */
+            reading_progress_pct: number;
+            /** Collections */
+            collections: components["schemas"]["CollectionRef"][];
+        };
         /** DocumentProgressResponse */
         DocumentProgressResponse: {
             /** Document Id */
@@ -6002,6 +6672,17 @@ export interface components {
             match_count: number;
             /** Snippet */
             snippet: string;
+        };
+        /** DocumentTopicsResponse */
+        DocumentTopicsResponse: {
+            /** Document Id */
+            document_id: string;
+            /** Title */
+            title: string;
+            /** Source */
+            source: string;
+            /** Topics */
+            topics: components["schemas"]["TopicItem"][];
         };
         /** DueCountResponse */
         DueCountResponse: {
@@ -6188,6 +6869,10 @@ export interface components {
             ablation_metrics?: {
                 [key: string]: unknown;
             } | null;
+            /** Extra Metrics */
+            extra_metrics?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** EvalRunListItem */
         EvalRunListItem: {
@@ -6195,6 +6880,8 @@ export interface components {
             id: string;
             /** Dataset Name */
             dataset_name: string;
+            /** Dataset Label */
+            dataset_label?: string | null;
             /** Run At */
             run_at: string;
             /** Hit Rate 5 */
@@ -6221,6 +6908,17 @@ export interface components {
             model_used: string;
             /** Citation Support Rate */
             citation_support_rate: number | null;
+            /** Extra Metrics */
+            extra_metrics?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Status
+             * @default complete
+             */
+            status: string;
+            /** Error Message */
+            error_message?: string | null;
         };
         /** EvalRunRequest */
         EvalRunRequest: {
@@ -6231,6 +6929,8 @@ export interface components {
              * @default false
              */
             assert_thresholds: boolean;
+            /** Model */
+            model?: string | null;
             /** Judge Model */
             judge_model?: string | null;
             /**
@@ -6240,6 +6940,16 @@ export interface components {
             check_citations: boolean;
             /** Max Questions */
             max_questions?: number | null;
+            /**
+             * Rerank
+             * @default false
+             */
+            rerank: boolean;
+            /**
+             * Ablation
+             * @default false
+             */
+            ablation: boolean;
         };
         /** EvalRunResponse */
         EvalRunResponse: {
@@ -6290,6 +7000,10 @@ export interface components {
             } | null;
             /** Ablation Metrics */
             ablation_metrics?: {
+                [key: string]: unknown;
+            } | null;
+            /** Extra Metrics */
+            extra_metrics?: {
                 [key: string]: unknown;
             } | null;
         };
@@ -6634,6 +7348,16 @@ export interface components {
             check_citations: boolean;
             /** Max Questions */
             max_questions?: number | null;
+            /**
+             * Rerank
+             * @default false
+             */
+            rerank: boolean;
+            /**
+             * Ablation
+             * @default false
+             */
+            ablation: boolean;
         };
         /** GeneratedRunResponse */
         GeneratedRunResponse: {
@@ -6706,6 +7430,11 @@ export interface components {
              * @default []
              */
             source_document_ids: string[];
+            /**
+             * Missing Document Ids
+             * @default []
+             */
+            missing_document_ids: string[];
             /** Status */
             status: string;
             /** Generated Count */
@@ -6771,6 +7500,42 @@ export interface components {
             /** Limit */
             limit: number;
         };
+        /** GoldenGenerateRequest */
+        GoldenGenerateRequest: {
+            /** Name */
+            name: string;
+            /** Source File */
+            source_file: string;
+            /**
+             * Generator Model
+             * @default openai/gpt-5.4
+             */
+            generator_model: string;
+            /** Verify Models */
+            verify_models?: string[];
+            /**
+             * Target
+             * @default 50
+             */
+            target: number;
+        };
+        /** GoldenInfoResponse */
+        GoldenInfoResponse: {
+            /** Name */
+            name: string;
+            /** Question Count */
+            question_count: number;
+            /** Source File */
+            source_file?: string | null;
+            /** Provenance */
+            provenance?: {
+                [key: string]: unknown;
+            } | null;
+            /** Quality */
+            quality?: {
+                [key: string]: unknown;
+            } | null;
+        };
         /** GoldenQuestionResponse */
         GoldenQuestionResponse: {
             /** Id */
@@ -6789,6 +7554,31 @@ export interface components {
             quality_score: number;
             /** Included */
             included: boolean;
+        };
+        /** GroundedConcept */
+        GroundedConcept: {
+            /** Id */
+            id: string;
+            /** Label */
+            label: string;
+        };
+        /** GroundedRequest */
+        GroundedRequest: {
+            /** Question */
+            question: string;
+            /** Concept Id */
+            concept_id?: string | null;
+            /** Model */
+            model?: string | null;
+        };
+        /** GroundedResponse */
+        GroundedResponse: {
+            /** Answer */
+            answer: string;
+            /** Grounded */
+            grounded: boolean;
+            /** Concepts */
+            concepts: components["schemas"]["GroundedConcept"][];
         };
         /** GroupInfo */
         GroupInfo: {
@@ -6842,6 +7632,11 @@ export interface components {
              */
             fading_items: components["schemas"]["FadingItem"][];
             weekly_stats?: components["schemas"]["WeeklyStats"] | null;
+            /**
+             * Recommendations
+             * @default []
+             */
+            recommendations: components["schemas"]["Recommendation"][];
         };
         /** ImageItem */
         ImageItem: {
@@ -6935,6 +7730,11 @@ export interface components {
              * @default []
              */
             cloud_providers: unknown[];
+            /**
+             * Ollama Reachable
+             * @default true
+             */
+            ollama_reachable: boolean;
         };
         /** LabsPatch */
         LabsPatch: {
@@ -7054,6 +7854,13 @@ export interface components {
             /** Cells */
             cells: components["schemas"]["HeatmapCellOut"][];
         };
+        /** MergeRequest */
+        MergeRequest: {
+            /** Source Id */
+            source_id: string;
+            /** Target Id */
+            target_id: string;
+        };
         /** MessageAppendRequest */
         MessageAppendRequest: {
             /**
@@ -7087,6 +7894,15 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+        };
+        /** MisconceptionStatsResponse */
+        MisconceptionStatsResponse: {
+            /** Open Count */
+            open_count: number;
+            /** Resolved Count */
+            resolved_count: number;
+            /** Resolved Last 30D */
+            resolved_last_30d: number;
         };
         /** ModelUsageItem */
         ModelUsageItem: {
@@ -7433,6 +8249,17 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /** PurgeJunkResponse */
+        PurgeJunkResponse: {
+            /** Dry Run */
+            dry_run: boolean;
+            /** Matched */
+            matched: number;
+            /** Deleted */
+            deleted: number;
+            /** Labels */
+            labels: string[];
+        };
         /** QARequest */
         QARequest: {
             /** Question */
@@ -7531,6 +8358,79 @@ export interface components {
             document_count: number;
             /** Note Count */
             note_count: number;
+        };
+        /** ReclassifyRequest */
+        ReclassifyRequest: {
+            /** Kind */
+            kind: string;
+        };
+        /** Recommendation */
+        Recommendation: {
+            /** Id */
+            id: string;
+            /**
+             * Kind
+             * @enum {string}
+             */
+            kind: "overdue_reviews" | "weak_concept" | "open_misconception" | "calibration_blind_spot" | "stalled_reading";
+            /**
+             * Target Type
+             * @enum {string}
+             */
+            target_type: "study" | "concept" | "flashcard" | "document";
+            /** Target Ref */
+            target_ref: string;
+            /** Label */
+            label: string;
+            /** Score */
+            score: number;
+            /** Reasons */
+            reasons: components["schemas"]["RecommendationReason"][];
+            /** Count */
+            count?: number | null;
+            /** Document Id */
+            document_id?: string | null;
+            /** Concept Slug */
+            concept_slug?: string | null;
+        };
+        /**
+         * RecommendationReason
+         * @description One evidence line behind a recommendation -- never asserted without one
+         *     (docs/recommender-spec.md).
+         */
+        RecommendationReason: {
+            /** Signal */
+            signal: string;
+            /** Detail */
+            detail: string;
+        };
+        /** RegenStatus */
+        RegenStatus: {
+            /** Status */
+            status: string;
+            /** Started At */
+            started_at?: string | null;
+            /** Finished At */
+            finished_at?: string | null;
+            /** Concepts */
+            concepts?: number | null;
+            /** Error */
+            error?: string | null;
+        };
+        /** RenameRequest */
+        RenameRequest: {
+            /** Label */
+            label: string;
+        };
+        /** RetrievalSettingsPatch */
+        RetrievalSettingsPatch: {
+            /** Rerank Enabled */
+            rerank_enabled: boolean;
+        };
+        /** RetrievalSettingsResponse */
+        RetrievalSettingsResponse: {
+            /** Rerank Enabled */
+            rerank_enabled: boolean;
         };
         /** ReviewRequest */
         ReviewRequest: {
@@ -7810,6 +8710,8 @@ export interface components {
             title?: string | null;
             /** Auto From Message */
             auto_from_message?: string | null;
+            /** Model */
+            model?: string | null;
         };
         /** SessionReviewRequest */
         SessionReviewRequest: {
@@ -8261,7 +9163,7 @@ export interface components {
              * Kind
              * @enum {string}
              */
-            kind: "review_cards" | "continue_reading" | "resume_note";
+            kind: "review_cards" | "continue_reading" | "resume_note" | "drill_concept" | "fix_misconception" | "confidence_check";
             /** Target Id */
             target_id?: string | null;
             /** Label */
@@ -8276,6 +9178,26 @@ export interface components {
             collection_color?: string | null;
             /** Scoped Count */
             scoped_count?: number | null;
+            /**
+             * Reasons
+             * @default []
+             */
+            reasons: components["schemas"]["RecommendationReason"][];
+            /** Recommendation Id */
+            recommendation_id?: string | null;
+            /** Document Id */
+            document_id?: string | null;
+        };
+        /** TopicItem */
+        TopicItem: {
+            /** Title */
+            title: string;
+            /** Level */
+            level: number;
+            /** Section Id */
+            section_id: string | null;
+            /** Page Start */
+            page_start: number | null;
         };
         /** TraceFlashcardRequest */
         TraceFlashcardRequest: {
@@ -9737,6 +10659,353 @@ export interface operations {
             };
         };
     };
+    get_concept_concepts__concept_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                concept_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConceptOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    rename_concept_concepts__concept_id__rename_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                concept_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RenameRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConceptOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reclassify_concept_concepts__concept_id__reclassify_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                concept_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReclassifyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConceptOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    confirm_concept_concepts__concept_id__confirm_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                concept_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reject_concept_concepts__concept_id__reject_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                concept_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    merge_concepts_concepts_merge_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MergeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConceptOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    apply_overrides_concepts_apply_overrides_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: number;
+                    };
+                };
+            };
+        };
+    };
+    purge_junk_concepts_concepts_purge_junk_post: {
+        parameters: {
+            query?: {
+                dry_run?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PurgeJunkResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    regenerate_concepts_concepts_regenerate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegenStatus"];
+                };
+            };
+        };
+    };
+    regenerate_concepts_status_concepts_regenerate_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegenStatus"];
+                };
+            };
+        };
+    };
+    concepts_for_note_concepts_for_note__note_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                note_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConceptOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_concepts_concepts_get: {
+        parameters: {
+            query?: {
+                status?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConceptOut"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     mark_suggestion_asked_chat_suggestions__suggestion_id__asked_post: {
         parameters: {
             query?: never;
@@ -10316,6 +11585,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_document_overview_documents__document_id__overview_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                document_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DocumentOverviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    assign_document_collections_documents__document_id__collections_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                document_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AssignCollectionsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CollectionRef"][];
                 };
             };
             /** @description Validation Error */
@@ -11430,6 +12765,37 @@ export interface operations {
             };
         };
     };
+    get_golden_info_evals_golden__name__info_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoldenInfoResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_golden_file_evals_golden__name__get: {
         parameters: {
             query?: {
@@ -11626,6 +12992,43 @@ export interface operations {
             };
         };
     };
+    relink_golden_dataset_evals_datasets__dataset_id__relink_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                dataset_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DatasetRelinkRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_golden_dataset_rows_evals_datasets__dataset_id__golden_get: {
         parameters: {
             query?: never;
@@ -11768,6 +13171,63 @@ export interface operations {
                 content: {
                     "application/json": {
                         [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_eval_models_evals_models_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: string[];
+                    };
+                };
+            };
+        };
+    };
+    generate_golden_file_evals_golden_generate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GoldenGenerateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: string;
                     };
                 };
             };
@@ -13249,6 +14709,64 @@ export interface operations {
             };
         };
     };
+    dismiss_recommendation_home_recommendations__feedback_id__dismiss_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                feedback_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    act_on_recommendation_home_recommendations__feedback_id__acted_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                feedback_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     upload_note_image_images_notes_post: {
         parameters: {
             query?: never;
@@ -14385,6 +15903,37 @@ export interface operations {
             };
         };
     };
+    backfill_descriptions_notes_descriptions_backfill_post: {
+        parameters: {
+            query?: {
+                force?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DescriptionBackfillResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_active_pomodoro_active_get: {
         parameters: {
             query?: never;
@@ -14635,6 +16184,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ClassifyOnlyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    ask_grounded_qa_grounded_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroundedRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroundedResponse"];
                 };
             };
             /** @description Validation Error */
@@ -15085,6 +16667,59 @@ export interface operations {
             };
         };
     };
+    get_retrieval_settings_settings_retrieval_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RetrievalSettingsResponse"];
+                };
+            };
+        };
+    };
+    patch_retrieval_settings_settings_retrieval_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RetrievalSettingsPatch"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RetrievalSettingsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_surface_settings_surface_get: {
         parameters: {
             query?: never;
@@ -15242,6 +16877,7 @@ export interface operations {
                 tag?: string | null;
                 document_ids?: string[] | null;
                 note_ids?: string[] | null;
+                section_id?: string | null;
                 limit?: number;
             };
             header?: never;
@@ -15257,6 +16893,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FlashcardResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    assemble_study_study_assemble_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AssembleRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AssembleResponse"];
                 };
             };
             /** @description Validation Error */
@@ -15877,6 +17546,26 @@ export interface operations {
             };
         };
     };
+    misconception_stats_study_misconception_stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MisconceptionStatsResponse"];
+                };
+            };
+        };
+    };
     get_calibration_stats_study_calibration_stats_get: {
         parameters: {
             query?: {
@@ -16055,6 +17744,71 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SessionReviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_document_topics_study_topics__document_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                document_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DocumentTopicsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_document_sections_study_sections__document_id__get: {
+        parameters: {
+            query?: {
+                q?: string | null;
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                document_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopicItem"][];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -2775,6 +2775,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/flashcards/collection/{collection_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete All Collection Flashcards
+         * @description Delete every flashcard sourced from a collection's documents and notes.
+         *
+         *     Returns the deleted count so the UI can confirm. Keeps FTS in sync per I-4.
+         */
+        delete: operations["delete_all_collection_flashcards_flashcards_collection__collection_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/flashcards/{card_id}/review": {
         parameters: {
             query?: never;
@@ -6218,9 +6240,14 @@ export interface components {
             title: string;
             /** Type */
             type: string;
+            /**
+             * Weight
+             * @default 0
+             */
+            weight: number;
         };
-        /** CollectionSubEnclave */
-        CollectionSubEnclave: {
+        /** CollectionSubCollection */
+        CollectionSubCollection: {
             /** Id */
             id: string;
             /** Name */
@@ -8835,7 +8862,7 @@ export interface components {
              * Sub Collections
              * @default []
              */
-            sub_collections: components["schemas"]["CollectionSubEnclave"][];
+            sub_collections: components["schemas"]["CollectionSubCollection"][];
         };
         /** StudyPathAPIResponse */
         StudyPathAPIResponse: {
@@ -14441,6 +14468,37 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_all_collection_flashcards_flashcards_collection__collection_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                collection_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BulkDeleteResponse"];
+                };
             };
             /** @description Validation Error */
             422: {


### PR DESCRIPTION
Three cohesive bodies of work on this branch, all gated green (backend `ruff` + layer/boundary + suite; frontend `tsc` + vitest + prod build). The only failing frontend tests are the 11 pre-existing PDF-reader ones that also fail on `master`.

## 1. Evidence-scored hub recommender + misconception lifecycle (`1ad395e`)
- Deterministic "what should I do next, and why" on the hub: five generators (overdue reviews, weak concepts, open misconceptions, calibration blind spots, stalled reading) scored by a transparent weighted sum, each with a because-line from the learner's own record. No LLM in the request path.
- `recommendation_feedback` table for persistent dismiss/acted + an anti-nag fatigue penalty.
- Misconceptions gain an open→resolved lifecycle (resolved deterministically by a later good review / passing teach-back); Progress shows a "Gaps Closed" stat. Hub restructured into a two-column dashboard.
- Spec: `docs/recommender-spec.md`.

## 2. Flashcard quality gate + retry-to-backfill (`10884d8`)
- Deterministic gate rejecting one-word answers, source-referencing/leading questions, and bloated-question/trivial-answer cards, on every generation path.
- Generation retries to backfill cards lost to the gate/parse failures so a request for N returns N, steering each retry away from questions already accepted.

## 3. Collection card management, navigation, and review-flow fixes (`c6ae980`)
- **Collections** get the same view / generate / bulk-and-all delete workflow documents have (`CollectionCardManager`, new `DELETE /flashcards/collection/{id}`, a shared `collection_card_filter` that fixes the old note-only scoping). "Enclave" renamed to "collection". One-click **Regenerate (replace)** for docs and collections.
- **Navigation**: `StudyBrowser` header popover browses collections and documents in separate labelled sections, reachable from any state (the old picker was documents-only).
- **Collection generation**: the count is a collection-wide **total** split across sources, weighted by content size (chunk count for docs, length for notes) with square-root damping and a floor of 1 — a book earns most questions, a small note a few, never zero.
- **Review-session fixes**: reconcile a resumed session's planned total to live cards; close **stale** sessions instead of resurfacing a stuck "Session Complete" screen; fix the card that toggled between question and answer (decoupled a `revealed` latch from the flip); the card now grows to fit content so long answers no longer overlap the controls, and answers are left-aligned with markdown structure.
- **Prompts**: consolidated to one clean flashcard system prompt (dropped the duplicate genre prompt + appended Bloom fragment); answers lead with a sentence then bullets for multi-point content, no chapter/section citation, with a `strip_source_ref` backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)