### PR TITLE
fix(monitoring): Phoenix traces workflow + tabbed observability page

### DIFF
--- a/backend/app/routers/monitoring.py
+++ b/backend/app/routers/monitoring.py
@@ -8,9 +8,10 @@ Routes:
 
 import json
 import logging
+import math
 import time
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import httpx
@@ -29,6 +30,8 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/monitoring", tags=["monitoring"])
 
 _PHOENIX_BASE = "http://127.0.0.1:6006"
+# Must match the project_name registered in app/telemetry.py::setup_tracing.
+_PHOENIX_PROJECT = "luminary"
 _TRACES_TIMEOUT = 3.0  # seconds
 _PHOENIX_REACHABILITY_TTL = 30.0  # seconds
 
@@ -43,9 +46,12 @@ class TraceItem(BaseModel):
     span_id: str
     trace_id: str
     operation_name: str
+    span_kind: str = "UNKNOWN"  # OpenInference kind: CHAIN | LLM | RETRIEVER | ...
+    parent_id: str | None = None
     start_time: str
     duration_ms: float
     status: str  # "ok" | "error" | "unset"
+    status_message: str = ""
     attributes: dict
 
 
@@ -57,11 +63,11 @@ class TracesResponse(BaseModel):
 class MonitoringOverview(BaseModel):
     llm_status: str
     phoenix_running: bool
+    phoenix_configured: bool = False
     langfuse_configured: bool
     total_documents: int
     total_chunks: int
     qa_calls_today: int
-    avg_latency_ms: float | None
 
 
 class EvalRunCreate(BaseModel):
@@ -123,28 +129,24 @@ class EvalRegressionResponse(BaseModel):
 
 class PhoenixUrlResponse(BaseModel):
     url: str
-    enabled: bool
+    enabled: bool  # configured AND currently reachable
+    configured: bool = False  # PHOENIX_ENABLED in backend settings
 
 
 async def _check_phoenix_running() -> bool:
-    try:
-        async with httpx.AsyncClient(timeout=_TRACES_TIMEOUT) as client:
-            resp = await client.get(f"{_PHOENIX_BASE}/healthz")
-            return resp.status_code < 400
-    except Exception:
-        return False
+    """GET /healthz with the result cached for 30 seconds.
 
-
-async def _check_phoenix_reachable_cached() -> bool:
-    """HEAD request to Phoenix with 2-second timeout; result cached for 30 seconds."""
+    Shared by /overview, /traces and /phoenix-url so a page render costs at
+    most one health probe instead of three.
+    """
     now = time.monotonic()
     cached = _phoenix_reachability_cache
     if cached.get("ts") and now - cached["ts"] < _PHOENIX_REACHABILITY_TTL:
         return bool(cached["value"])
     try:
         async with httpx.AsyncClient(timeout=2.0) as client:
-            resp = await client.head(f"{_PHOENIX_BASE}")
-            reachable = resp.status_code < 500
+            resp = await client.get(f"{_PHOENIX_BASE}/healthz")
+            reachable = resp.status_code < 400
     except Exception:
         reachable = False
     _phoenix_reachability_cache["value"] = reachable
@@ -153,38 +155,47 @@ async def _check_phoenix_reachable_cached() -> bool:
 
 
 async def _fetch_phoenix_spans(limit: int = 50) -> list[TraceItem]:
-    """Fetch recent spans from Phoenix REST API. Returns [] on failure."""
+    """Fetch recent spans from Phoenix REST API. Returns [] on failure.
+
+    Uses GET /v1/projects/{project}/spans (arize-phoenix >= 9). The older
+    GET /v1/spans is deprecated and requires a request body, so a plain GET
+    against it 422s — that was why the traces panel always came back empty.
+    Spans are returned newest-first. 404 means the project has no traces yet.
+    """
     try:
         async with httpx.AsyncClient(timeout=_TRACES_TIMEOUT) as client:
             resp = await client.get(
-                f"{_PHOENIX_BASE}/v1/spans",
-                params={"limit": limit, "sort_col": "startTime", "sort_dir": "desc"},
+                f"{_PHOENIX_BASE}/v1/projects/{_PHOENIX_PROJECT}/spans",
+                params={"limit": limit},
             )
             if resp.status_code != 200:
                 return []
-            data = resp.json()
-            spans_raw = data if isinstance(data, list) else data.get("data", [])
+            spans_raw = resp.json().get("data", [])
             items: list[TraceItem] = []
             for s in spans_raw[:limit]:
-                attrs = s.get("attributes", s.get("context", {}))
-                start = s.get("start_time", s.get("startTime", ""))
-                end = s.get("end_time", s.get("endTime", ""))
+                context = s.get("context") or {}
+                start = s.get("start_time") or ""
+                end = s.get("end_time") or ""
                 duration_ms = 0.0
                 if start and end:
                     try:
                         t_start = datetime.fromisoformat(start.replace("Z", "+00:00"))
                         t_end = datetime.fromisoformat(end.replace("Z", "+00:00"))
                         duration_ms = (t_end - t_start).total_seconds() * 1000
-                    except Exception:
+                    except ValueError:
                         pass
+                attrs = s.get("attributes")
                 items.append(
                     TraceItem(
-                        span_id=str(s.get("span_id", s.get("context", {}).get("span_id", ""))),
-                        trace_id=str(s.get("trace_id", s.get("context", {}).get("trace_id", ""))),
-                        operation_name=str(s.get("name", s.get("span_kind", "unknown"))),
+                        span_id=str(context.get("span_id") or ""),
+                        trace_id=str(context.get("trace_id") or ""),
+                        operation_name=str(s.get("name") or "unknown"),
+                        span_kind=str(s.get("span_kind") or "UNKNOWN"),
+                        parent_id=s.get("parent_id"),
                         start_time=start,
                         duration_ms=round(duration_ms, 2),
-                        status=str(s.get("status_code", s.get("status", "unset"))).lower(),
+                        status=str(s.get("status_code") or "UNSET").lower(),
+                        status_message=str(s.get("status_message") or ""),
                         attributes=attrs if isinstance(attrs, dict) else {},
                     )
                 )
@@ -196,17 +207,17 @@ async def _fetch_phoenix_spans(limit: int = 50) -> list[TraceItem]:
 
 @router.get("/phoenix-url", response_model=PhoenixUrlResponse)
 async def get_phoenix_url() -> PhoenixUrlResponse:
-    """Return the Phoenix UI URL and whether it is currently reachable."""
+    """Return the Phoenix UI URL, whether tracing is configured, and reachability."""
     settings = get_settings()
     if not settings.PHOENIX_ENABLED:
-        return PhoenixUrlResponse(url=_PHOENIX_BASE, enabled=False)
-    reachable = await _check_phoenix_reachable_cached()
-    return PhoenixUrlResponse(url=_PHOENIX_BASE, enabled=reachable)
+        return PhoenixUrlResponse(url=_PHOENIX_BASE, enabled=False, configured=False)
+    reachable = await _check_phoenix_running()
+    return PhoenixUrlResponse(url=_PHOENIX_BASE, enabled=reachable, configured=True)
 
 
 @router.get("/traces", response_model=TracesResponse)
-async def get_traces() -> TracesResponse:
-    """Return last 50 spans from Phoenix. Returns empty list if Phoenix is not running."""
+async def get_traces(limit: int = 50) -> TracesResponse:
+    """Return recent spans from Phoenix. Returns empty list if Phoenix is not running."""
     settings = get_settings()
     if not settings.PHOENIX_ENABLED:
         return TracesResponse(traces=[], message="Phoenix is disabled")
@@ -215,7 +226,7 @@ async def get_traces() -> TracesResponse:
     if not running:
         return TracesResponse(traces=[], message="Phoenix is not running")
 
-    spans = await _fetch_phoenix_spans(limit=50)
+    spans = await _fetch_phoenix_spans(limit=max(1, min(limit, 200)))
     return TracesResponse(traces=spans)
 
 
@@ -246,17 +257,14 @@ async def get_overview(
     # Phoenix health
     phoenix_running = await _check_phoenix_running() if settings.PHOENIX_ENABLED else False
 
-    # LLM status
-    llm_status = settings.LITELLM_DEFAULT_MODEL
-
     return MonitoringOverview(
-        llm_status=llm_status,
+        llm_status=settings.LITELLM_DEFAULT_MODEL,
         phoenix_running=phoenix_running,
+        phoenix_configured=settings.PHOENIX_ENABLED,
         langfuse_configured=bool(settings.LANGFUSE_PUBLIC_KEY),
         total_documents=total_documents,
         total_chunks=total_chunks,
         qa_calls_today=qa_calls_today,
-        avg_latency_ms=None,  # Would require span query if Phoenix running
     )
 
 
@@ -384,10 +392,101 @@ async def get_eval_regressions(
     return [EvalRegressionResponse(**regression.__dict__) for regression in regressions]
 
 
+class QADailyCount(BaseModel):
+    date: str  # YYYY-MM-DD (UTC)
+    count: int
+
+
+class MonitoringMetrics(BaseModel):
+    phoenix_available: bool
+    spans_sampled: int
+    traces_sampled: int
+    latency_p50_ms: float | None
+    latency_p95_ms: float | None
+    error_count: int
+    error_rate: float | None
+    llm_calls: int
+    llm_prompt_tokens: int
+    llm_completion_tokens: int
+    spans_by_kind: dict[str, int]
+    qa_daily: list[QADailyCount]
+
+
+def _percentile(sorted_vals: list[float], q: float) -> float | None:
+    if not sorted_vals:
+        return None
+    idx = min(len(sorted_vals) - 1, max(0, math.ceil(q * len(sorted_vals)) - 1))
+    return round(sorted_vals[idx], 1)
+
+
+@router.get("/metrics", response_model=MonitoringMetrics)
+async def get_metrics(
+    db: AsyncSession = Depends(get_db),
+) -> MonitoringMetrics:
+    """Operational metrics: latency/error/token stats from a sample of recent
+    Phoenix spans, plus a 7-day QA activity trend from SQLite (available even
+    when tracing is off)."""
+    settings = get_settings()
+    phoenix_available = (
+        await _check_phoenix_running() if settings.PHOENIX_ENABLED else False
+    )
+
+    spans: list[TraceItem] = []
+    if phoenix_available:
+        spans = await _fetch_phoenix_spans(limit=200)
+
+    root_durations = sorted(s.duration_ms for s in spans if s.parent_id is None)
+    error_count = sum(1 for s in spans if s.status == "error")
+    spans_by_kind: dict[str, int] = {}
+    llm_calls = llm_prompt_tokens = llm_completion_tokens = 0
+    for s in spans:
+        spans_by_kind[s.span_kind] = spans_by_kind.get(s.span_kind, 0) + 1
+        if s.span_kind == "LLM":
+            llm_calls += 1
+            try:
+                llm_prompt_tokens += int(s.attributes.get("llm.token_count.prompt") or 0)
+                llm_completion_tokens += int(
+                    s.attributes.get("llm.token_count.completion") or 0
+                )
+            except (TypeError, ValueError):
+                pass
+
+    # QA activity per UTC day, zero-filled over the trailing 7 days.
+    today = datetime.now(tz=UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    since = today - timedelta(days=6)
+    result = await db.execute(
+        select(func.date(QAHistoryModel.created_at).label("day"), func.count())
+        .where(QAHistoryModel.created_at >= since.replace(tzinfo=None))
+        .group_by("day")
+    )
+    counts_by_day = {str(row[0]): row[1] for row in result.all()}
+    qa_daily = [
+        QADailyCount(
+            date=(since + timedelta(days=i)).strftime("%Y-%m-%d"),
+            count=counts_by_day.get((since + timedelta(days=i)).strftime("%Y-%m-%d"), 0),
+        )
+        for i in range(7)
+    ]
+
+    return MonitoringMetrics(
+        phoenix_available=phoenix_available,
+        spans_sampled=len(spans),
+        traces_sampled=len({s.trace_id for s in spans}),
+        latency_p50_ms=_percentile(root_durations, 0.50),
+        latency_p95_ms=_percentile(root_durations, 0.95),
+        error_count=error_count,
+        error_rate=round(error_count / len(spans), 4) if spans else None,
+        llm_calls=llm_calls,
+        llm_prompt_tokens=llm_prompt_tokens,
+        llm_completion_tokens=llm_completion_tokens,
+        spans_by_kind=spans_by_kind,
+        qa_daily=qa_daily,
+    )
+
+
 class ModelUsageItem(BaseModel):
     model: str
     call_count: int
-    avg_latency_ms: float | None
 
 
 @router.get("/model-usage", response_model=list[ModelUsageItem])
@@ -401,14 +500,7 @@ async def get_model_usage(
         .order_by(func.count().desc())
     )
     rows = result.all()
-    return [
-        ModelUsageItem(
-            model=row.model_used,
-            call_count=row.call_count,
-            avg_latency_ms=None,  # QAHistoryModel has no latency column
-        )
-        for row in rows
-    ]
+    return [ModelUsageItem(model=row.model_used, call_count=row.call_count) for row in rows]
 
 
 class EvalHistoryItem(BaseModel):

--- a/backend/tests/test_monitoring.py
+++ b/backend/tests/test_monitoring.py
@@ -522,6 +522,119 @@ async def test_get_eval_regressions_endpoint(test_db):
     assert data[0]["metric"] == "mrr"
 
 
+# GET /monitoring/metrics
+
+
+async def test_metrics_without_phoenix_still_returns_qa_daily(test_db, monkeypatch):
+    """With Phoenix off, metrics returns zero-filled 7-day QA trend and null latencies."""
+    _, factory, _ = test_db
+
+    import app.routers.monitoring as mon_module
+
+    async def _not_running() -> bool:
+        return False
+
+    monkeypatch.setattr(mon_module, "_check_phoenix_running", _not_running)
+
+    doc = _make_document()
+    qa = _make_qa(doc.id, datetime.now(tz=UTC).replace(tzinfo=None))
+    async with factory() as session:
+        session.add_all([doc, qa])
+        await session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/monitoring/metrics")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["phoenix_available"] is False
+    assert data["latency_p50_ms"] is None
+    assert data["error_rate"] is None
+    assert data["spans_sampled"] == 0
+    assert len(data["qa_daily"]) == 7
+    assert data["qa_daily"][-1]["count"] >= 1
+    assert sum(d["count"] for d in data["qa_daily"][:-1]) == 0
+
+
+async def test_metrics_aggregates_span_sample(test_db, monkeypatch):
+    """Latency percentiles, error rate, token totals, and kind counts from spans."""
+    monkeypatch.setenv("PHOENIX_ENABLED", "true")
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+    import app.routers.monitoring as mon_module
+    from app.routers.monitoring import TraceItem
+
+    def _span(
+        i: int,
+        kind: str,
+        duration: float,
+        parent: str | None,
+        status: str = "ok",
+        attrs: dict | None = None,
+    ):
+        return TraceItem(
+            span_id=f"s{i}",
+            trace_id=f"t{i % 3}",
+            operation_name=f"op{i}",
+            span_kind=kind,
+            parent_id=parent,
+            start_time="2026-07-09T00:00:00+00:00",
+            duration_ms=duration,
+            status=status,
+            attributes=attrs or {},
+        )
+
+    fake_spans = [
+        _span(1, "CHAIN", 100.0, None),
+        _span(2, "CHAIN", 200.0, None),
+        _span(3, "CHAIN", 1000.0, None, status="error"),
+        _span(
+            4,
+            "LLM",
+            90.0,
+            "s1",
+            attrs={"llm.token_count.prompt": 30, "llm.token_count.completion": 10},
+        ),
+        _span(
+            5,
+            "LLM",
+            190.0,
+            "s2",
+            attrs={"llm.token_count.prompt": 50, "llm.token_count.completion": 20},
+        ),
+        _span(6, "RETRIEVER", 15.0, "s1"),
+    ]
+
+    async def _running() -> bool:
+        return True
+
+    async def _fetch(limit: int = 200):
+        return fake_spans
+
+    monkeypatch.setattr(mon_module, "_check_phoenix_running", _running)
+    monkeypatch.setattr(mon_module, "_fetch_phoenix_spans", _fetch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/monitoring/metrics")
+
+    get_settings.cache_clear()
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["phoenix_available"] is True
+    assert data["spans_sampled"] == 6
+    assert data["traces_sampled"] == 3
+    assert data["latency_p50_ms"] == pytest.approx(200.0)
+    assert data["latency_p95_ms"] == pytest.approx(1000.0)
+    assert data["error_count"] == 1
+    assert data["error_rate"] == pytest.approx(1 / 6, abs=1e-3)
+    assert data["llm_calls"] == 2
+    assert data["llm_prompt_tokens"] == 80
+    assert data["llm_completion_tokens"] == 30
+    assert data["spans_by_kind"] == {"CHAIN": 3, "LLM": 2, "RETRIEVER": 1}
+
+
 # GET /monitoring/model-usage
 
 
@@ -562,7 +675,7 @@ async def test_model_usage_empty_when_no_qa_history(test_db):
 
 @pytest.mark.asyncio
 async def test_phoenix_url_returns_url_and_enabled_flag(test_db, monkeypatch):
-    """When Phoenix is enabled and reachable, enabled=true is returned."""
+    """When Phoenix is enabled and reachable, enabled=true and configured=true."""
     import httpx
 
     from app.routers import monitoring as mon_module
@@ -573,48 +686,150 @@ async def test_phoenix_url_returns_url_and_enabled_flag(test_db, monkeypatch):
     class _FakeResponse:
         status_code = 200
 
-    async def _fake_head(self, url, **kwargs):  # noqa: ARG001
-        return _FakeResponse()
+    orig_get = httpx.AsyncClient.get
+
+    # Only intercept the Phoenix health probe; the ASGI test client also
+    # goes through httpx.AsyncClient.get.
+    async def _fake_get(self, url, **kwargs):
+        if ":6006" in str(url):
+            return _FakeResponse()
+        return await orig_get(self, url, **kwargs)
 
     monkeypatch.setenv("PHOENIX_ENABLED", "true")
     from app.config import get_settings
 
     get_settings.cache_clear()
 
-    with unittest.mock.patch.object(httpx.AsyncClient, "head", _fake_head):
+    with unittest.mock.patch.object(httpx.AsyncClient, "get", _fake_get):
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.get("/monitoring/phoenix-url")
 
     get_settings.cache_clear()
+    mon_module._phoenix_reachability_cache.clear()
     assert resp.status_code == 200
     body = resp.json()
     assert "url" in body
     assert body["enabled"] is True
+    assert body["configured"] is True
 
 
 @pytest.mark.asyncio
 async def test_phoenix_url_disabled_when_unreachable(test_db, monkeypatch):
-    """When Phoenix HEAD request times out, enabled=false is returned."""
+    """When the Phoenix health check times out, enabled=false but configured=true."""
     import httpx
 
     from app.routers import monitoring as mon_module
 
     mon_module._phoenix_reachability_cache.clear()
 
-    async def _timeout_head(self, url, **kwargs):  # noqa: ARG001
-        raise httpx.ConnectError("unreachable")
+    orig_get = httpx.AsyncClient.get
+
+    async def _timeout_get(self, url, **kwargs):
+        if ":6006" in str(url):
+            raise httpx.ConnectError("unreachable")
+        return await orig_get(self, url, **kwargs)
 
     monkeypatch.setenv("PHOENIX_ENABLED", "true")
     from app.config import get_settings
 
     get_settings.cache_clear()
 
-    with unittest.mock.patch.object(httpx.AsyncClient, "head", _timeout_head):
+    with unittest.mock.patch.object(httpx.AsyncClient, "get", _timeout_get):
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.get("/monitoring/phoenix-url")
 
     get_settings.cache_clear()
+    mon_module._phoenix_reachability_cache.clear()
     assert resp.status_code == 200
     body = resp.json()
     assert "url" in body
     assert body["enabled"] is False
+    assert body["configured"] is True
+
+
+@pytest.mark.asyncio
+async def test_phoenix_url_not_configured(test_db, monkeypatch):
+    """When PHOENIX_ENABLED=false, configured=false and no health probe is made."""
+    monkeypatch.setenv("PHOENIX_ENABLED", "false")
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/monitoring/phoenix-url")
+
+    get_settings.cache_clear()
+    body = resp.json()
+    assert body["enabled"] is False
+    assert body["configured"] is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_phoenix_spans_parses_project_spans_shape(monkeypatch):
+    """_fetch_phoenix_spans hits /v1/projects/{project}/spans and maps the 13.x shape."""
+    import httpx
+
+    from app.routers import monitoring as mon_module
+
+    seen: dict = {}
+
+    class _FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {
+                "next_cursor": None,
+                "data": [
+                    {
+                        "id": "U3Bhbjox",
+                        "name": "qa.stream_answer",
+                        "context": {"trace_id": "t1", "span_id": "s1"},
+                        "span_kind": "CHAIN",
+                        "parent_id": None,
+                        "start_time": "2026-07-09T00:00:00+00:00",
+                        "end_time": "2026-07-09T00:00:01.500000+00:00",
+                        "status_code": "OK",
+                        "status_message": "",
+                        "attributes": {"input.value": "What is X?"},
+                        "events": [],
+                    },
+                    {
+                        "id": "U3Bhbjoy",
+                        "name": "retrieval.hybrid",
+                        "context": {"trace_id": "t1", "span_id": "s2"},
+                        "span_kind": "RETRIEVER",
+                        "parent_id": "s1",
+                        "start_time": "2026-07-09T00:00:00+00:00",
+                        "end_time": "2026-07-09T00:00:00.250000+00:00",
+                        "status_code": "UNSET",
+                        "status_message": "",
+                        "attributes": {},
+                        "events": [],
+                    },
+                ],
+            }
+
+    async def _fake_get(self, url, **kwargs):  # noqa: ARG001
+        seen["url"] = url
+        seen["params"] = kwargs.get("params")
+        return _FakeResponse()
+
+    with unittest.mock.patch.object(httpx.AsyncClient, "get", _fake_get):
+        items = await mon_module._fetch_phoenix_spans(limit=50)
+
+    assert seen["url"].endswith("/v1/projects/luminary/spans")
+    assert seen["params"] == {"limit": 50}
+    assert len(items) == 2
+    root, child = items
+    assert root.span_id == "s1"
+    assert root.trace_id == "t1"
+    assert root.operation_name == "qa.stream_answer"
+    assert root.span_kind == "CHAIN"
+    assert root.parent_id is None
+    assert root.duration_ms == pytest.approx(1500.0)
+    assert root.status == "ok"
+    assert child.parent_id == "s1"
+    assert child.span_kind == "RETRIEVER"
+    assert child.status == "unset"
+    assert child.duration_ms == pytest.approx(250.0)

--- a/frontend/src/pages/Monitoring.tsx
+++ b/frontend/src/pages/Monitoring.tsx
@@ -1,453 +1,82 @@
-/**
- * Monitoring tab — complete metrics dashboard.
- *
- * Sections:
- *   1. System Status — Ollama, Phoenix, Langfuse, Active Model
- *   2. RAG Quality — grouped BarChart per dataset (HR@5, MRR, Faithfulness, AR, CP)
- *   3. Retrieval Quality Over Time — HR@5 sparkline per dataset
- *   4. Model Usage — PieChart (local vs cloud) + BarChart (latency by model)
- *   5. Ingestion Queue — in-progress documents
- *   6. Recent Traces — last 50 Phoenix spans
- *   7. Eval Runs — table with HR@5 row coloring
- *
- * Each section fetches independently: if one endpoint fails the rest render normally.
- */
-
+// Monitoring page shell: hash-persisted tab nav over four panels.
+// Each tab fetches its own data via useSection, so a failed endpoint
+// degrades one section, never the page (invariant I-10).
 
 import { useEffect, useState } from "react"
 
-import { EvalTrendsPanel } from "@/components/EvalTrendsPanel"
-import { logger } from "@/lib/logger"
-import { Skeleton } from "@/components/ui/skeleton"
-
-import {
-  EvalHistorySparkline,
-  ModelUsageSection,
-  RAGQualityChart,
-  TracesCard,
-} from "./Monitoring/Charts"
-import { EvalPanel } from "./Monitoring/EvalPanel"
+import { EvalsTab } from "./Monitoring/EvalsTab"
 import { MasteryPanel } from "./Monitoring/MasteryPanel"
-import {
-  EmptyState,
-  MetricCardSkeleton,
-  ModelBadge,
-  SectionErrorCard,
-  SectionSkeleton,
-  StatusBadge,
-  StatusIndicator,
-  TraceDetailPanel,
-} from "./Monitoring/SharedUI"
-import {
-  fetchDocuments,
-  fetchEvalHistory,
-  fetchEvalRuns,
-  fetchLLMSettings,
-  fetchModelUsage,
-  fetchOverview,
-  fetchPhoenixUrl,
-  fetchTraces,
-} from "./Monitoring/api"
-import type {
-  Document,
-  EvalHistoryItem,
-  EvalRun,
-  LLMSettings,
-  ModelUsageItem,
-  MonitoringOverview,
-  PhoenixUrl,
-  SectionState,
-  TraceItem,
-  TracesResponse,
-} from "./Monitoring/types"
-import { initSection } from "./Monitoring/types"
+import { OverviewTab } from "./Monitoring/OverviewTab"
+import { PanelErrorBoundary } from "./Monitoring/SharedUI"
+import { TracesTab } from "./Monitoring/TracesTab"
+import { fetchDocuments } from "./Monitoring/api"
+import type { Document } from "./Monitoring/types"
+import { useSection } from "./Monitoring/useSection"
+
+const TABS = [
+  { id: "overview", label: "Overview" },
+  { id: "traces", label: "Traces" },
+  { id: "evals", label: "Evals" },
+  { id: "mastery", label: "Mastery" },
+] as const
+
+type TabId = (typeof TABS)[number]["id"]
+
+function MasteryTab() {
+  const docs = useSection<Document[]>("Documents", fetchDocuments, [])
+  return <MasteryPanel documents={docs.data} />
+}
 
 export default function Monitoring() {
-  const [activeTab, setActiveTab] = useState<"overview" | "mastery">("overview")
-  const [overviewState, setOverviewState] = useState<SectionState<MonitoringOverview | null>>(
-    initSection(null),
-  )
-  const [tracesState, setTracesState] = useState<SectionState<TracesResponse>>(
-    initSection({ traces: [] }),
-  )
-  const [evalRunsState, setEvalRunsState] = useState<SectionState<EvalRun[]>>(initSection([]))
-  const [evalHistState, setEvalHistState] = useState<SectionState<EvalHistoryItem[]>>(
-    initSection([]),
-  )
-  const [modelUsageState, setModelUsageState] = useState<SectionState<ModelUsageItem[]>>(
-    initSection([]),
-  )
-  const [llmState, setLlmState] = useState<SectionState<LLMSettings | null>>(initSection(null))
-  const [docsState, setDocsState] = useState<SectionState<Document[]>>(initSection([]))
-  const [phoenixUrlState, setPhoenixUrlState] = useState<SectionState<PhoenixUrl | null>>(
-    initSection(null),
-  )
-
-  const [selectedTrace, setSelectedTrace] = useState<TraceItem | null>(null)
+  const [activeTab, setActiveTab] = useState<TabId>(() => {
+    const hash = window.location.hash.replace("#", "") as TabId
+    return TABS.some((t) => t.id === hash) ? hash : "overview"
+  })
 
   useEffect(() => {
-    let cancelled = false
-
-    fetchOverview()
-      .then((d) => {
-        if (!cancelled) setOverviewState({ loading: false, data: d, error: false })
-      })
-      .catch((e: unknown) => {
-        logger.warn("[Monitoring] section failed", "System Status", e)
-        if (!cancelled) setOverviewState({ loading: false, data: null, error: true })
-      })
-
-    fetchTraces()
-      .then((d) => {
-        if (!cancelled) setTracesState({ loading: false, data: d, error: false })
-      })
-      .catch((e: unknown) => {
-        logger.warn("[Monitoring] section failed", "Recent Traces", e)
-        if (!cancelled) setTracesState({ loading: false, data: { traces: [] }, error: true })
-      })
-
-    fetchEvalRuns()
-      .then((d) => {
-        if (!cancelled) setEvalRunsState({ loading: false, data: d, error: false })
-      })
-      .catch((e: unknown) => {
-        logger.warn("[Monitoring] section failed", "Eval Runs", e)
-        if (!cancelled) setEvalRunsState({ loading: false, data: [], error: true })
-      })
-
-    fetchEvalHistory()
-      .then((d) => {
-        if (!cancelled) setEvalHistState({ loading: false, data: d, error: false })
-      })
-      .catch((e: unknown) => {
-        logger.warn("[Monitoring] section failed", "Eval History", e)
-        if (!cancelled) setEvalHistState({ loading: false, data: [], error: true })
-      })
-
-    fetchModelUsage()
-      .then((d) => {
-        if (!cancelled) setModelUsageState({ loading: false, data: d, error: false })
-      })
-      .catch((e: unknown) => {
-        logger.warn("[Monitoring] section failed", "Model Usage", e)
-        if (!cancelled) setModelUsageState({ loading: false, data: [], error: true })
-      })
-
-    fetchLLMSettings()
-      .then((d) => {
-        if (!cancelled) setLlmState({ loading: false, data: d, error: false })
-      })
-      .catch((e: unknown) => {
-        logger.warn("[Monitoring] section failed", "LLM Settings", e)
-        if (!cancelled) setLlmState({ loading: false, data: null, error: true })
-      })
-
-    fetchDocuments()
-      .then((d) => {
-        if (!cancelled) setDocsState({ loading: false, data: d, error: false })
-      })
-      .catch((e: unknown) => {
-        logger.warn("[Monitoring] section failed", "Ingestion Queue", e)
-        if (!cancelled) setDocsState({ loading: false, data: [], error: true })
-      })
-
-    const loadPhoenixUrl = () => {
-      fetchPhoenixUrl()
-        .then((d) => {
-          if (!cancelled) setPhoenixUrlState({ loading: false, data: d, error: false })
-        })
-        .catch((e: unknown) => {
-          logger.warn("[Monitoring] section failed", "Phoenix URL", e)
-          if (!cancelled) setPhoenixUrlState({ loading: false, data: null, error: true })
-        })
-    }
-    loadPhoenixUrl()
-    const phoenixInterval = setInterval(loadPhoenixUrl, 30_000)
-
-    return () => {
-      cancelled = true
-      clearInterval(phoenixInterval)
-    }
-  }, [])
-
-  const ollamaOnline = llmState.data?.processing_mode === "local"
-  const activeModel = llmState.data?.active_model ?? overviewState.data?.llm_status ?? "—"
-  const ingestingDocs = docsState.data.filter((d) => d.stage !== "complete")
+    window.history.replaceState(null, "", `#${activeTab}`)
+  }, [activeTab])
 
   return (
     <div className="flex flex-col gap-8 px-6 py-8">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold text-foreground">Monitoring</h1>
-        {/* Tab bar */}
         <div className="flex gap-1 rounded-lg border border-border bg-secondary p-1">
-          {(["overview", "mastery"] as const).map((tab) => (
+          {TABS.map((tab) => (
             <button
-              key={tab}
-              onClick={() => setActiveTab(tab)}
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
               className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
-                activeTab === tab
+                activeTab === tab.id
                   ? "bg-background text-foreground shadow-sm"
                   : "text-muted-foreground hover:text-foreground"
               }`}
             >
-              {tab === "overview" ? "Overview" : "Mastery"}
+              {tab.label}
             </button>
           ))}
         </div>
       </div>
 
-      {/* Mastery tab */}
-      {activeTab === "mastery" && (
-        <MasteryPanel documents={docsState.data} />
-      )}
-
-      {/* Overview tab sections -- hidden when mastery tab is active */}
       {activeTab === "overview" && (
-        <>
-      {/* 0. Traces link card */}
-      <section className="flex flex-col gap-2">
-        <h2 className="text-lg font-semibold text-foreground">Traces</h2>
-        {phoenixUrlState.loading ? (
-          <Skeleton className="h-12 w-full rounded-lg" />
-        ) : phoenixUrlState.error ? (
-          <div className="flex h-12 items-center justify-center rounded-lg border border-red-200 bg-red-50 text-sm text-red-600">
-            Could not check Phoenix status.
-          </div>
-        ) : (
-          <TracesCard phoenix={phoenixUrlState.data} />
-        )}
-      </section>
-
-      {/* 1. System Status */}
-      <section className="flex flex-col gap-3">
-        <h2 className="text-lg font-semibold text-foreground">System Status</h2>
-        {overviewState.loading || llmState.loading ? (
-          <MetricCardSkeleton />
-        ) : overviewState.error && llmState.error ? (
-          <SectionErrorCard name="System Status" />
-        ) : (
-          <>
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-              <StatusIndicator ok={ollamaOnline} label="Ollama" />
-              <StatusIndicator ok={overviewState.data?.phoenix_running ?? false} label="Phoenix" />
-              <StatusIndicator ok={overviewState.data?.langfuse_configured ?? false} label="Langfuse" />
-              <ModelBadge model={activeModel} />
-            </div>
-            {overviewState.data && (
-              <div className="grid grid-cols-3 gap-3">
-                <div className="flex flex-col gap-0.5 rounded-lg border border-border bg-card px-4 py-3">
-                  <span className="text-lg font-bold text-foreground">{overviewState.data.total_documents}</span>
-                  <span className="text-xs text-muted-foreground">Documents</span>
-                </div>
-                <div className="flex flex-col gap-0.5 rounded-lg border border-border bg-card px-4 py-3">
-                  <span className="text-lg font-bold text-foreground">{overviewState.data.total_chunks}</span>
-                  <span className="text-xs text-muted-foreground">Chunks</span>
-                </div>
-                <div className="flex flex-col gap-0.5 rounded-lg border border-border bg-card px-4 py-3">
-                  <span className="text-lg font-bold text-foreground">{overviewState.data.qa_calls_today}</span>
-                  <span className="text-xs text-muted-foreground">QA calls today</span>
-                </div>
-              </div>
-            )}
-          </>
-        )}
-      </section>
-
-      {/* 2. RAG Quality */}
-      <section className="flex flex-col gap-3">
-        <h2 className="text-lg font-semibold text-foreground">RAG Quality</h2>
-        {evalRunsState.loading ? (
-          <SectionSkeleton rows={4} />
-        ) : evalRunsState.error ? (
-          <SectionErrorCard name="RAG Quality" />
-        ) : (
-          <RAGQualityChart evalRuns={evalRunsState.data} />
-        )}
-      </section>
-
-      {/* 3. HR@5 Over Time */}
-      <section className="flex flex-col gap-3">
-        <h2 className="text-lg font-semibold text-foreground">Retrieval Quality Over Time</h2>
-        <p className="text-xs text-muted-foreground">HR@5 per dataset across eval runs. Dashed line = 0.60 threshold.</p>
-        {evalHistState.loading ? (
-          <SectionSkeleton rows={3} />
-        ) : evalHistState.error ? (
-          <SectionErrorCard name="Retrieval Quality Over Time" />
-        ) : (
-          <EvalHistorySparkline history={evalHistState.data} />
-        )}
-      </section>
-
-      <section className="flex flex-col gap-3">
-        {evalHistState.loading ? (
-          <SectionSkeleton rows={3} />
-        ) : evalHistState.error ? (
-          <SectionErrorCard name="Eval Trends" />
-        ) : (
-          <EvalTrendsPanel history={evalHistState.data} />
-        )}
-      </section>
-
-      {/* 4. Model Usage */}
-      <section className="flex flex-col gap-3">
-        <h2 className="text-lg font-semibold text-foreground">Model Usage</h2>
-        {modelUsageState.loading ? (
-          <SectionSkeleton rows={3} />
-        ) : modelUsageState.error ? (
-          <SectionErrorCard name="Model Usage" />
-        ) : (
-          <ModelUsageSection modelUsage={modelUsageState.data} />
-        )}
-      </section>
-
-      {/* 5. Ingestion Queue */}
-      <section className="flex flex-col gap-3">
-        <h2 className="text-lg font-semibold text-foreground">Ingestion Queue</h2>
-        {docsState.loading ? (
-          <SectionSkeleton rows={2} />
-        ) : docsState.error ? (
-          <SectionErrorCard name="Ingestion Queue" />
-        ) : ingestingDocs.length === 0 ? (
-          <EmptyState message="No documents currently ingesting." />
-        ) : (
-          <div className="flex flex-col gap-1 rounded-lg border border-border">
-            {ingestingDocs.map((doc, i) => (
-              <div
-                key={doc.id}
-                className={`flex items-center justify-between px-4 py-2 text-sm ${
-                  i > 0 ? "border-t border-border" : ""
-                }`}
-              >
-                <span className="font-medium text-foreground">{doc.title}</span>
-                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
-                  {doc.stage}
-                </span>
-              </div>
-            ))}
-          </div>
-        )}
-      </section>
-
-      {/* 6. Recent Traces */}
-      <section className="flex flex-col gap-3">
-        <h2 className="text-lg font-semibold text-foreground">Recent Traces</h2>
-        {tracesState.loading ? (
-          <SectionSkeleton rows={5} />
-        ) : tracesState.error ? (
-          <SectionErrorCard name="Recent Traces" />
-        ) : (
-          <>
-            {tracesState.data.message && (
-              <p className="text-sm text-muted-foreground">{tracesState.data.message}</p>
-            )}
-            {tracesState.data.traces.length === 0 ? (
-              <EmptyState message="No traces available." />
-            ) : (
-              <div className="overflow-auto rounded-lg border border-border">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-border bg-secondary/50">
-                      <th className="px-4 py-2 text-left text-xs font-semibold text-muted-foreground">Timestamp</th>
-                      <th className="px-4 py-2 text-left text-xs font-semibold text-muted-foreground">Operation</th>
-                      <th className="px-4 py-2 text-right text-xs font-semibold text-muted-foreground">Duration</th>
-                      <th className="px-4 py-2 text-center text-xs font-semibold text-muted-foreground">Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {tracesState.data.traces.map((t) => (
-                      <tr
-                        key={t.span_id || `${t.trace_id}-${t.start_time}`}
-                        onClick={() => setSelectedTrace(t)}
-                        className="cursor-pointer border-b border-border last:border-0 hover:bg-accent"
-                      >
-                        <td className="px-4 py-2 text-xs text-muted-foreground">
-                          {t.start_time ? new Date(t.start_time).toLocaleTimeString() : "—"}
-                        </td>
-                        <td className="px-4 py-2 font-medium text-foreground">{t.operation_name}</td>
-                        <td className="px-4 py-2 text-right text-muted-foreground">
-                          {t.duration_ms.toFixed(1)} ms
-                        </td>
-                        <td className="px-4 py-2 text-center">
-                          <StatusBadge status={t.status} />
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </>
-        )}
-      </section>
-
-      {/* 7a. RAGAS Eval Results — from /evals/results */}
-      <section className="flex flex-col gap-3">
-        <h2 className="text-lg font-semibold text-foreground">RAGAS Eval Results</h2>
-        <p className="text-xs text-muted-foreground">
-          Latest result per dataset. Green = meets threshold, amber = close, grey = below. Click Run Eval to trigger a background eval run.
-        </p>
-        <EvalPanel />
-      </section>
-
-      {/* 7b. Eval Runs (legacy /monitoring/evals) */}
-      <section className="flex flex-col gap-3">
-        <h2 className="text-lg font-semibold text-foreground">Eval Runs</h2>
-        {evalRunsState.loading ? (
-          <SectionSkeleton rows={4} />
-        ) : evalRunsState.error ? (
-          <SectionErrorCard name="Eval Runs" />
-        ) : evalRunsState.data.length === 0 ? (
-          <EmptyState message="No evaluation runs yet. Run evals/run_eval.py to populate." />
-        ) : (
-          <div className="overflow-auto rounded-lg border border-border">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border bg-secondary/50">
-                  <th className="px-4 py-2 text-left text-xs font-semibold text-muted-foreground">Dataset</th>
-                  <th className="px-4 py-2 text-left text-xs font-semibold text-muted-foreground">Run At</th>
-                  <th className="px-4 py-2 text-right text-xs font-semibold text-muted-foreground">HR@5</th>
-                  <th className="px-4 py-2 text-right text-xs font-semibold text-muted-foreground">MRR</th>
-                  <th className="px-4 py-2 text-right text-xs font-semibold text-muted-foreground">Faithfulness</th>
-                </tr>
-              </thead>
-              <tbody>
-                {evalRunsState.data.map((run) => {
-                  const hr5 = run.hit_rate_5
-                  const rowBg =
-                    hr5 !== null && hr5 < 0.5
-                      ? "bg-red-50 dark:bg-red-950/30"
-                      : hr5 !== null && hr5 > 0.7
-                        ? "bg-green-50 dark:bg-green-950/30"
-                        : ""
-                  return (
-                    <tr key={run.id} className={`border-b border-border last:border-0 ${rowBg}`}>
-                      <td className="px-4 py-2 font-medium text-foreground">{run.dataset_name}</td>
-                      <td className="px-4 py-2 text-xs text-muted-foreground">
-                        {new Date(run.run_at).toLocaleString()}
-                      </td>
-                      <td className="px-4 py-2 text-right text-foreground">
-                        {hr5 !== null ? hr5.toFixed(2) : "—"}
-                      </td>
-                      <td className="px-4 py-2 text-right text-foreground">
-                        {run.mrr !== null ? run.mrr.toFixed(2) : "—"}
-                      </td>
-                      <td className="px-4 py-2 text-right text-foreground">
-                        {run.faithfulness !== null ? run.faithfulness.toFixed(2) : "—"}
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </section>
-
-      {/* Trace detail panel */}
-      {selectedTrace && (
-        <TraceDetailPanel trace={selectedTrace} onClose={() => setSelectedTrace(null)} />
+        <PanelErrorBoundary name="Overview">
+          <OverviewTab />
+        </PanelErrorBoundary>
       )}
-        </>
+      {activeTab === "traces" && (
+        <PanelErrorBoundary name="Traces">
+          <TracesTab />
+        </PanelErrorBoundary>
+      )}
+      {activeTab === "evals" && (
+        <PanelErrorBoundary name="Evals">
+          <EvalsTab />
+        </PanelErrorBoundary>
+      )}
+      {activeTab === "mastery" && (
+        <PanelErrorBoundary name="Mastery">
+          <MasteryTab />
+        </PanelErrorBoundary>
       )}
     </div>
   )

--- a/frontend/src/pages/Monitoring/Charts.tsx
+++ b/frontend/src/pages/Monitoring/Charts.tsx
@@ -1,19 +1,16 @@
 // Recharts-based visualisations for the Monitoring page:
 //   - EvalHistorySparkline: HR@5 over time per dataset
 //   - RAGQualityChart:      grouped bar chart of last run per dataset
-//   - ModelUsageSection:    Pie (local vs cloud) + Bar (calls/model)
+//   - QAActivityChart:      QA calls per day, trailing week
 //   - TracesCard:           Phoenix link card
 
 import {
   Bar,
   BarChart,
   CartesianGrid,
-  Cell,
   Legend,
   Line,
   LineChart,
-  Pie,
-  PieChart,
   ReferenceLine,
   ResponsiveContainer,
   Tooltip,
@@ -22,12 +19,10 @@ import {
 } from "recharts"
 
 import { EmptyState } from "./SharedUI"
-import type { EvalHistoryItem, EvalRun, ModelUsageItem, PhoenixUrl } from "./types"
+import type { EvalHistoryItem, EvalRun, PhoenixUrl, QADailyCount } from "./types"
 import {
   DATASET_COLORS,
   METRIC_BARS,
-  PIE_COLORS,
-  buildPieData,
   buildRagChartData,
   buildSparklineData,
 } from "./utils"
@@ -116,87 +111,71 @@ export function RAGQualityChart({ evalRuns }: { evalRuns: EvalRun[] }) {
   )
 }
 
-export function ModelUsageSection({ modelUsage }: { modelUsage: ModelUsageItem[] }) {
-  if (modelUsage.length === 0) {
-    return <EmptyState message="No QA calls recorded yet." />
+export function QAActivityChart({ daily }: { daily: QADailyCount[] }) {
+  if (daily.every((d) => d.count === 0)) {
+    return <EmptyState message="No QA activity in the last 7 days. Ask a question to populate." />
   }
-  const pieData = buildPieData(modelUsage)
+  const data = daily.map((d) => ({ ...d, label: d.date.slice(5) }))
   return (
-    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-      {/* PieChart -- local vs cloud */}
-      <div className="flex flex-col gap-2">
-        <p className="text-sm font-medium text-muted-foreground">Local vs Cloud</p>
-        {pieData.length > 0 ? (
-          <ResponsiveContainer width="100%" height={180}>
-            <PieChart>
-              <Pie
-                data={pieData}
-                dataKey="value"
-                nameKey="name"
-                cx="50%"
-                cy="50%"
-                outerRadius={70}
-                label={({ name, percent }: { name?: string; percent?: number }) =>
-                  `${name ?? ""} ${((percent ?? 0) * 100).toFixed(0)}%`
-                }
-              >
-                {pieData.map((_, i) => (
-                  <Cell key={i} fill={PIE_COLORS[i % PIE_COLORS.length]} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
-        ) : (
-          <EmptyState message="No calls recorded." />
-        )}
-      </div>
-
-      {/* BarChart -- calls per model */}
-      <div className="flex flex-col gap-2">
-        <p className="text-sm font-medium text-muted-foreground">Calls by Model</p>
-        <ResponsiveContainer width="100%" height={180}>
-          <BarChart data={modelUsage} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
-            <XAxis dataKey="model" tick={{ fontSize: 10 }} />
-            <YAxis tick={{ fontSize: 10 }} />
-            <Tooltip />
-            <Bar dataKey="call_count" name="Calls" fill="#6366f1" />
-          </BarChart>
-        </ResponsiveContainer>
-      </div>
-    </div>
+    <ResponsiveContainer width="100%" height={160}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
+        <XAxis dataKey="label" tick={{ fontSize: 10 }} />
+        <YAxis allowDecimals={false} tick={{ fontSize: 10 }} width={30} />
+        <Tooltip
+          formatter={(v) => [v ?? 0, "QA calls"]}
+          labelFormatter={(_, payload) => payload?.[0]?.payload?.date ?? ""}
+        />
+        <Bar
+          dataKey="count"
+          name="QA calls"
+          fill="#6366f1"
+          radius={[4, 4, 0, 0]}
+          maxBarSize={28}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ResponsiveContainer>
   )
 }
 
 export function TracesCard({ phoenix }: { phoenix: PhoenixUrl | null }) {
+  const configured = phoenix?.configured ?? false
   const enabled = phoenix?.enabled ?? false
   const url = phoenix?.url ?? "http://localhost:6006"
+  const hint = !configured
+    ? "Tracing is off. Set PHOENIX_ENABLED=true in backend/.env and restart the backend — Phoenix launches in-process."
+    : !enabled
+      ? "Phoenix is enabled but not responding yet. It starts with the backend; give it a few seconds or check backend logs."
+      : "Collecting traces for every LLM call, retrieval, and ingestion run."
   return (
-    <div className="flex items-center justify-between rounded-lg border border-border bg-card px-4 py-3">
-      <div className="flex items-center gap-2">
-        <span
-          className={`inline-block h-2.5 w-2.5 rounded-full ${enabled ? "bg-green-500" : "bg-gray-400"}`}
-        />
-        <span className="text-sm font-medium text-foreground">
-          Arize Phoenix — Distributed Tracing
+    <div className="flex items-center justify-between gap-4 rounded-lg border border-border bg-card px-4 py-3">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <div className="flex items-center gap-2">
+          <span
+            className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${
+              enabled ? "bg-green-500" : configured ? "bg-amber-500" : "bg-gray-400"
+            }`}
+          />
+          <span className="text-sm font-medium text-foreground">
+            Arize Phoenix — Distributed Tracing
+          </span>
+        </div>
+        <span className="truncate pl-[18px] text-xs text-muted-foreground" title={hint}>
+          {hint}
         </span>
       </div>
       <button
         disabled={!enabled}
         onClick={() => window.open(url, "_blank")}
-        title={
-          enabled
-            ? "Open Phoenix UI"
-            : "Start Phoenix: cd backend && uv run python -m phoenix.server.main"
-        }
-        className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
+        title={enabled ? "Open Phoenix UI" : hint}
+        className={`shrink-0 rounded px-3 py-1 text-xs font-medium transition-colors ${
           enabled
             ? "bg-primary text-primary-foreground hover:bg-primary/90"
             : "cursor-not-allowed bg-secondary text-muted-foreground"
         }`}
       >
-        View Traces
+        Open Phoenix
       </button>
     </div>
   )

--- a/frontend/src/pages/Monitoring/EvalsTab.tsx
+++ b/frontend/src/pages/Monitoring/EvalsTab.tsx
@@ -1,0 +1,119 @@
+// Evals tab: consolidates the four eval surfaces that previously
+// stacked on one scroll -- latest-run bar chart, HR@5 history, metric
+// trends, RAGAS results with run trigger, and the raw runs table.
+
+import { EvalTrendsPanel } from "@/components/EvalTrendsPanel"
+
+import { EvalHistorySparkline, RAGQualityChart } from "./Charts"
+import { EvalPanel } from "./EvalPanel"
+import { EmptyState, SectionErrorCard, SectionSkeleton } from "./SharedUI"
+import { fetchEvalHistory, fetchEvalRuns } from "./api"
+import type { EvalHistoryItem, EvalRun } from "./types"
+import { useSection } from "./useSection"
+
+export function EvalsTab() {
+  const evalRuns = useSection<EvalRun[]>("Eval Runs", fetchEvalRuns, [])
+  const evalHist = useSection<EvalHistoryItem[]>("Eval History", fetchEvalHistory, [])
+
+  return (
+    <div className="flex flex-col gap-8">
+      <section className="flex flex-col gap-3">
+        <h2 className="text-lg font-semibold text-foreground">RAG Quality</h2>
+        <p className="text-xs text-muted-foreground">Latest run per dataset.</p>
+        {evalRuns.loading ? (
+          <SectionSkeleton rows={4} />
+        ) : evalRuns.error ? (
+          <SectionErrorCard name="RAG Quality" />
+        ) : (
+          <RAGQualityChart evalRuns={evalRuns.data} />
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-lg font-semibold text-foreground">Retrieval Quality Over Time</h2>
+        <p className="text-xs text-muted-foreground">
+          HR@5 per dataset across eval runs. Dashed line = 0.60 threshold.
+        </p>
+        {evalHist.loading ? (
+          <SectionSkeleton rows={3} />
+        ) : evalHist.error ? (
+          <SectionErrorCard name="Retrieval Quality Over Time" />
+        ) : (
+          <EvalHistorySparkline history={evalHist.data} />
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        {evalHist.loading ? (
+          <SectionSkeleton rows={3} />
+        ) : evalHist.error ? (
+          <SectionErrorCard name="Eval Trends" />
+        ) : (
+          <EvalTrendsPanel history={evalHist.data} />
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-lg font-semibold text-foreground">RAGAS Eval Results</h2>
+        <p className="text-xs text-muted-foreground">
+          Latest result per dataset. Green = meets threshold, amber = close, grey = below. Click
+          Run Eval to trigger a background eval run.
+        </p>
+        <EvalPanel />
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-lg font-semibold text-foreground">Eval Runs</h2>
+        {evalRuns.loading ? (
+          <SectionSkeleton rows={4} />
+        ) : evalRuns.error ? (
+          <SectionErrorCard name="Eval Runs" />
+        ) : evalRuns.data.length === 0 ? (
+          <EmptyState message="No evaluation runs yet. Run evals/run_eval.py to populate." />
+        ) : (
+          <div className="overflow-auto rounded-lg border border-border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border bg-secondary/50">
+                  <th className="px-4 py-2 text-left text-xs font-semibold text-muted-foreground">Dataset</th>
+                  <th className="px-4 py-2 text-left text-xs font-semibold text-muted-foreground">Run At</th>
+                  <th className="px-4 py-2 text-right text-xs font-semibold text-muted-foreground">HR@5</th>
+                  <th className="px-4 py-2 text-right text-xs font-semibold text-muted-foreground">MRR</th>
+                  <th className="px-4 py-2 text-right text-xs font-semibold text-muted-foreground">Faithfulness</th>
+                </tr>
+              </thead>
+              <tbody>
+                {evalRuns.data.map((run) => {
+                  const hr5 = run.hit_rate_5
+                  const rowBg =
+                    hr5 != null && hr5 < 0.5
+                      ? "bg-red-50 dark:bg-red-950/30"
+                      : hr5 != null && hr5 > 0.7
+                        ? "bg-green-50 dark:bg-green-950/30"
+                        : ""
+                  return (
+                    <tr key={run.id} className={`border-b border-border last:border-0 ${rowBg}`}>
+                      <td className="px-4 py-2 font-medium text-foreground">{run.dataset_name}</td>
+                      <td className="px-4 py-2 text-xs text-muted-foreground">
+                        {new Date(run.run_at).toLocaleString()}
+                      </td>
+                      <td className="px-4 py-2 text-right text-foreground">
+                        {hr5 != null ? hr5.toFixed(2) : "—"}
+                      </td>
+                      <td className="px-4 py-2 text-right text-foreground">
+                        {run.mrr != null ? run.mrr.toFixed(2) : "—"}
+                      </td>
+                      <td className="px-4 py-2 text-right text-foreground">
+                        {run.faithfulness != null ? run.faithfulness.toFixed(2) : "—"}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/pages/Monitoring/MasteryPanel.tsx
+++ b/frontend/src/pages/Monitoring/MasteryPanel.tsx
@@ -1,11 +1,10 @@
 // MasteryPanel -- Concept mastery heatmap + weak-spots list +
 // "no flashcards yet" chips, scoped to a single document chosen via a
-// header dropdown.
+// header dropdown. The data block is keyed by document id so switching
+// documents remounts it with fresh loading state (no setState-in-effect).
 
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
-
-import { logger } from "@/lib/logger"
 
 import { fetchMasteryConcepts, fetchMasteryHeatmap } from "./api"
 import {
@@ -17,72 +16,24 @@ import type {
   Document,
   MasteryConceptsResponse,
   MasteryHeatmapResponse,
-  SectionState,
 } from "./types"
-import { initSection } from "./types"
+import { useSection } from "./useSection"
 import { masteryColor } from "./utils"
 
 export function MasteryPanel({ documents }: { documents: Document[] }) {
-  const [selectedDocId, setSelectedDocId] = useState<string>(documents[0]?.id ?? "")
-  const [conceptsState, setConceptsState] = useState<
-    SectionState<MasteryConceptsResponse | null>
-  >(initSection(null))
-  const [heatmapState, setHeatmapState] = useState<
-    SectionState<MasteryHeatmapResponse | null>
-  >(initSection(null))
-
-  // When documents load after mount (selectedDocId is ""), auto-select the first
-  useEffect(() => {
-    if (!selectedDocId && documents.length > 0) {
-      setSelectedDocId(documents[0].id)
-    }
-  }, [documents, selectedDocId])
-
-  useEffect(() => {
-    if (!selectedDocId) return
-    let cancelled = false
-    setConceptsState(initSection(null))
-    setHeatmapState(initSection(null))
-
-    fetchMasteryConcepts([selectedDocId])
-      .then((d) => {
-        if (!cancelled) setConceptsState({ loading: false, data: d, error: false })
-      })
-      .catch((e: unknown) => {
-        logger.warn("[Monitoring] mastery/concepts failed", e)
-        if (!cancelled) setConceptsState({ loading: false, data: null, error: true })
-      })
-
-    fetchMasteryHeatmap(selectedDocId)
-      .then((d) => {
-        if (!cancelled) setHeatmapState({ loading: false, data: d, error: false })
-      })
-      .catch((e: unknown) => {
-        logger.warn("[Monitoring] mastery/heatmap failed", e)
-        if (!cancelled) setHeatmapState({ loading: false, data: null, error: true })
-      })
-
-    return () => {
-      cancelled = true
-    }
-  }, [selectedDocId])
+  const [selectedDocId, setSelectedDocId] = useState<string>("")
+  const docId = selectedDocId || documents[0]?.id || ""
 
   if (documents.length === 0) {
     return <EmptyState message="No documents yet. Ingest a document to see mastery data." />
   }
 
-  const concepts = conceptsState.data?.concepts ?? []
-  const heatmap = heatmapState.data
-  const weakSpots = concepts.filter((c) => c.mastery < 0.4 && c.card_count >= 1).slice(0, 5)
-  const noCards = concepts.filter((c) => c.no_flashcards).slice(0, 5)
-
   return (
     <div className="flex flex-col gap-6">
-      {/* Document selector */}
       <div className="flex items-center gap-3">
         <label className="text-sm font-medium text-foreground">Document:</label>
         <select
-          value={selectedDocId}
+          value={docId}
           onChange={(e) => setSelectedDocId(e.target.value)}
           className="rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground"
         >
@@ -94,6 +45,30 @@ export function MasteryPanel({ documents }: { documents: Document[] }) {
         </select>
       </div>
 
+      {docId && <MasteryData key={docId} docId={docId} />}
+    </div>
+  )
+}
+
+function MasteryData({ docId }: { docId: string }) {
+  const conceptsState = useSection<MasteryConceptsResponse | null>(
+    "Mastery Concepts",
+    () => fetchMasteryConcepts([docId]),
+    null,
+  )
+  const heatmapState = useSection<MasteryHeatmapResponse | null>(
+    "Mastery Heatmap",
+    () => fetchMasteryHeatmap(docId),
+    null,
+  )
+
+  const concepts = conceptsState.data?.concepts ?? []
+  const heatmap = heatmapState.data
+  const weakSpots = concepts.filter((c) => c.mastery < 0.4 && c.card_count >= 1).slice(0, 5)
+  const noCards = concepts.filter((c) => c.no_flashcards).slice(0, 5)
+
+  return (
+    <>
       {/* Heatmap */}
       <section className="flex flex-col gap-3">
         <h2 className="text-lg font-semibold text-foreground">Concept Mastery Heatmap</h2>
@@ -182,7 +157,7 @@ export function MasteryPanel({ documents }: { documents: Document[] }) {
                   <span>{(c.mastery * 100).toFixed(0)}% mastery</span>
                   <span>{c.card_count} cards</span>
                   {c.due_soon > 0 && (
-                    <span className="rounded bg-amber-100 px-2 py-0.5 text-xs text-amber-700">
+                    <span className="rounded bg-amber-100 px-2 py-0.5 text-xs text-amber-700 dark:bg-amber-950/60 dark:text-amber-400">
                       {c.due_soon} due soon
                     </span>
                   )}
@@ -218,6 +193,6 @@ export function MasteryPanel({ documents }: { documents: Document[] }) {
           </div>
         </section>
       )}
-    </div>
+    </>
   )
 }

--- a/frontend/src/pages/Monitoring/OverviewTab.tsx
+++ b/frontend/src/pages/Monitoring/OverviewTab.tsx
@@ -1,0 +1,170 @@
+// Overview tab: system status pills (tri-state -- a deliberately disabled
+// integration renders neutral, not as an alarming "Offline"), corpus
+// counts, span-derived performance metrics, QA activity trend, and the
+// ingestion queue. Model configuration lives in Settings; per-model call
+// counts live on the Admin page -- neither is repeated here.
+
+import { QAActivityChart } from "./Charts"
+import {
+  EmptyState,
+  KindChip,
+  MetricCardSkeleton,
+  SectionErrorCard,
+  SectionSkeleton,
+  StatCard,
+  StatusPill,
+} from "./SharedUI"
+import { fetchDocuments, fetchLLMSettings, fetchMetrics, fetchOverview } from "./api"
+import type { Document, LLMSettings, MonitoringMetrics, MonitoringOverview } from "./types"
+import { useSection } from "./useSection"
+import { formatCount, formatDuration } from "./utils"
+
+export function OverviewTab() {
+  const overview = useSection<MonitoringOverview | null>("System Status", fetchOverview, null, 30_000)
+  const llm = useSection<LLMSettings | null>("LLM Settings", fetchLLMSettings, null)
+  const metrics = useSection<MonitoringMetrics | null>("Performance", fetchMetrics, null, 30_000)
+  const docs = useSection<Document[]>("Ingestion Queue", fetchDocuments, [], 15_000)
+
+  // ollama_reachable is a real health probe; processing_mode alone only
+  // says which mode is configured.
+  const ollamaState =
+    llm.data == null
+      ? "disabled"
+      : (llm.data.ollama_reachable ?? llm.data.processing_mode === "local")
+        ? "online"
+        : "offline"
+  const phoenixState = !overview.data?.phoenix_configured
+    ? "disabled"
+    : overview.data.phoenix_running
+      ? "online"
+      : "offline"
+  const langfuseState = overview.data?.langfuse_configured ? "online" : "disabled"
+  const ingestingDocs = docs.data.filter((d) => d.stage !== "complete")
+  const m = metrics.data
+
+  return (
+    <div className="flex flex-col gap-8">
+      <section className="flex flex-col gap-3">
+        <h2 className="text-lg font-semibold text-foreground">System Status</h2>
+        {overview.loading || llm.loading ? (
+          <MetricCardSkeleton />
+        ) : overview.error && llm.error ? (
+          <SectionErrorCard name="System Status" />
+        ) : (
+          <>
+            <div className="grid grid-cols-3 gap-3">
+              <StatusPill state={ollamaState} label="Ollama" />
+              <StatusPill
+                state={phoenixState}
+                label="Phoenix Tracing"
+                detail={
+                  phoenixState === "disabled"
+                    ? "Set PHOENIX_ENABLED=true in backend/.env to enable tracing"
+                    : undefined
+                }
+              />
+              <StatusPill
+                state={langfuseState}
+                label="Langfuse"
+                detail={
+                  langfuseState === "disabled" ? "No LANGFUSE_PUBLIC_KEY configured" : undefined
+                }
+              />
+            </div>
+            {overview.data && (
+              <div className="grid grid-cols-3 gap-3">
+                <StatCard value={overview.data.total_documents} label="Documents" />
+                <StatCard value={overview.data.total_chunks} label="Chunks" />
+                <StatCard value={overview.data.qa_calls_today} label="QA calls today" />
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-lg font-semibold text-foreground">Performance</h2>
+        <p className="text-xs text-muted-foreground">
+          Computed from the most recent traced operations (up to 200 spans).
+        </p>
+        {metrics.loading ? (
+          <MetricCardSkeleton />
+        ) : metrics.error ? (
+          <SectionErrorCard name="Performance" />
+        ) : !m ? null : !m.phoenix_available ? (
+          <EmptyState message="Latency, error, and token metrics need tracing. Set PHOENIX_ENABLED=true in backend/.env and restart the backend." />
+        ) : m.spans_sampled === 0 ? (
+          <EmptyState message="No traced operations yet. Ask a question or ingest a document." />
+        ) : (
+          <>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <StatCard
+                value={m.latency_p50_ms != null ? formatDuration(m.latency_p50_ms) : "—"}
+                label="Latency p50"
+              />
+              <StatCard
+                value={m.latency_p95_ms != null ? formatDuration(m.latency_p95_ms) : "—"}
+                label="Latency p95"
+              />
+              <StatCard
+                value={m.error_rate != null ? `${(m.error_rate * 100).toFixed(1)}%` : "—"}
+                label={`Error rate (${m.error_count} of ${m.spans_sampled} spans)`}
+              />
+              <StatCard
+                value={`${formatCount(m.llm_prompt_tokens)} in / ${formatCount(m.llm_completion_tokens)} out`}
+                label={`LLM tokens (${m.llm_calls} calls)`}
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span>Spans by kind:</span>
+              {Object.entries(m.spans_by_kind).map(([kind, count]) => (
+                <span key={kind} className="flex items-center gap-1">
+                  <KindChip kind={kind} />
+                  <span className="text-foreground">{count}</span>
+                </span>
+              ))}
+            </div>
+          </>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-lg font-semibold text-foreground">QA Activity (7 days)</h2>
+        {metrics.loading ? (
+          <SectionSkeleton rows={2} />
+        ) : metrics.error ? (
+          <SectionErrorCard name="QA Activity" />
+        ) : m ? (
+          <QAActivityChart daily={m.qa_daily} />
+        ) : null}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-lg font-semibold text-foreground">Ingestion Queue</h2>
+        {docs.loading ? (
+          <SectionSkeleton rows={2} />
+        ) : docs.error ? (
+          <SectionErrorCard name="Ingestion Queue" />
+        ) : ingestingDocs.length === 0 ? (
+          <EmptyState message="No documents currently ingesting." />
+        ) : (
+          <div className="flex flex-col gap-1 rounded-lg border border-border">
+            {ingestingDocs.map((doc, i) => (
+              <div
+                key={doc.id}
+                className={`flex items-center justify-between px-4 py-2 text-sm ${
+                  i > 0 ? "border-t border-border" : ""
+                }`}
+              >
+                <span className="font-medium text-foreground">{doc.title}</span>
+                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-950/60 dark:text-amber-400">
+                  {doc.stage}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/pages/Monitoring/SharedUI.tsx
+++ b/frontend/src/pages/Monitoring/SharedUI.tsx
@@ -1,48 +1,99 @@
 // Small shared UI primitives for the Monitoring page: status pills,
-// section error / empty / skeleton states, and the trace detail
-// drawer. Each is pure presentation, no fetch or local state beyond
-// what the trace drawer's onClose requires.
+// section error / empty / skeleton states, span-kind chips, and the
+// trace detail drawer. Each is pure presentation.
 
-import { X as XIcon } from "lucide-react"
+import { Component, type ReactNode } from "react"
+
+import { ExternalLink, X as XIcon } from "lucide-react"
 
 import { Skeleton } from "@/components/ui/skeleton"
 
+import { logger } from "@/lib/logger"
+
 import type { TraceItem } from "./types"
 
+// A rendering bug in one panel must degrade that panel, not unmount
+// the page (invariant I-10: no blank panels).
+export class PanelErrorBoundary extends Component<
+  { name: string; children: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false }
+
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+
+  componentDidCatch(error: unknown) {
+    logger.warn("[Monitoring] panel crashed", this.props.name, error)
+  }
+
+  render() {
+    if (this.state.failed) return <SectionErrorCard name={this.props.name} />
+    return this.props.children
+  }
+}
+
 export function StatusBadge({ status }: { status: string }) {
-  const isError = status === "error"
+  const cls =
+    status === "error"
+      ? "bg-red-100 text-red-700 dark:bg-red-950/60 dark:text-red-400"
+      : status === "ok"
+        ? "bg-green-100 text-green-700 dark:bg-green-950/60 dark:text-green-400"
+        : "bg-secondary text-muted-foreground"
   return (
-    <span
-      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-        isError ? "bg-red-100 text-red-700" : "bg-green-100 text-green-700"
-      }`}
-    >
-      {isError ? "error" : "ok"}
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${cls}`}>
+      {status || "unset"}
     </span>
   )
 }
 
-export function StatusIndicator({ ok, label }: { ok: boolean; label: string }) {
+const KIND_COLORS: Record<string, string> = {
+  CHAIN: "bg-indigo-100 text-indigo-700 dark:bg-indigo-950/60 dark:text-indigo-400",
+  LLM: "bg-violet-100 text-violet-700 dark:bg-violet-950/60 dark:text-violet-400",
+  RETRIEVER: "bg-sky-100 text-sky-700 dark:bg-sky-950/60 dark:text-sky-400",
+  EMBEDDING: "bg-teal-100 text-teal-700 dark:bg-teal-950/60 dark:text-teal-400",
+  TOOL: "bg-amber-100 text-amber-700 dark:bg-amber-950/60 dark:text-amber-400",
+  AGENT: "bg-pink-100 text-pink-700 dark:bg-pink-950/60 dark:text-pink-400",
+}
+
+export function KindChip({ kind }: { kind: string }) {
+  const cls = KIND_COLORS[kind] ?? "bg-secondary text-muted-foreground"
   return (
-    <div className="flex flex-col gap-1 rounded-lg border border-border bg-card p-3">
+    <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide ${cls}`}>
+      {kind}
+    </span>
+  )
+}
+
+export type PillState = "online" | "offline" | "disabled"
+
+export function StatusPill({ state, label, detail }: { state: PillState; label: string; detail?: string }) {
+  const dot =
+    state === "online" ? "bg-green-500" : state === "offline" ? "bg-red-500" : "bg-gray-400"
+  const text =
+    state === "online"
+      ? "text-green-700 dark:text-green-400"
+      : state === "offline"
+        ? "text-red-600 dark:text-red-400"
+        : "text-muted-foreground"
+  const caption = state === "online" ? "Online" : state === "offline" ? "Offline" : "Disabled"
+  return (
+    <div className="flex flex-col gap-1 rounded-lg border border-border bg-card p-3" title={detail}>
       <div className="flex items-center gap-2">
-        <span
-          className={`inline-block h-2.5 w-2.5 rounded-full ${ok ? "bg-green-500" : "bg-red-500"}`}
-        />
-        <span className={`text-sm font-semibold ${ok ? "text-green-700" : "text-red-600"}`}>
-          {ok ? "Online" : "Offline"}
-        </span>
+        <span className={`inline-block h-2.5 w-2.5 rounded-full ${dot}`} />
+        <span className={`text-sm font-semibold ${text}`}>{caption}</span>
       </div>
       <span className="text-xs text-muted-foreground">{label}</span>
     </div>
   )
 }
 
-export function ModelBadge({ model }: { model: string }) {
+export function StatCard({ value, label }: { value: string | number; label: string }) {
   return (
-    <div className="flex flex-col gap-1 rounded-lg border border-border bg-card p-3">
-      <span className="truncate text-sm font-semibold text-foreground">{model}</span>
-      <span className="text-xs text-muted-foreground">Active Model</span>
+    <div className="flex flex-col gap-0.5 rounded-lg border border-border bg-card px-4 py-3">
+      <span className="text-lg font-bold text-foreground">{value}</span>
+      <span className="text-xs text-muted-foreground">{label}</span>
     </div>
   )
 }
@@ -57,7 +108,7 @@ export function EmptyState({ message }: { message: string }) {
 
 export function SectionErrorCard({ name }: { name: string }) {
   return (
-    <div className="flex h-24 items-center justify-center rounded-lg border border-red-200 bg-red-50 text-sm text-red-600">
+    <div className="flex h-24 items-center justify-center rounded-lg border border-red-200 bg-red-50 text-sm text-red-600 dark:border-red-900 dark:bg-red-950/40 dark:text-red-400">
       Could not load {name}
     </div>
   )
@@ -85,9 +136,11 @@ export function MetricCardSkeleton() {
 
 export function TraceDetailPanel({
   trace,
+  phoenixUrl,
   onClose,
 }: {
   trace: TraceItem
+  phoenixUrl?: string
   onClose: () => void
 }) {
   return (
@@ -96,18 +149,35 @@ export function TraceDetailPanel({
       <div className="relative z-10 flex h-full w-full max-w-lg flex-col bg-background shadow-xl">
         <div className="flex items-center justify-between border-b border-border px-4 py-3">
           <h3 className="font-semibold text-foreground">Span Details</h3>
-          <button
-            onClick={onClose}
-            className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-          >
-            <XIcon size={16} />
-          </button>
+          <div className="flex items-center gap-2">
+            {phoenixUrl && (
+              <a
+                href={phoenixUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <ExternalLink size={12} />
+                Open in Phoenix
+              </a>
+            )}
+            <button
+              onClick={onClose}
+              className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <XIcon size={16} />
+            </button>
+          </div>
         </div>
         <div className="flex-1 overflow-auto p-4">
           <div className="mb-4 flex flex-col gap-1 text-sm">
             <div className="flex justify-between">
               <span className="text-muted-foreground">Operation</span>
               <span className="font-medium text-foreground">{trace.operation_name}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Kind</span>
+              <KindChip kind={trace.span_kind ?? "UNKNOWN"} />
             </div>
             <div className="flex justify-between">
               <span className="text-muted-foreground">Span ID</span>
@@ -117,6 +187,12 @@ export function TraceDetailPanel({
               <span className="text-muted-foreground">Trace ID</span>
               <span className="font-mono text-xs text-foreground">{trace.trace_id}</span>
             </div>
+            {trace.parent_id && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Parent span</span>
+                <span className="font-mono text-xs text-foreground">{trace.parent_id}</span>
+              </div>
+            )}
             <div className="flex justify-between">
               <span className="text-muted-foreground">Duration</span>
               <span className="text-foreground">{trace.duration_ms.toFixed(1)} ms</span>
@@ -125,6 +201,14 @@ export function TraceDetailPanel({
               <span className="text-muted-foreground">Status</span>
               <StatusBadge status={trace.status} />
             </div>
+            {trace.status_message ? (
+              <div className="flex justify-between gap-4">
+                <span className="shrink-0 text-muted-foreground">Message</span>
+                <span className="text-right text-xs text-red-600 dark:text-red-400">
+                  {trace.status_message}
+                </span>
+              </div>
+            ) : null}
             <div className="flex justify-between">
               <span className="text-muted-foreground">Start time</span>
               <span className="text-foreground">

--- a/frontend/src/pages/Monitoring/TracesTab.tsx
+++ b/frontend/src/pages/Monitoring/TracesTab.tsx
@@ -1,0 +1,123 @@
+// Traces tab: Phoenix link card + live span table. Spans auto-refresh
+// every 15 s (silently -- stale data stays visible if a refresh fails)
+// with a manual refresh button as well.
+
+import { useState } from "react"
+
+import { RefreshCw } from "lucide-react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+
+import { TracesCard } from "./Charts"
+import {
+  EmptyState,
+  KindChip,
+  SectionErrorCard,
+  SectionSkeleton,
+  StatusBadge,
+  TraceDetailPanel,
+} from "./SharedUI"
+import { fetchPhoenixUrl, fetchTraces } from "./api"
+import type { PhoenixUrl, TraceItem, TracesResponse } from "./types"
+import { useSection } from "./useSection"
+import { formatDuration } from "./utils"
+
+export function TracesTab() {
+  const phoenix = useSection<PhoenixUrl | null>("Phoenix URL", fetchPhoenixUrl, null, 30_000)
+  const traces = useSection<TracesResponse>("Recent Traces", fetchTraces, { traces: [] }, 15_000)
+  const [selectedTrace, setSelectedTrace] = useState<TraceItem | null>(null)
+
+  return (
+    <div className="flex flex-col gap-8">
+      <section className="flex flex-col gap-2">
+        {phoenix.loading ? (
+          <Skeleton className="h-16 w-full rounded-lg" />
+        ) : phoenix.error ? (
+          <SectionErrorCard name="Phoenix status" />
+        ) : (
+          <TracesCard phoenix={phoenix.data} />
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-foreground">Recent Spans</h2>
+          <button
+            onClick={() => traces.reload()}
+            title="Refresh now (auto-refreshes every 15 s)"
+            className="flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <RefreshCw size={12} />
+            Refresh
+          </button>
+        </div>
+        {traces.loading ? (
+          <SectionSkeleton rows={5} />
+        ) : traces.error ? (
+          <SectionErrorCard name="Recent Spans" />
+        ) : (
+          <>
+            {traces.data.message && (
+              <p className="text-sm text-muted-foreground">{traces.data.message}</p>
+            )}
+            {traces.data.traces.length === 0 ? (
+              <EmptyState message="No spans yet. Ask a question or ingest a document to generate traces." />
+            ) : (
+              <div className="overflow-auto rounded-lg border border-border">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border bg-secondary/50">
+                      <th className="px-4 py-2 text-left text-xs font-semibold text-muted-foreground">Time</th>
+                      <th className="px-4 py-2 text-left text-xs font-semibold text-muted-foreground">Operation</th>
+                      <th className="px-4 py-2 text-left text-xs font-semibold text-muted-foreground">Kind</th>
+                      <th className="px-4 py-2 text-right text-xs font-semibold text-muted-foreground">Duration</th>
+                      <th className="px-4 py-2 text-center text-xs font-semibold text-muted-foreground">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {traces.data.traces.map((t) => (
+                      <tr
+                        key={t.span_id || `${t.trace_id}-${t.start_time}`}
+                        onClick={() => setSelectedTrace(t)}
+                        className="cursor-pointer border-b border-border last:border-0 hover:bg-accent"
+                      >
+                        <td
+                          className="whitespace-nowrap px-4 py-2 text-xs text-muted-foreground"
+                          title={t.start_time ? new Date(t.start_time).toLocaleString() : undefined}
+                        >
+                          {t.start_time ? new Date(t.start_time).toLocaleTimeString() : "—"}
+                        </td>
+                        <td className="px-4 py-2 font-medium text-foreground">
+                          <span className={t.parent_id ? "pl-4 text-muted-foreground" : ""}>
+                            {t.operation_name}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2">
+                          <KindChip kind={t.span_kind ?? "UNKNOWN"} />
+                        </td>
+                        <td className="whitespace-nowrap px-4 py-2 text-right text-muted-foreground">
+                          {formatDuration(t.duration_ms)}
+                        </td>
+                        <td className="px-4 py-2 text-center">
+                          <StatusBadge status={t.status} />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      {selectedTrace && (
+        <TraceDetailPanel
+          trace={selectedTrace}
+          phoenixUrl={phoenix.data?.enabled ? phoenix.data.url : undefined}
+          onClose={() => setSelectedTrace(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Monitoring/api.ts
+++ b/frontend/src/pages/Monitoring/api.ts
@@ -13,7 +13,7 @@ import type {
   LLMSettings,
   MasteryConceptsResponse,
   MasteryHeatmapResponse,
-  ModelUsageItem,
+  MonitoringMetrics,
   MonitoringOverview,
   PhoenixUrl,
   TracesResponse,
@@ -28,8 +28,8 @@ export const fetchTraces = (): Promise<TracesResponse> =>
 export const fetchEvalRuns = (): Promise<EvalRun[]> =>
   apiGet<EvalRun[]>("/monitoring/evals")
 
-export const fetchModelUsage = (): Promise<ModelUsageItem[]> =>
-  apiGet<ModelUsageItem[]>("/monitoring/model-usage")
+export const fetchMetrics = (): Promise<MonitoringMetrics> =>
+  apiGet<MonitoringMetrics>("/monitoring/metrics")
 
 export const fetchLLMSettings = (): Promise<LLMSettings> =>
   apiGet<LLMSettings>("/settings/llm")
@@ -50,8 +50,14 @@ export const fetchPhoenixUrl = (): Promise<PhoenixUrl> =>
 export const fetchEvalResults = (): Promise<EvalResultItem[]> =>
   apiGet<EvalResultItem[]>("/evals/results")
 
-export const fetchEvalDatasets = (): Promise<string[]> =>
-  apiGet<string[]>("/evals/datasets")
+// /evals/datasets returns GoldenDatasetListItem objects (older builds
+// returned bare strings); EvalPanel only needs the names.
+export async function fetchEvalDatasets(): Promise<string[]> {
+  const data = await apiGet<Array<string | { name?: string }>>("/evals/datasets")
+  return data
+    .map((d) => (typeof d === "string" ? d : (d.name ?? "")))
+    .filter((name) => name.length > 0)
+}
 
 export const triggerEvalRun = (dataset: string): Promise<void> =>
   apiPost<void>("/evals/run", { dataset })

--- a/frontend/src/pages/Monitoring/types.ts
+++ b/frontend/src/pages/Monitoring/types.ts
@@ -7,8 +7,9 @@ import type { components } from "@/types/api"
 export type TraceItem = components["schemas"]["TraceItem"]
 export type TracesResponse = components["schemas"]["TracesResponse"]
 export type MonitoringOverview = components["schemas"]["MonitoringOverview"]
+export type MonitoringMetrics = components["schemas"]["MonitoringMetrics"]
+export type QADailyCount = components["schemas"]["QADailyCount"]
 export type EvalRun = components["schemas"]["EvalRunResponse"]
-export type ModelUsageItem = components["schemas"]["ModelUsageItem"]
 export type EvalHistoryItem = components["schemas"]["EvalHistoryItem"]
 export type EvalResultItem = components["schemas"]["EvalResultItem"]
 export type PhoenixUrl = components["schemas"]["PhoenixUrlResponse"]
@@ -23,6 +24,7 @@ export type MasteryHeatmapResponse = components["schemas"]["MasteryHeatmapOut"]
 export interface LLMSettings {
   processing_mode: string
   active_model: string
+  ollama_reachable?: boolean
 }
 
 // Local-only: 4-field subset of DocumentListItem for the document

--- a/frontend/src/pages/Monitoring/useSection.ts
+++ b/frontend/src/pages/Monitoring/useSection.ts
@@ -1,0 +1,55 @@
+// Per-section fetch envelope for the Monitoring page (invariant I-10:
+// every section owns loading/error/empty independently). Optional
+// refreshMs re-fetches silently -- state only changes on completion, so
+// a failed refresh keeps the last good data on screen instead of
+// blanking the table.
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { logger } from "@/lib/logger"
+
+import type { SectionState } from "./types"
+
+export function useSection<T>(
+  name: string,
+  fetcher: () => Promise<T>,
+  fallback: T,
+  refreshMs?: number,
+) {
+  const [state, setState] = useState<SectionState<T>>({
+    loading: true,
+    data: fallback,
+    error: false,
+  })
+  const fetcherRef = useRef(fetcher)
+  useEffect(() => {
+    fetcherRef.current = fetcher
+  }, [fetcher])
+
+  const load = useCallback(() => {
+    let cancelled = false
+    fetcherRef.current()
+      .then((d) => {
+        if (!cancelled) setState({ loading: false, data: d, error: false })
+      })
+      .catch((e: unknown) => {
+        logger.warn("[Monitoring] section failed", name, e)
+        if (!cancelled) setState((prev) => ({ ...prev, loading: false, error: true }))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [name])
+
+  useEffect(() => {
+    const cancel = load()
+    if (!refreshMs) return cancel
+    const id = setInterval(load, refreshMs)
+    return () => {
+      cancel()
+      clearInterval(id)
+    }
+  }, [load, refreshMs])
+
+  return { ...state, reload: load }
+}

--- a/frontend/src/pages/Monitoring/utils.test.ts
+++ b/frontend/src/pages/Monitoring/utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import { formatCount, formatDuration } from "./utils"
+
+describe("formatDuration", () => {
+  it("renders sub-second spans in ms", () => {
+    expect(formatDuration(0)).toBe("0.0 ms")
+    expect(formatDuration(42.55)).toBe("42.5 ms")
+    expect(formatDuration(999.9)).toBe("999.9 ms")
+  })
+
+  it("renders 1s..60s spans in seconds", () => {
+    expect(formatDuration(1000)).toBe("1.00 s")
+    expect(formatDuration(1534)).toBe("1.53 s")
+    expect(formatDuration(59999)).toBe("60.00 s")
+  })
+
+  it("renders >=60s spans in minutes", () => {
+    expect(formatDuration(60000)).toBe("1.0 min")
+    expect(formatDuration(90000)).toBe("1.5 min")
+  })
+})
+
+describe("formatCount", () => {
+  it("keeps small numbers verbatim", () => {
+    expect(formatCount(0)).toBe("0")
+    expect(formatCount(999)).toBe("999")
+  })
+
+  it("abbreviates thousands and millions", () => {
+    expect(formatCount(1_534)).toBe("1.5k")
+    expect(formatCount(45_120)).toBe("45k")
+    expect(formatCount(2_400_000)).toBe("2.4M")
+  })
+})

--- a/frontend/src/pages/Monitoring/utils.ts
+++ b/frontend/src/pages/Monitoring/utils.ts
@@ -2,7 +2,7 @@
 // constants) consumed by the Monitoring page sub-components. No
 // React, no fetches.
 
-import type { EvalHistoryItem, EvalRun, ModelUsageItem } from "./types"
+import type { EvalHistoryItem, EvalRun } from "./types"
 
 // Colour palettes
 
@@ -24,8 +24,6 @@ export const METRIC_BARS = [
   { key: "answer_relevance", label: "Answer Rel.", color: "#f59e0b" },
   { key: "context_precision", label: "Ctx Prec.", color: "#ec4899" },
 ]
-
-export const PIE_COLORS = ["#6366f1", "#0ea5e9", "#22c55e", "#f59e0b", "#ec4899"]
 
 export const EVAL_THRESHOLDS: Record<string, number> = {
   hit_rate_5: 0.6,
@@ -68,17 +66,17 @@ export function buildRagChartData(evalRuns: EvalRun[]) {
   }))
 }
 
-export function buildPieData(modelUsage: ModelUsageItem[]) {
-  const local = modelUsage
-    .filter((m) => m.model.startsWith("ollama/"))
-    .reduce((s, m) => s + m.call_count, 0)
-  const cloud = modelUsage
-    .filter((m) => !m.model.startsWith("ollama/"))
-    .reduce((s, m) => s + m.call_count, 0)
-  return [
-    { name: "Local (Ollama)", value: local },
-    { name: "Cloud", value: cloud },
-  ].filter((d) => d.value > 0)
+export function formatDuration(ms: number): string {
+  if (ms >= 60_000) return `${(ms / 60_000).toFixed(1)} min`
+  if (ms >= 1_000) return `${(ms / 1_000).toFixed(2)} s`
+  return `${ms.toFixed(1)} ms`
+}
+
+export function formatCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 10_000) return `${(n / 1_000).toFixed(0)}k`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
 }
 
 // Score / mastery colour mappers

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -3142,7 +3142,7 @@ export interface paths {
         };
         /**
          * Get Phoenix Url
-         * @description Return the Phoenix UI URL and whether it is currently reachable.
+         * @description Return the Phoenix UI URL, whether tracing is configured, and reachability.
          */
         get: operations["get_phoenix_url_monitoring_phoenix_url_get"];
         put?: never;
@@ -3162,7 +3162,7 @@ export interface paths {
         };
         /**
          * Get Traces
-         * @description Return last 50 spans from Phoenix. Returns empty list if Phoenix is not running.
+         * @description Return recent spans from Phoenix. Returns empty list if Phoenix is not running.
          */
         get: operations["get_traces_monitoring_traces_get"];
         put?: never;
@@ -3245,6 +3245,28 @@ export interface paths {
          * @description Return eval metrics whose latest value dropped versus a moving baseline.
          */
         get: operations["get_eval_regressions_monitoring_evals_regressions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/monitoring/metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Metrics
+         * @description Operational metrics: latency/error/token stats from a sample of recent
+         *     Phoenix spans, plus a 7-day QA activity trend from SQLite (available even
+         *     when tracing is off).
+         */
+        get: operations["get_metrics_monitoring_metrics_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -7937,8 +7959,35 @@ export interface components {
             model: string;
             /** Call Count */
             call_count: number;
-            /** Avg Latency Ms */
-            avg_latency_ms: number | null;
+        };
+        /** MonitoringMetrics */
+        MonitoringMetrics: {
+            /** Phoenix Available */
+            phoenix_available: boolean;
+            /** Spans Sampled */
+            spans_sampled: number;
+            /** Traces Sampled */
+            traces_sampled: number;
+            /** Latency P50 Ms */
+            latency_p50_ms: number | null;
+            /** Latency P95 Ms */
+            latency_p95_ms: number | null;
+            /** Error Count */
+            error_count: number;
+            /** Error Rate */
+            error_rate: number | null;
+            /** Llm Calls */
+            llm_calls: number;
+            /** Llm Prompt Tokens */
+            llm_prompt_tokens: number;
+            /** Llm Completion Tokens */
+            llm_completion_tokens: number;
+            /** Spans By Kind */
+            spans_by_kind: {
+                [key: string]: number;
+            };
+            /** Qa Daily */
+            qa_daily: components["schemas"]["QADailyCount"][];
         };
         /** MonitoringOverview */
         MonitoringOverview: {
@@ -7946,6 +7995,11 @@ export interface components {
             llm_status: string;
             /** Phoenix Running */
             phoenix_running: boolean;
+            /**
+             * Phoenix Configured
+             * @default false
+             */
+            phoenix_configured: boolean;
             /** Langfuse Configured */
             langfuse_configured: boolean;
             /** Total Documents */
@@ -7954,8 +8008,6 @@ export interface components {
             total_chunks: number;
             /** Qa Calls Today */
             qa_calls_today: number;
-            /** Avg Latency Ms */
-            avg_latency_ms: number | null;
         };
         /** NamingFixItem */
         NamingFixItem: {
@@ -8264,6 +8316,11 @@ export interface components {
             url: string;
             /** Enabled */
             enabled: boolean;
+            /**
+             * Configured
+             * @default false
+             */
+            configured: boolean;
         };
         /** ProgressResponse */
         ProgressResponse: {
@@ -8286,6 +8343,13 @@ export interface components {
             deleted: number;
             /** Labels */
             labels: string[];
+        };
+        /** QADailyCount */
+        QADailyCount: {
+            /** Date */
+            date: string;
+            /** Count */
+            count: number;
         };
         /** QARequest */
         QARequest: {
@@ -9247,12 +9311,24 @@ export interface components {
             trace_id: string;
             /** Operation Name */
             operation_name: string;
+            /**
+             * Span Kind
+             * @default UNKNOWN
+             */
+            span_kind: string;
+            /** Parent Id */
+            parent_id?: string | null;
             /** Start Time */
             start_time: string;
             /** Duration Ms */
             duration_ms: number;
             /** Status */
             status: string;
+            /**
+             * Status Message
+             * @default
+             */
+            status_message: string;
             /** Attributes */
             attributes: {
                 [key: string]: unknown;
@@ -15008,7 +15084,9 @@ export interface operations {
     };
     get_traces_monitoring_traces_get: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -15022,6 +15100,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TracesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -15127,6 +15214,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_metrics_monitoring_metrics_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MonitoringMetrics"];
                 };
             };
         };


### PR DESCRIPTION
Replaces #14 (closed by a branch rename to satisfy the branch-naming convention).

## Problem

The Monitoring page (dev tier) was broken in three ways:

1. **Traces always empty.** The backend proxied Phoenix at `GET /v1/spans`, which is deprecated in arize-phoenix >= 9 and requires a JSON request body — a plain GET 422s, silently swallowed into an empty list.
2. **Blank page.** `/evals/datasets` returns `GoldenDatasetListItem` objects since the eval-harness rebuild, but `EvalPanel` typed it `string[]` and rendered the objects as `<option>` children — React threw and, with no error boundary, unmounted the whole page.
3. **No useful metrics + duplication.** Overview repeated model config/usage already shown in Settings and Admin, while latency fields were hardcoded `None`.

## Changes

### Backend
- Span proxy now uses `GET /v1/projects/luminary/spans` and maps the 13.x shape (`span_kind`, `parent_id`, `status_code`, `status_message`)
- New `GET /monitoring/metrics`: latency p50/p95 (root spans), error count/rate, LLM token in/out totals, spans-by-kind, zero-filled 7-day QA trend from SQLite (works with tracing off)
- `configured` vs `enabled` split on phoenix-url; `phoenix_configured` on overview; one cached healthz probe (30 s TTL) shared by all endpoints
- Dropped never-populated `avg_latency_ms` fields

### Frontend
- Monitoring restructured into hash-persisted **Overview | Traces | Evals | Mastery** tabs; shared `useSection` hook replaces 8 copy-pasted fetch blocks; every tab wrapped in `PanelErrorBoundary`
- Eval dataset objects mapped to names (blank-screen fix)
- Overview: tri-state status pills (disabled integrations no longer render as red "Offline"; Ollama uses the real `ollama_reachable` probe), performance stat cards, spans-by-kind chips, QA activity chart; model config/usage duplication removed (lives in Settings/Admin)
- Traces tab: 15 s silent auto-refresh, span-kind chips, child-span indenting, Open-in-Phoenix link, correct enable-tracing guidance
- Dark-mode variants for all previously light-only colors; MasteryPanel setState-in-effect lint errors fixed via key-remounted data block

## Testing

- Full local `make ci` equivalent: ruff, layer linter, boundary checker, public-import guard, **1890 backend tests passed**, manifest schema/coverage checks, frontend `npm run build` + `tsc --noEmit`
- End-to-end: booted a backend with `PHOENIX_ENABLED=true`, real spans flowed through the proxy; all four tabs rendered in headless Chrome with zero console errors
- GitHub CI green on this branch (run 28996569883)
- Pre-existing/unrelated: 11 vitest failures in `src/components/reader/pdf*` fail on clean master too

🤖 Generated with [Claude Code](https://claude.com/claude-code)