### PR TITLE
Research-paper ingestion, reader fixes, offline resilience, and dark-mode polish

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,7 +32,7 @@ ENRICHMENT_VISION_CONCURRENCY=@@VISION_CONCURRENCY@@
 
 # Image and figure analysis. Requires pulling the model first:
 #   ollama pull <model>
-# VISION_MODEL=ollama/llava:7b
+# VISION_MODEL=ollama/qwen2.5vl:7b
 
 # Disable on memory-constrained machines to avoid OOM during ingestion.
 GLINER_ENABLED=true

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -102,7 +102,7 @@ class Settings(BaseSettings):
     LANGFUSE_PUBLIC_KEY: str = ""
     LANGFUSE_SECRET_KEY: str = ""
     WHISPER_MODEL_SIZE: str = "base"
-    VISION_MODEL: str = "ollama/llava:7b"
+    VISION_MODEL: str = "ollama/qwen2.5vl:7b"
     # Max concurrent vision (image_analyze) LLM calls across all documents. Default
     # 1 = one-at-a-time (safe on 8GB). Raise (e.g. 2-4) on a host with headroom and
     # pair with OLLAMA_NUM_PARALLEL so a single Ollama batches the calls. The install

--- a/backend/app/routers/sections.py
+++ b/backend/app/routers/sections.py
@@ -13,12 +13,37 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/sections", tags=["sections"])
 
 
+_SETEXT_UNDERLINE_RE = re.compile(r"^[ \t]*(-{1,}|={1,})[ \t]*$")
+
+
+def _reader_safe(text: str) -> str:
+    """Neutralise markdown that document text triggers by accident.
+
+    Extracted PDF text is rendered as markdown, so a line of dashes directly
+    under a line of prose becomes a setext heading -- a hyphen left alone on its
+    own line by the PDF text layer silently promoted whole sentences to <h2>.
+    Inserting a blank line demotes it to a horizontal rule, which is what a
+    reader would expect, and leaves deliberate rules and lists untouched.
+    """
+    if not text:
+        return text
+    lines = text.split("\n")
+    out: list[str] = []
+    for line in lines:
+        if out and out[-1].strip() and _SETEXT_UNDERLINE_RE.match(line):
+            out.append("")
+        out.append(line)
+    return "\n".join(out)
+
+
 class SectionContentItem(BaseModel):
     section_id: str
     heading: str
     level: int
     section_order: int
     content: str
+    page_start: int = 0
+    page_end: int = 0
 
 
 class SectionResponse(BaseModel):
@@ -93,13 +118,15 @@ async def get_section_content(document_id: str) -> list[SectionContentItem]:
         # If preview exists and is NOT truncated (shorter than the storage cap),
         # use it -- it preserves original formatting.
         if s.preview and len(s.preview) < PREVIEW_LIMIT:
-            return s.preview
+            return _reader_safe(s.preview)
         # Preview was truncated or empty -- reassemble from chunks, stripping
         # the "[Title > Section] " enrichment prefix from each chunk.
         if chunk_texts:
-            return "\n\n".join(re.sub(r"^\[.*?\]\s*", "", c) for c in chunk_texts)
+            return _reader_safe(
+                "\n\n".join(re.sub(r"^\[.*?\]\s*", "", c) for c in chunk_texts)
+            )
         # Last resort: return whatever preview we have, even if truncated
-        return s.preview or ""
+        return _reader_safe(s.preview or "")
 
     result = [
         SectionContentItem(
@@ -108,6 +135,8 @@ async def get_section_content(document_id: str) -> list[SectionContentItem]:
             level=s.level,
             section_order=s.section_order,
             content=_section_content(s),
+            page_start=s.page_start or 0,
+            page_end=s.page_end or 0,
         )
         for s in sections
     ]

--- a/backend/app/services/article_extractor.py
+++ b/backend/app/services/article_extractor.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from urllib.parse import urljoin
 
 import httpx
+from bs4 import BeautifulSoup, NavigableString
 
 from app.config import get_settings
 from app.full_extras import require_extra
@@ -23,6 +24,17 @@ USER_AGENTS = [
         "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
     ),
 ]
+
+
+_BOILERPLATE_CONTAINERS = ("nav", "header", "footer", "aside")
+
+_INLINE_MARKERS = {
+    "strong": "**",
+    "b": "**",
+    "em": "*",
+    "i": "*",
+    "code": "`",
+}
 
 
 class ArticleExtractor:
@@ -65,7 +77,7 @@ class ArticleExtractor:
         # 3. Mirror Images AND Extract Markdown in one pass
         # We let trafilatura handle the extraction first to find the "real" content
         markdown_text = trafilatura.extract(
-            html_content,
+            self._prepare_html(html_content),
             url=url,
             output_format="markdown",
             include_links=True,
@@ -100,6 +112,96 @@ class ArticleExtractor:
             sections=sections,
             raw_text=markdown_text,
         )
+
+    def _prepare_html(self, html: str) -> str:
+        """Repairs markup that trafilatura's extractor silently drops."""
+        soup = BeautifulSoup(html, "html.parser")
+        self._hydrate_lazy_images(soup)
+        self._flatten_inline_formatting(soup)
+        return str(soup)
+
+    def _hydrate_lazy_images(self, soup: BeautifulSoup) -> None:
+        """
+        Gives every <img> a real src. Lazy-loading sites ship <img> with no src at
+        all and keep the true URL in a sibling <picture><source srcset> or a data-*
+        attribute; trafilatura only reads img/@src, so those images vanish entirely.
+        """
+        for img in soup.find_all("img"):
+            if not img.get("src"):
+                url = None
+                picture = img.find_parent("picture")
+                if picture:
+                    for source in picture.find_all("source"):
+                        url = self._best_srcset_url(source.get("srcset")) or url
+                url = (
+                    url
+                    or img.get("data-src")
+                    or img.get("data-original")
+                    or img.get("data-lazy-src")
+                    or self._best_srcset_url(img.get("srcset"))
+                )
+                if not url:
+                    continue
+                img["src"] = url
+
+            if not img.get("alt"):
+                figure = img.find_parent("figure")
+                caption = figure.find("figcaption") if figure else None
+                if caption and caption.get_text().strip():
+                    img["alt"] = caption.get_text().strip()
+
+    def _flatten_inline_formatting(self, soup: BeautifulSoup) -> None:
+        """
+        Rewrites inline tags to literal markdown before extraction.
+
+        trafilatura 2.0.0's markdown serialiser mishandles any block whose first
+        child is an inline element: a <li> starting with <strong> loses its bullet
+        and merges into the previous item, and one starting with <a> is dropped
+        outright. Feeding it plain text sidesteps the bug and also preserves the
+        inter-element spacing the serialiser otherwise strips.
+
+        Anchors are flattened only inside non-boilerplate list items. Flattening
+        them everywhere hides them from trafilatura's link-density heuristic, which
+        is how it recognises navigation and ad blocks -- measured to pull sponsor
+        markup into the article body on sites whose main content is already
+        marginal. Innermost-first so nested tags are rewritten before their parent.
+        """
+        for tag in reversed(list(soup.find_all([*_INLINE_MARKERS, "a"]))):
+            if tag.find_parent("pre"):
+                continue
+            if tag.name == "a":
+                list_item = tag.find_parent("li")
+                if not list_item or list_item.find_parent(_BOILERPLATE_CONTAINERS):
+                    continue
+            text = tag.get_text()
+            if not text.strip():
+                continue
+            if tag.name == "a":
+                href = tag.get("href")
+                replacement = f"[{text}]({href})" if href else text
+            else:
+                marker = _INLINE_MARKERS[tag.name]
+                replacement = f"{marker}{text}{marker}"
+            tag.replace_with(NavigableString(replacement))
+
+    @staticmethod
+    def _best_srcset_url(srcset: str | None) -> str | None:
+        """Picks the highest-resolution candidate from a srcset attribute."""
+        if not srcset:
+            return None
+        candidates: list[tuple[int, str]] = []
+        for candidate in srcset.split(","):
+            parts = candidate.strip().split()
+            if not parts:
+                continue
+            width = 0
+            if len(parts) > 1 and parts[1].endswith("w"):
+                try:
+                    width = int(parts[1][:-1])
+                except ValueError:
+                    width = 0
+            candidates.append((width, parts[0]))
+        return max(candidates)[1] if candidates else None
 
     async def _mirror_markdown_images(self, md: str, doc_id: str, base_url: str) -> str:
         """Finds ![alt](url) in markdown, downloads them, and updates to local path."""

--- a/backend/app/services/clustering_service.py
+++ b/backend/app/services/clustering_service.py
@@ -191,6 +191,7 @@ class ClusteringService:
                     {"role": "user", "content": excerpts_text},
                 ],
                 temperature=0.0,
+                background=True,
             )
             name = raw.strip().split("\n")[0].strip()[:60]
             return name if name else "Notes Cluster"

--- a/backend/app/services/connectivity.py
+++ b/backend/app/services/connectivity.py
@@ -1,0 +1,72 @@
+"""Provider reachability checks for offline-aware routing.
+
+A local-first app must not depend on the network being up. Probing whether a
+cloud provider is reachable lets routing switch to the local model *before*
+attempting a doomed call -- avoiding the SDK's retry storm (litellm wraps a
+connection failure as InternalServerError only after several retries) and giving
+the UI something to say.
+
+Results are cached briefly so a chat turn does not open a socket per LLM call.
+Both error directions are safe: a false "offline" routes local (the safe default
+for a local-first app), and a false "online" simply falls through to the reactive
+fallback in the LLM service.
+"""
+
+import logging
+import socket
+import time
+
+logger = logging.getLogger(__name__)
+
+# Cloud model prefixes mapped to the host a routed call would contact.
+_PROVIDER_HOSTS: dict[str, str] = {
+    "openai": "api.openai.com",
+    "anthropic": "api.anthropic.com",
+    "gemini": "generativelanguage.googleapis.com",
+}
+
+_CACHE_TTL_S = 15.0
+_PROBE_TIMEOUT_S = 2.0
+
+# host -> (checked_at_monotonic, reachable)
+_cache: dict[str, tuple[float, bool]] = {}
+
+
+def _probe(host: str, port: int, timeout: float) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def host_reachable(host: str, port: int = 443, timeout: float = _PROBE_TIMEOUT_S) -> bool:
+    """Cached TCP reachability check. Blocking; call via to_thread on the loop."""
+    now = time.monotonic()
+    cached = _cache.get(host)
+    if cached is not None and now - cached[0] < _CACHE_TTL_S:
+        return cached[1]
+    ok = _probe(host, port, timeout)
+    _cache[host] = (now, ok)
+    if not ok:
+        logger.info("connectivity: %s unreachable; treating as offline", host)
+    return ok
+
+
+def is_cloud_model(model: str) -> bool:
+    """True when the model string routes to an external provider."""
+    return model.split("/", 1)[0] in _PROVIDER_HOSTS
+
+
+def provider_reachable(model: str) -> bool:
+    """Whether the provider for a model string is reachable. Local models -> True."""
+    prefix = model.split("/", 1)[0]
+    host = _PROVIDER_HOSTS.get(prefix)
+    if host is None:
+        return True
+    return host_reachable(host)
+
+
+def reset_cache() -> None:
+    """Test hook: drop cached probe results."""
+    _cache.clear()

--- a/backend/app/services/flashcard_audit.py
+++ b/backend/app/services/flashcard_audit.py
@@ -180,7 +180,7 @@ class FlashcardAuditService:
 
             async with llm_sem:
                 llm = get_llm_service()
-                raw = await llm.generate(prompt, system=system, stream=False)
+                raw = await llm.generate(prompt, system=system, stream=False, background=True)
 
             cards_data = _parse_llm_response(raw, document_id)
             return (section_id, level, cards_data)

--- a/backend/app/services/gap_detector.py
+++ b/backend/app/services/gap_detector.py
@@ -100,6 +100,7 @@ class GapDetectorService:
                     {"role": "user", "content": user_msg},
                 ],
                 temperature=0.0,
+                background=True,
             )
         except LLMUnavailableError:
             raise

--- a/backend/app/services/image_enricher.py
+++ b/backend/app/services/image_enricher.py
@@ -1,7 +1,7 @@
 """Vision LLM image analysis service
 
-Processes ImageModel rows with description=null, calling a vision LLM (llava:13b)
-to classify each image and generate a text description.  Descriptions are embedded
+Processes ImageModel rows with description=null, calling the configured
+VISION_MODEL to classify each image and generate a text description.  Descriptions are embedded
 and stored in LanceDB image_vectors_v1 and indexed in the images_fts FTS5 table.
 
 Pre-filter: images with <5 unique colors (solid-color) or aspect ratio >10:1 (rule

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -5,7 +5,9 @@ All LLM completions in the codebase MUST go through this module so that telemetr
 litellm.acompletion in services/routers bypass observability.
 """
 
+import asyncio
 import logging
+import socket
 import warnings
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -63,6 +65,27 @@ LLMUnreachableError: tuple[type[BaseException], ...] = (
     LLMTimeoutError,
     ConnectionRefusedError,
 )
+
+# litellm maps a connection failure to InternalServerError ("OpenAIException -
+# Connection error"), NOT APIConnectionError, so isinstance alone misses the very
+# case this exists for. Walk the cause chain for the underlying socket/DNS error
+# instead. InternalServerError from a genuine provider 500 has no such cause and
+# is correctly left to propagate.
+def _is_offline_error(exc: BaseException) -> bool:
+    if isinstance(exc, LLMUnreachableError):
+        return True
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, LLMUnreachableError):
+            return True
+        if isinstance(cur, (socket.gaierror, ConnectionError)):
+            return True
+        if isinstance(cur, OSError) and "Connect" in type(cur).__name__:
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
 
 # Langfuse — optional LLM call observability
 
@@ -199,6 +222,33 @@ class LLMService:
                 retry[key] = kwargs[key]
         return retry
 
+    async def _reroute_if_offline(
+        self, requested_model: str | None, effective_model: str, settings: Settings
+    ) -> tuple[str, str | None, bool]:
+        """Swap a routed cloud model for the local one when the provider is
+        unreachable, before any call is attempted.
+
+        Returns (model, override_key, rerouted). Skipped for pinned models so
+        evals and overrides stay reproducible. Doing this up front avoids the
+        SDK's multi-retry stall on a dead connection.
+        """
+        from app.services.connectivity import is_cloud_model, provider_reachable  # noqa: PLC0415
+
+        if requested_model is not None or not is_cloud_model(effective_model):
+            return effective_model, None, False
+        if await asyncio.to_thread(provider_reachable, effective_model):
+            return effective_model, None, False
+
+        local_model = settings.LITELLM_DEFAULT_MODEL
+        if not local_model.startswith("ollama/"):
+            local_model = f"ollama/{local_model}"
+        logger.warning(
+            "%s provider unreachable; routing to local model %s",
+            effective_model,
+            local_model,
+        )
+        return local_model, None, True
+
     def _resolve_model(
         self, model: str | None, *, background: bool
     ) -> tuple[str, str | None]:
@@ -236,6 +286,9 @@ class LLMService:
         """
         settings = get_settings()
         effective_model, override_key = self._resolve_model(model, background=background)
+        effective_model, override_key, _ = await self._reroute_if_offline(
+            model, effective_model, settings
+        )
 
         kwargs = self._build_kwargs(
             effective_model, messages, settings,
@@ -255,9 +308,13 @@ class LLMService:
         with trace_llm_call("complete", model=effective_model) as span:
             try:
                 response = await litellm.acompletion(**kwargs)
-            except LLMUnreachableError as exc:
-                retry = self._offline_fallback_kwargs(
-                    model, effective_model, kwargs, settings, num_ctx=num_ctx
+            except Exception as exc:
+                retry = (
+                    self._offline_fallback_kwargs(
+                        model, effective_model, kwargs, settings, num_ctx=num_ctx
+                    )
+                    if _is_offline_error(exc)
+                    else None
                 )
                 if retry is None:
                     raise
@@ -296,6 +353,9 @@ class LLMService:
         """Stream content deltas for the given message list."""
         settings = get_settings()
         effective_model, override_key = self._resolve_model(model, background=background)
+        effective_model, override_key, _ = await self._reroute_if_offline(
+            model, effective_model, settings
+        )
         kwargs = self._build_kwargs(
             effective_model, messages, settings,
             override_key=override_key, timeout=timeout, num_ctx=num_ctx,
@@ -347,8 +407,8 @@ class LLMService:
     ) -> AsyncGenerator[str]:
         try:
             response = await litellm.acompletion(stream=True, **kwargs)
-        except LLMUnreachableError as exc:
-            if fallback_kwargs is None:
+        except Exception as exc:
+            if fallback_kwargs is None or not _is_offline_error(exc):
                 raise
             logger.warning(
                 "%s unreachable while streaming (%s); retrying on local model %s",

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -54,6 +54,16 @@ LLMUnavailableError: tuple[type[BaseException], ...] = (
     ConnectionRefusedError,
 )
 
+# The subset meaning "could not reach the provider" -- the offline case. Auth,
+# rate-limit and not-found are deliberately excluded: they are configuration
+# faults, and silently answering from a different model would hide them.
+LLMUnreachableError: tuple[type[BaseException], ...] = (
+    LLMServiceUnavailableError,
+    LLMAPIConnectionError,
+    LLMTimeoutError,
+    ConnectionRefusedError,
+)
+
 # Langfuse — optional LLM call observability
 
 _langfuse = None  # type: ignore[var-annotated]
@@ -150,6 +160,45 @@ class LLMService:
             kwargs["api_key"] = settings.GOOGLE_API_KEY
         return kwargs
 
+    def _offline_fallback_kwargs(
+        self,
+        requested_model: str | None,
+        effective_model: str,
+        kwargs: dict,
+        settings: Settings,
+        *,
+        num_ctx: int | None = None,
+    ) -> dict | None:
+        """Rebuild kwargs against the local model, or None when not applicable.
+
+        Keeps the app usable with no internet: a cloud call that cannot reach its
+        provider is retried on Ollama. Only for calls whose model came from
+        routing -- an explicitly pinned model is honoured or allowed to fail, so
+        evals and per-request overrides stay reproducible rather than silently
+        answering from a different model.
+        """
+        if requested_model is not None:
+            return None
+        if effective_model.startswith("ollama/"):
+            return None
+
+        local_model = settings.LITELLM_DEFAULT_MODEL
+        if not local_model.startswith("ollama/"):
+            local_model = f"ollama/{local_model}"
+
+        retry = self._build_kwargs(
+            local_model,
+            kwargs["messages"],
+            settings,
+            override_key=None,
+            timeout=kwargs.get("timeout"),
+            num_ctx=num_ctx,
+        )
+        for key in ("temperature", "max_tokens", "response_format", "stream"):
+            if key in kwargs:
+                retry[key] = kwargs[key]
+        return retry
+
     def _resolve_model(
         self, model: str | None, *, background: bool
     ) -> tuple[str, str | None]:
@@ -204,7 +253,23 @@ class LLMService:
             kwargs.update(extra)
 
         with trace_llm_call("complete", model=effective_model) as span:
-            response = await litellm.acompletion(**kwargs)
+            try:
+                response = await litellm.acompletion(**kwargs)
+            except LLMUnreachableError as exc:
+                retry = self._offline_fallback_kwargs(
+                    model, effective_model, kwargs, settings, num_ctx=num_ctx
+                )
+                if retry is None:
+                    raise
+                logger.warning(
+                    "%s unreachable (%s); retrying on local model %s",
+                    effective_model,
+                    type(exc).__name__,
+                    retry["model"],
+                )
+                effective_model = retry["model"]
+                span.set_attribute("llm.offline_fallback", True)
+                response = await litellm.acompletion(**retry)
             content = response.choices[0].message.content or ""
             usage = getattr(response, "usage", None)
             prompt_tokens = 0
@@ -237,7 +302,10 @@ class LLMService:
         )
         if temperature is not None:
             kwargs["temperature"] = temperature
-        return self._token_stream(kwargs)
+        fallback = self._offline_fallback_kwargs(
+            model, effective_model, kwargs, settings, num_ctx=num_ctx
+        )
+        return self._token_stream(kwargs, fallback)
 
     async def generate(
         self,
@@ -274,8 +342,22 @@ class LLMService:
             temperature=temperature,
         )
 
-    async def _token_stream(self, kwargs: dict) -> AsyncGenerator[str]:
-        response = await litellm.acompletion(stream=True, **kwargs)
+    async def _token_stream(
+        self, kwargs: dict, fallback_kwargs: dict | None = None
+    ) -> AsyncGenerator[str]:
+        try:
+            response = await litellm.acompletion(stream=True, **kwargs)
+        except LLMUnreachableError as exc:
+            if fallback_kwargs is None:
+                raise
+            logger.warning(
+                "%s unreachable while streaming (%s); retrying on local model %s",
+                kwargs.get("model"),
+                type(exc).__name__,
+                fallback_kwargs["model"],
+            )
+            fallback_kwargs.pop("stream", None)
+            response = await litellm.acompletion(stream=True, **fallback_kwargs)
         async for chunk in response:
             delta = chunk.choices[0].delta.content
             if delta:

--- a/backend/app/services/note_tagger.py
+++ b/backend/app/services/note_tagger.py
@@ -56,6 +56,7 @@ class NoteTaggerService:
                     {"role": "user", "content": prompt},
                 ],
                 temperature=0.0,
+                background=True,
             )
             return _parse_tag_list(raw)
         except Exception as exc:

--- a/backend/app/services/note_title_generator.py
+++ b/backend/app/services/note_title_generator.py
@@ -46,6 +46,7 @@ class NoteTitleGeneratorService:
                 ],
                 temperature=0.3,
                 max_tokens=30,
+                background=True,
             )
             title = raw.strip()
             title = re.sub(r'^["\']|["\']$', "", title)

--- a/backend/app/services/paper_chunker.py
+++ b/backend/app/services/paper_chunker.py
@@ -1,0 +1,203 @@
+"""Research-paper chunking: structure-aware segmentation with a safe fallback.
+
+Papers previously fell through to the generic splitter, which has no sentence
+separator and a 300-char budget -- tight enough that splits descended past word
+boundaries into characters. This module segments a section into prose, captions
+and figure-internal noise before splitting, so captions stay whole and figure
+label text never reaches the index.
+
+Pure functions only; the ingestion node owns persistence.
+"""
+
+import re
+
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+PAPER_SEPARATORS = ["\n\n", "\n", ". ", " ", ""]
+
+# Academic caption conventions. A caption is kept atomic so retrieval returns the
+# whole "Figure 3: ..." statement rather than half of it.
+_CAPTION_RE = re.compile(
+    r"^\s*(?:figure|fig\.?|table|algorithm|listing|scheme|equation|eq\.?)\s*\d+[.:)]",
+    re.I,
+)
+
+_REFERENCES_RE = re.compile(
+    r"^\s*(?:\d+[.\s]*)?(?:references|bibliography|works\s+cited|literature\s+cited)\s*$",
+    re.I,
+)
+
+_STRUCTURAL_HEADING_RE = re.compile(
+    r"^\s*(?:\d+(?:\.\d+)*[.\s]+)?"
+    r"(?:abstract|introduction|background|related\s+work|method(?:s|ology)?|"
+    r"approach|model|experiment(?:s|al\s+setup)?|result(?:s)?|evaluation|"
+    r"discussion|analysis|conclusion(?:s)?|future\s+work|references|"
+    r"bibliography|appendix|acknowledg(?:e)?ments?)\b",
+    re.I,
+)
+
+_NUMBERED_HEADING_RE = re.compile(r"^\s*\d+(?:\.\d+)*[.\s]+\S")
+
+# A "token line" is a line holding at most this many words. Figure axis labels
+# and legend entries are emitted one token per line by PDF text layers, so a long
+# run of them marks figure internals rather than prose.
+_TOKEN_LINE_MAX_WORDS = 2
+_TOKEN_LINE_MAX_CHARS = 30
+_MIN_NOISE_RUN = 6
+
+# A caption runs until a blank line, but PDF text layers frequently emit none --
+# unbounded, a caption would swallow every following page until the next figure.
+_MAX_CAPTION_LINES = 8
+_MAX_CAPTION_CHARS = 600
+
+
+def is_references_heading(heading: str) -> bool:
+    """True when a section heading denotes a reference list."""
+    return bool(_REFERENCES_RE.match(heading or ""))
+
+
+def looks_like_paper(sections: list[dict]) -> bool:
+    """Gate for the structure-aware path.
+
+    Requires several recognisable headings AND at least one anchor heading that
+    only papers carry. A document that merely uses numbered headings (many
+    manuals do) falls back to generic chunking rather than being force-fitted.
+    """
+    headings = [(s.get("heading") or "").strip() for s in sections]
+    headings = [h for h in headings if h]
+    if len(headings) < 3:
+        return False
+
+    structural = sum(1 for h in headings if _STRUCTURAL_HEADING_RE.match(h))
+    numbered = sum(1 for h in headings if _NUMBERED_HEADING_RE.match(h))
+    anchored = any(
+        re.match(r"^\s*(?:\d+(?:\.\d+)*[.\s]+)?(?:abstract|references|bibliography)\b", h, re.I)
+        or re.match(r"^\s*(?:\d+(?:\.\d+)*[.\s]+)?(?:introduction|conclusion)", h, re.I)
+        for h in headings
+    )
+    return anchored and (structural + numbered) >= 3
+
+
+def _is_token_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if len(stripped) > _TOKEN_LINE_MAX_CHARS:
+        return False
+    return len(stripped.split()) <= _TOKEN_LINE_MAX_WORDS
+
+
+def segment_section(text: str) -> list[tuple[str, str]]:
+    """Split section text into ('prose'|'caption'|'noise', text) segments.
+
+    Noise runs are the vertical token streams PDF text layers produce for figure
+    internals. They are detected by shape rather than by any particular marker,
+    so this generalises past one paper's notation.
+    """
+    lines = text.split("\n")
+    segments: list[tuple[str, str]] = []
+    buffer: list[str] = []
+    kind = "prose"
+
+    def flush() -> None:
+        if buffer and "".join(buffer).strip():
+            segments.append((kind, "\n".join(buffer)))
+        buffer.clear()
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+
+        run_end = i
+        while run_end < len(lines) and _is_token_line(lines[run_end]):
+            run_end += 1
+        if run_end - i >= _MIN_NOISE_RUN:
+            flush()
+            kind = "noise"
+            buffer.extend(lines[i:run_end])
+            flush()
+            kind = "prose"
+            i = run_end
+            continue
+
+        if _CAPTION_RE.match(line):
+            flush()
+            kind = "caption"
+            buffer.append(line)
+            caption_chars = len(line)
+            i += 1
+            while (
+                i < len(lines)
+                and lines[i].strip()
+                and not _CAPTION_RE.match(lines[i])
+                and len(buffer) < _MAX_CAPTION_LINES
+                and caption_chars < _MAX_CAPTION_CHARS
+            ):
+                buffer.append(lines[i])
+                caption_chars += len(lines[i])
+                i += 1
+            flush()
+            kind = "prose"
+            continue
+
+        buffer.append(line)
+        i += 1
+
+    flush()
+    return segments
+
+
+def unwrap_prose(text: str) -> str:
+    """Rejoin PDF line-wrapped prose into real paragraphs.
+
+    A PDF text layer breaks lines at the column edge, so '\\n' lands mid-sentence.
+    Because the splitter tries '\\n' before '. ', those wrap points get used as
+    split boundaries and chunks start mid-sentence. Unwrapping first restores
+    paragraphs, letting the sentence separator do its job. Hyphenated line breaks
+    are rejoined without the hyphen.
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    for raw in lines:
+        line = raw.rstrip()
+        if not line.strip():
+            out.append("")
+            continue
+        if not out or not out[-1]:
+            out.append(line)
+            continue
+        prev = out[-1]
+        if prev.endswith("-") and len(prev) > 1 and prev[-2].isalpha():
+            out[-1] = prev[:-1] + line.lstrip()
+        elif prev.rstrip().endswith((".", "!", "?", ":", ";")):
+            out.append(line)
+        else:
+            out[-1] = prev + " " + line.lstrip()
+    return "\n".join(out)
+
+
+def chunk_paper_section(section_text: str, chunk_size: int, chunk_overlap: int) -> list[str]:
+    """Chunk one section: captions atomic, figure internals dropped, prose split.
+
+    A caption longer than chunk_size is still emitted whole -- splitting it would
+    strip the "Figure N" anchor from the half that describes the figure.
+    """
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        separators=PAPER_SEPARATORS,
+    )
+
+    out: list[str] = []
+    for kind, text in segment_section(section_text):
+        if kind == "noise":
+            continue
+        if kind == "caption":
+            out.append(text.strip())
+            continue
+        for piece in splitter.split_text(unwrap_prose(text)):
+            # Splitting on ". " leaves the period leading the next piece.
+            cleaned = re.sub(r"^[.\s]+", "", piece)
+            if cleaned.strip():
+                out.append(cleaned)
+    return out

--- a/backend/app/services/qa.py
+++ b/backend/app/services/qa.py
@@ -5,6 +5,7 @@ The graph handles: intent classification, query rewriting, retrieval, LLM call,
 citation enrichment.  stream_answer() remains the thin SSE streaming layer.
 """
 
+import asyncio
 import json
 import logging
 import re
@@ -431,6 +432,28 @@ class QAService:
                 store_model = model or get_effective_routing()[0]
             except Exception:
                 store_model = model or "unknown"
+
+            # Tell the user when a routed cloud answer is about to run locally
+            # because the provider is unreachable. Only for routed (model=None)
+            # cloud models; a pinned model or local routing says nothing.
+            if model is None and store_model and not store_model.startswith("ollama/"):
+                from app.services.connectivity import (  # noqa: PLC0415
+                    is_cloud_model,
+                    provider_reachable,
+                )
+
+                if is_cloud_model(store_model) and not await asyncio.to_thread(
+                    provider_reachable, store_model
+                ):
+                    notice = {
+                        "type": "notice",
+                        "level": "offline",
+                        "message": (
+                            "No internet connection — answering with the local model "
+                            "instead of the cloud provider."
+                        ),
+                    }
+                    yield f"data: {json.dumps(notice)}\n\n"
 
             with trace_chain("qa.answer", input_value=question) as root_span:
                 root_span.set_attribute("qa.scope", scope)

--- a/backend/app/services/retriever_strategies.py
+++ b/backend/app/services/retriever_strategies.py
@@ -290,7 +290,22 @@ class _CrossEncoderReranker:
         slug = model_name.rsplit("/", 1)[-1].lower()
         cache_dir = Path(settings.DATA_DIR).expanduser() / "models" / slug
         cache_dir.mkdir(parents=True, exist_ok=True)
-        self._model = CrossEncoder(model_name, cache_folder=str(cache_dir), device="cpu")
+        # Cache-first, matching embedder/GLiNER/Whisper: without local_files_only
+        # the hub is contacted on every load, so with no internet this stalls on a
+        # network timeout before falling back -- on the chat path.
+        try:
+            self._model = CrossEncoder(
+                model_name,
+                cache_folder=str(cache_dir),
+                device="cpu",
+                local_files_only=True,
+            )
+        except Exception as local_exc:
+            logger.debug(
+                "Reranker local load failed (local_files_only=True), trying online: %s",
+                local_exc,
+            )
+            self._model = CrossEncoder(model_name, cache_folder=str(cache_dir), device="cpu")
         logger.info("Loaded cross-encoder reranker %s", model_name)
 
     def score(self, query: str, texts: list[str]) -> list[float]:

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -283,9 +283,13 @@ def get_llm_error_message() -> str:
 def get_effective_routing(background: bool = False) -> tuple[str, str | None]:
     """Return (litellm_model_string, api_key_or_none).
 
-    background=True  — caller is a background/ingestion task.  In hybrid mode
-                       this forces local Ollama so cloud quota is not consumed.
-    background=False — caller is user-facing (chat, explain, flashcards).
+    background=True  — the call must stay on the machine. In hybrid mode this
+                       forces local Ollama. Two kinds of caller need it: automatic
+                       tasks (ingestion, backfills), and anything handling the
+                       user's own notes or documents, even when a click triggered
+                       it. The default is local; cloud is opt-in per call site.
+    background=False — caller is user-facing and the cloud is the point of hybrid
+                       mode (chat, explain, feynman, study, flashcard generation).
 
     Raises ValueError when cloud routing is active but the API key is missing.
     """

--- a/backend/app/services/suggestion_service.py
+++ b/backend/app/services/suggestion_service.py
@@ -254,6 +254,7 @@ class SuggestionService:
                     {"role": "user", "content": user},
                 ],
                 temperature=0.7,
+                background=True,
             )
             candidates = _parse_questions(raw)
             filtered = self.filter_near_duplicates(candidates, history)

--- a/backend/app/services/topic_service.py
+++ b/backend/app/services/topic_service.py
@@ -242,6 +242,7 @@ class TopicService:
                 ],
                 temperature=0.2,
                 response_format={"type": "json_object"},
+                background=True,
             )
             data = json.loads(re.sub(r"^```[a-zA-Z]*\n?|\n?```$", "", raw.strip()))
             items = data.get("topics") if isinstance(data, dict) else None

--- a/backend/app/workflows/ingestion_nodes/_shared.py
+++ b/backend/app/workflows/ingestion_nodes/_shared.py
@@ -52,7 +52,11 @@ ContentType = Literal[
 _parser = DocumentParser()
 
 CHUNK_CONFIGS: dict[str, dict[str, int]] = {
-    "paper": {"chunk_size": 300, "chunk_overlap": 45},
+    # Papers are the densest content type and previously had the smallest budget,
+    # tight enough that splits fell past word boundaries into mid-word cuts. The
+    # chunk embedder (bge-small-en-v1.5) carries 512 tokens (~2000 chars), so this
+    # still leaves headroom.
+    "paper": {"chunk_size": 900, "chunk_overlap": 150},
     "book": {"chunk_size": 600, "chunk_overlap": 120},
     "conversation": {"chunk_size": 450, "chunk_overlap": 90},
     "notes": {"chunk_size": 300, "chunk_overlap": 75},

--- a/backend/app/workflows/ingestion_nodes/chunk.py
+++ b/backend/app/workflows/ingestion_nodes/chunk.py
@@ -650,87 +650,218 @@ async def chunk_node(state: IngestionState) -> IngestionState:
             if content_type == "conversation":
                 return await _chunk_conversation(state, pd, doc_id)
 
-            cfg = CHUNK_CONFIGS.get(content_type, CHUNK_CONFIGS["notes"])
-            splitter = RecursiveCharacterTextSplitter(
-                chunk_size=cfg["chunk_size"], chunk_overlap=cfg["chunk_overlap"]
-            )
-            chunks = []
-            async with get_session_factory()() as session:
-                raw_sections = pd["sections"] if pd else []
-                if not raw_sections:
-                    raw_text = pd["raw_text"] if pd else ""
-                    raw_sections = [
-                        {
-                            "heading": "Full Text",
-                            "level": 1,
-                            "text": raw_text,
-                            "page_start": 0,
-                            "page_end": 0,
-                        }
-                    ]
+            if content_type == "paper":
+                return await _chunk_paper(state, pd, doc_id)
 
-                section_models: list[SectionModel] = []
-                for s_idx, s in enumerate(raw_sections):
-                    section_model = SectionModel(
-                        id=str(uuid.uuid4()),
-                        document_id=doc_id,
-                        heading=s.get("heading", "") or f"Section {s_idx + 1}",
-                        level=s.get("level", 1),
-                        page_start=s.get("page_start", 0),
-                        page_end=s.get("page_end", 0),
-                        section_order=s_idx,
-                        preview=s.get("text", "")[:10000],
-                    )
-                    session.add(section_model)
-                    section_models.append(section_model)
-                await session.flush()
-
-                chunk_models: list[ChunkModel] = []
-                chunk_idx = 0
-                fmt = state.get("format", "").lower()
-
-                for section_model, s in zip(section_models, raw_sections, strict=False):
-                    section_text = s.get("text", "")
-                    if not section_text.strip():
-                        continue
-
-                    chunk_pdf_page: int | None = None
-                    if fmt == "pdf":
-                        chunk_pdf_page = s.get("page_start", 0) or 1
-
-                    for text in splitter.split_text(section_text):
-                        chunk_id = str(uuid.uuid4())
-                        chunk_models.append(
-                            ChunkModel(
-                                id=chunk_id,
-                                document_id=doc_id,
-                                section_id=section_model.id,
-                                text=text,
-                                token_count=len(text.split()),
-                                page_number=s.get("page_start", 0),
-                                speaker=None,
-                                chunk_index=chunk_idx,
-                                pdf_page_number=chunk_pdf_page,
-                            )
-                        )
-                        chunks.append(
-                            {
-                                "id": chunk_id,
-                                "document_id": doc_id,
-                                "text": text,
-                                "index": chunk_idx,
-                            }
-                        )
-                        chunk_idx += 1
-                session.add_all(chunk_models)
-                await session.commit()
-            logger.info(
-                "Chunked document",
-                extra={"doc_id": doc_id, "num_chunks": len(chunks)},
-            )
-            return {**state, "chunks": chunks, "status": "embedding"}
+            return await _chunk_generic(state, pd, doc_id, content_type)
         except Exception as exc:
             logger.error("chunk_node failed", exc_info=exc)
             return {**state, "status": "error", "error": str(exc)}
+
+
+async def _chunk_paper(state: IngestionState, pd: dict | None, doc_id: str) -> IngestionState:
+    """Research-paper chunking: captions atomic, figure internals and reference
+    lists kept out of the index, prose split sentence-aware.
+
+    Falls back to generic chunking when the document does not present recognisable
+    paper structure, or on any failure -- a paper that ingests imperfectly beats
+    one that does not ingest at all.
+    """
+    from app.services.paper_chunker import (  # noqa: PLC0415
+        chunk_paper_section,
+        is_references_heading,
+        looks_like_paper,
+    )
+
+    raw_sections = (pd["sections"] if pd else []) or []
+    if not looks_like_paper(raw_sections):
+        logger.info(
+            "Paper structure not recognised; using generic chunking",
+            extra={"doc_id": doc_id, "num_sections": len(raw_sections)},
+        )
+        return await _chunk_generic(state, pd, doc_id, "paper")
+
+    try:
+        cfg = CHUNK_CONFIGS["paper"]
+        chunks: list[dict] = []
+        async with get_session_factory()() as session:
+            doc_result = await session.execute(
+                select(DocumentModel.title).where(DocumentModel.id == doc_id)
+            )
+            paper_title = doc_result.scalar_one_or_none() or "Unknown Paper"
+
+            section_models: list[SectionModel] = []
+            for s_idx, s in enumerate(raw_sections):
+                section_model = SectionModel(
+                    id=str(uuid.uuid4()),
+                    document_id=doc_id,
+                    heading=s.get("heading", "") or f"Section {s_idx + 1}",
+                    level=s.get("level", 1),
+                    page_start=s.get("page_start", 0),
+                    page_end=s.get("page_end", 0),
+                    section_order=s_idx,
+                    preview=s.get("text", "")[:10000],
+                )
+                session.add(section_model)
+                section_models.append(section_model)
+            await session.flush()
+
+            chunk_models: list[ChunkModel] = []
+            chunk_idx = 0
+            is_pdf = state.get("format", "").lower() == "pdf"
+            skipped_reference_sections = 0
+
+            for section_model, s in zip(section_models, raw_sections, strict=False):
+                section_text = s.get("text", "")
+                if not section_text.strip():
+                    continue
+
+                # Reference lists stay readable as a section but are not indexed:
+                # they are author/venue strings that dilute both vector and BM25
+                # results without ever being the answer to a question.
+                if is_references_heading(section_model.heading):
+                    skipped_reference_sections += 1
+                    continue
+
+                context_header = f"[{paper_title} > {section_model.heading}]"
+                chunk_pdf_page = (s.get("page_start", 0) or 1) if is_pdf else None
+
+                for text in chunk_paper_section(
+                    section_text, cfg["chunk_size"], cfg["chunk_overlap"]
+                ):
+                    chunk_id = str(uuid.uuid4())
+                    chunk_models.append(
+                        ChunkModel(
+                            id=chunk_id,
+                            document_id=doc_id,
+                            section_id=section_model.id,
+                            text=text,
+                            token_count=len(text.split()),
+                            page_number=s.get("page_start", 0),
+                            speaker=None,
+                            chunk_index=chunk_idx,
+                            pdf_page_number=chunk_pdf_page,
+                            context_header=context_header,
+                        )
+                    )
+                    chunks.append(
+                        {
+                            "id": chunk_id,
+                            "document_id": doc_id,
+                            "text": text,
+                            "index": chunk_idx,
+                        }
+                    )
+                    chunk_idx += 1
+
+            session.add_all(chunk_models)
+            await session.commit()
+
+        logger.info(
+            "Paper chunking complete",
+            extra={
+                "doc_id": doc_id,
+                "num_chunks": len(chunks),
+                "num_sections": len(section_models),
+                "skipped_reference_sections": skipped_reference_sections,
+            },
+        )
+        return {**state, "chunks": chunks, "status": "embedding"}
+    except Exception as exc:
+        logger.warning(
+            "Paper chunking failed; falling back to generic chunking",
+            exc_info=exc,
+            extra={"doc_id": doc_id},
+        )
+        return await _chunk_generic(state, pd, doc_id, "paper")
+
+
+async def _chunk_generic(
+    state: IngestionState, pd: dict | None, doc_id: str, content_type: str
+) -> IngestionState:
+    """Section-aware chunking with the default splitter.
+
+    Also the fallback for content types with a specialised chunker, so an
+    unrecognised or malformed document still ingests instead of failing.
+    """
+    cfg = CHUNK_CONFIGS.get(content_type, CHUNK_CONFIGS["notes"])
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=cfg["chunk_size"], chunk_overlap=cfg["chunk_overlap"]
+    )
+    chunks = []
+    async with get_session_factory()() as session:
+        raw_sections = pd["sections"] if pd else []
+        if not raw_sections:
+            raw_text = pd["raw_text"] if pd else ""
+            raw_sections = [
+                {
+                    "heading": "Full Text",
+                    "level": 1,
+                    "text": raw_text,
+                    "page_start": 0,
+                    "page_end": 0,
+                }
+            ]
+
+        section_models: list[SectionModel] = []
+        for s_idx, s in enumerate(raw_sections):
+            section_model = SectionModel(
+                id=str(uuid.uuid4()),
+                document_id=doc_id,
+                heading=s.get("heading", "") or f"Section {s_idx + 1}",
+                level=s.get("level", 1),
+                page_start=s.get("page_start", 0),
+                page_end=s.get("page_end", 0),
+                section_order=s_idx,
+                preview=s.get("text", "")[:10000],
+            )
+            session.add(section_model)
+            section_models.append(section_model)
+        await session.flush()
+
+        chunk_models: list[ChunkModel] = []
+        chunk_idx = 0
+        fmt = state.get("format", "").lower()
+
+        for section_model, s in zip(section_models, raw_sections, strict=False):
+            section_text = s.get("text", "")
+            if not section_text.strip():
+                continue
+
+            chunk_pdf_page: int | None = None
+            if fmt == "pdf":
+                chunk_pdf_page = s.get("page_start", 0) or 1
+
+            for text in splitter.split_text(section_text):
+                chunk_id = str(uuid.uuid4())
+                chunk_models.append(
+                    ChunkModel(
+                        id=chunk_id,
+                        document_id=doc_id,
+                        section_id=section_model.id,
+                        text=text,
+                        token_count=len(text.split()),
+                        page_number=s.get("page_start", 0),
+                        speaker=None,
+                        chunk_index=chunk_idx,
+                        pdf_page_number=chunk_pdf_page,
+                    )
+                )
+                chunks.append(
+                    {
+                        "id": chunk_id,
+                        "document_id": doc_id,
+                        "text": text,
+                        "index": chunk_idx,
+                    }
+                )
+                chunk_idx += 1
+        session.add_all(chunk_models)
+        await session.commit()
+    logger.info(
+        "Chunked document",
+        extra={"doc_id": doc_id, "num_chunks": len(chunks)},
+    )
+    return {**state, "chunks": chunks, "status": "embedding"}
 
 

--- a/backend/tests/test_article_extractor.py
+++ b/backend/tests/test_article_extractor.py
@@ -1,0 +1,124 @@
+import pytest
+
+trafilatura = pytest.importorskip("trafilatura")
+
+from app.services.article_extractor import ArticleExtractor  # noqa: E402
+
+PAD = "padding sentence for extractor density. " * 20
+
+
+def _extract(html: str) -> str:
+    extractor = ArticleExtractor()
+    return trafilatura.extract(
+        extractor._prepare_html(html),
+        output_format="markdown",
+        include_links=True,
+        include_images=True,
+        include_formatting=True,
+    )
+
+
+def _wrap(body: str) -> str:
+    return (
+        f"<html><body><article><h1>Title</h1><p>{PAD}</p>{body}<p>{PAD}</p></article></body></html>"
+    )
+
+
+class TestLazyImageHydration:
+    def test_picture_source_srcset_is_hydrated(self):
+        html = _wrap(
+            "<figure><picture>"
+            '<source srcset="https://cdn.test/small.png 640w, https://cdn.test/large.png 1400w">'
+            '<img role="presentation" width="700">'
+            "</picture></figure>"
+        )
+        assert "![](https://cdn.test/large.png)" in _extract(html)
+
+    def test_data_src_is_hydrated(self):
+        html = _wrap('<figure><img data-src="https://cdn.test/diagram.png"></figure>')
+        assert "https://cdn.test/diagram.png" in _extract(html)
+
+    def test_figcaption_becomes_alt_text(self):
+        html = _wrap(
+            '<figure><img data-src="https://cdn.test/d.png">'
+            "<figcaption>Figure 1: system schematic</figcaption></figure>"
+        )
+        assert "![Figure 1: system schematic](https://cdn.test/d.png)" in _extract(html)
+
+    def test_existing_src_is_not_overwritten(self):
+        html = _wrap(
+            '<figure><picture><source srcset="https://cdn.test/other.png 1400w">'
+            '<img src="https://cdn.test/original.png"></picture></figure>'
+        )
+        assert "https://cdn.test/original.png" in _extract(html)
+
+
+class TestListStructure:
+    def test_bold_prefixed_items_keep_bullets_and_spacing(self):
+        html = _wrap(
+            "<ul>"
+            "<li><strong>Positive Signals:</strong> capturing engagement.</li>"
+            "<li><strong>Negative Signals:</strong> capturing fatigue.</li>"
+            "</ul>"
+        )
+        lines = _extract(html).splitlines()
+        assert "- **Positive Signals:** capturing engagement." in lines
+        assert "- **Negative Signals:** capturing fatigue." in lines
+
+    def test_link_leading_item_is_not_dropped(self):
+        html = _wrap('<ul><li><a href="https://test.dev">Planner</a> writes intent.</li></ul>')
+        assert "- [Planner](https://test.dev) writes intent." in _extract(html).splitlines()
+
+    def test_plain_items_are_unaffected(self):
+        html = _wrap("<ul><li>first item</li><li>second item</li></ul>")
+        lines = _extract(html).splitlines()
+        assert "- first item" in lines
+        assert "- second item" in lines
+
+
+class TestAnchorFlatteningScope:
+    def test_anchors_in_prose_stay_real_links(self):
+        """Flattened anchors are invisible to trafilatura's link-density heuristic."""
+        html = _wrap('<p>See <a href="https://test.dev">the docs</a> for detail.</p>')
+        prepared = ArticleExtractor()._prepare_html(html)
+        assert '<a href="https://test.dev">the docs</a>' in prepared
+
+    def test_anchors_in_navigation_lists_are_untouched(self):
+        html = _wrap('<nav><ul><li><a href="/home">Home</a></li></ul></nav>')
+        prepared = ArticleExtractor()._prepare_html(html)
+        assert '<a href="/home">Home</a>' in prepared
+
+    def test_anchors_in_content_list_items_are_flattened(self):
+        html = _wrap('<ul><li><a href="https://test.dev">Planner</a> writes intent.</li></ul>')
+        prepared = ArticleExtractor()._prepare_html(html)
+        assert "[Planner](https://test.dev)" in prepared
+
+
+class TestInlineFormatting:
+    def test_inter_element_spacing_is_preserved(self):
+        html = _wrap(
+            "<p>Uses <strong>fast</strong> <em>slow</em> "
+            '<a href="https://t.dev">policy</a> here.</p>'
+        )
+        assert "Uses **fast** *slow* [policy](https://t.dev) here." in _extract(html)
+
+    def test_code_inside_pre_is_not_double_wrapped(self):
+        html = _wrap("<pre><code>value = compute(1)</code></pre>")
+        extracted = _extract(html)
+        assert "`value = compute(1)`" in extracted
+        assert "``" not in extracted
+
+
+class TestBestSrcsetUrl:
+    @pytest.mark.parametrize(
+        ("srcset", "expected"),
+        [
+            ("https://cdn.test/a.png 640w, https://cdn.test/b.png 1400w", "https://cdn.test/b.png"),
+            ("https://cdn.test/only.png", "https://cdn.test/only.png"),
+            ("https://cdn.test/a.png bad, https://cdn.test/b.png 800w", "https://cdn.test/b.png"),
+            ("", None),
+            (None, None),
+        ],
+    )
+    def test_picks_highest_width(self, srcset, expected):
+        assert ArticleExtractor._best_srcset_url(srcset) == expected

--- a/backend/tests/test_background_routing_privacy.py
+++ b/backend/tests/test_background_routing_privacy.py
@@ -1,10 +1,15 @@
-"""Automatic tasks must not send user content to a cloud provider.
+"""Work on the user's own content must not reach a cloud provider.
 
 In hybrid mode `get_effective_routing` sends interactive traffic to the cloud
-and background traffic to local Ollama. A background caller that omits
-`background=True` silently takes the interactive route -- which is how the note
+and everything flagged `background=True` to local Ollama. A caller that omits
+the flag silently takes the interactive route -- which is how the note
 description backfill came to send every note to OpenAI at startup, visible only
 in the traces.
+
+The policy is local-by-default: notes and documents are personal, so a call site
+handling them stays on the machine even when a click triggered it. Cloud routing
+is reserved for the surfaces where reaching for a bigger model is the point of
+hybrid mode (chat, explain, feynman, study, flashcard generation).
 
 These tests pin the routing contract and the call sites that depend on it.
 """
@@ -16,13 +21,23 @@ import pytest
 
 from app.services import settings_service as ss
 
-# Automatic, non-user-initiated work on private content. Each entry is the
-# module and the callee whose invocation must carry background=True.
-AUTOMATIC_CALL_SITES = [
+# Call sites that must never leave the machine, as (module, callee). Two groups:
+# automatic tasks that run without the user asking, and user-triggered helpers
+# that nonetheless process the user's own notes or documents.
+LOCAL_ONLY_CALL_SITES = [
+    # Automatic
     ("app/services/note_description_generator.py", "complete"),
     ("app/services/document_tagger.py", "complete"),
     ("app/workflows/ingestion_nodes/parse.py", "generate"),
     ("app/workflows/concept_nodes/score_concepts.py", "complete"),
+    # User-triggered, but operating on the user's own notes / documents
+    ("app/services/note_tagger.py", "complete"),
+    ("app/services/note_title_generator.py", "complete"),
+    ("app/services/clustering_service.py", "complete"),
+    ("app/services/gap_detector.py", "complete"),
+    ("app/services/suggestion_service.py", "complete"),
+    ("app/services/topic_service.py", "complete"),
+    ("app/services/flashcard_audit.py", "generate"),
 ]
 
 
@@ -58,8 +73,8 @@ def test_hybrid_sends_background_work_to_ollama(hybrid_routing):
     )
 
 
-@pytest.mark.parametrize(("module_path", "callee"), AUTOMATIC_CALL_SITES)
-def test_automatic_call_sites_declare_background(module_path, callee):
+@pytest.mark.parametrize(("module_path", "callee"), LOCAL_ONLY_CALL_SITES)
+def test_local_only_call_sites_declare_background(module_path, callee):
     path = pathlib.Path(__file__).resolve().parents[1] / module_path
     tree = ast.parse(path.read_text())
 

--- a/backend/tests/test_connectivity.py
+++ b/backend/tests/test_connectivity.py
@@ -1,0 +1,41 @@
+"""Provider reachability probe used by offline-aware routing."""
+
+import app.services.connectivity as conn
+
+
+def setup_function():
+    conn.reset_cache()
+
+
+def test_local_models_are_always_reachable(monkeypatch):
+    # Even with every probe failing, an ollama/ model must never be probed.
+    monkeypatch.setattr(conn, "_probe", lambda *a, **k: False)
+    assert conn.provider_reachable("ollama/qwen2.5:14b-instruct") is True
+
+
+def test_cloud_model_reflects_probe(monkeypatch):
+    monkeypatch.setattr(conn, "_probe", lambda *a, **k: False)
+    assert conn.provider_reachable("openai/gpt-5-mini") is False
+    conn.reset_cache()
+    monkeypatch.setattr(conn, "_probe", lambda *a, **k: True)
+    assert conn.provider_reachable("openai/gpt-5-mini") is True
+
+
+def test_result_is_cached(monkeypatch):
+    calls = {"n": 0}
+
+    def counting_probe(*a, **k):
+        calls["n"] += 1
+        return False
+
+    monkeypatch.setattr(conn, "_probe", counting_probe)
+    conn.provider_reachable("anthropic/claude-sonnet-5")
+    conn.provider_reachable("anthropic/claude-sonnet-5")
+    assert calls["n"] == 1, "second call within TTL must use the cache"
+
+
+def test_is_cloud_model():
+    assert conn.is_cloud_model("openai/gpt-5-mini")
+    assert conn.is_cloud_model("anthropic/claude-sonnet-5")
+    assert conn.is_cloud_model("gemini/gemini-2.0-flash")
+    assert not conn.is_cloud_model("ollama/qwen2.5:14b-instruct")

--- a/backend/tests/test_image_enricher.py
+++ b/backend/tests/test_image_enricher.py
@@ -1,7 +1,8 @@
 """Tests for ImageEnricherService (S134).
 
 Unit tests use in-memory SQLite + mocked LiteDB and LiteLLM.
-Integration test (requires ollama llava) is guarded with pytest.mark.skipif.
+The integration test calls a real vision model; it is marked e2e (excluded by
+default) and additionally skipped unless the configured VISION_MODEL is pulled.
 """
 
 import asyncio
@@ -675,23 +676,30 @@ async def test_image_analyze_handler_no_qualifying_images_skips_enqueue(
     assert len(jobs) == 0
 
 
-# Integration test — requires ollama with llava model
+# Integration test — requires ollama with the configured VISION_MODEL pulled
 
 
-def _ollama_has_llava() -> bool:
-    """Return True if ollama is in PATH and llava model is listed."""
+def _configured_vision_model() -> str:
+    """The vision model the app would actually use, without the provider prefix."""
+    from app.config import get_settings  # noqa: PLC0415
+
+    return get_settings().VISION_MODEL.removeprefix("ollama/")
+
+
+def _ollama_has_vision_model() -> bool:
+    """Return True if ollama is in PATH and the configured vision model is pulled."""
     if not shutil.which("ollama"):
         return False
     import subprocess  # noqa: PLC0415
 
     try:
         result = subprocess.run(["ollama", "list"], capture_output=True, text=True, timeout=5)
-        return "llava:7b" in result.stdout
+        return _configured_vision_model() in result.stdout
     except Exception:
         return False
 
 
-_HAS_OLLAMA = _ollama_has_llava()
+_HAS_OLLAMA = _ollama_has_vision_model()
 
 
 @pytest.mark.e2e
@@ -700,10 +708,11 @@ _HAS_OLLAMA = _ollama_has_llava()
 async def test_integration_vision_analysis_real_image(tmp_path: Path) -> None:
     """Integration: enrich() calls real vision LLM and stores description.
 
-    Requires ollama running with llava:7b pulled, and marked e2e because of it:
-    a real vision inference overruns the 120s global timeout, which kills the
-    whole session and blames whichever test happened to be running. The skipif
-    alone is not enough -- it passes on any developer machine that has the model.
+    Requires ollama running with the configured VISION_MODEL pulled, and marked
+    e2e because of it: a real inference in the default suite can overrun the 120s
+    global timeout, which kills the whole session and blames whichever test
+    happened to be running. The skipif alone is not enough -- it passes on any
+    developer machine that has the model.
     """
     from app.services.image_enricher import ImageEnricherService  # noqa: PLC0415
 
@@ -760,6 +769,10 @@ async def test_integration_vision_analysis_real_image(tmp_path: Path) -> None:
     mock_embedder = MagicMock()
     mock_embedder.encode.return_value = [[0.1] * 384]
 
+    # Resolve before patching: inside the context get_settings is a MagicMock,
+    # so reading VISION_MODEL there yields a mock rather than the real name.
+    vision_model = _configured_vision_model()
+
     with (
         patch("app.database.get_session_factory", return_value=sf),
         patch("app.config.get_settings") as mock_settings,
@@ -768,7 +781,10 @@ async def test_integration_vision_analysis_real_image(tmp_path: Path) -> None:
     ):
         settings = MagicMock()
         settings.DATA_DIR = str(tmp_path)
-        settings.VISION_MODEL = "ollama/llava:7b"
+        # Exercise the model the app is actually configured to use. This test
+        # makes a real call, so a pinned literal would validate a model that is
+        # no longer in the pipeline.
+        settings.VISION_MODEL = f"ollama/{vision_model}"
         settings.OLLAMA_URL = "http://localhost:11434"
         settings.LITELLM_DEFAULT_MODEL = "ollama/gemma4"
         mock_settings.return_value = settings

--- a/backend/tests/test_image_enricher.py
+++ b/backend/tests/test_image_enricher.py
@@ -694,13 +694,16 @@ def _ollama_has_llava() -> bool:
 _HAS_OLLAMA = _ollama_has_llava()
 
 
+@pytest.mark.e2e
 @pytest.mark.skipif(not _HAS_OLLAMA, reason="ollama not available in this environment")
 @pytest.mark.asyncio
 async def test_integration_vision_analysis_real_image(tmp_path: Path) -> None:
     """Integration: enrich() calls real vision LLM and stores description.
 
-    Requires: ollama running with llava:13b pulled.
-    Skipped automatically if ollama is not in PATH.
+    Requires ollama running with llava:7b pulled, and marked e2e because of it:
+    a real vision inference overruns the 120s global timeout, which kills the
+    whole session and blames whichever test happened to be running. The skipif
+    alone is not enough -- it passes on any developer machine that has the model.
     """
     from app.services.image_enricher import ImageEnricherService  # noqa: PLC0415
 

--- a/backend/tests/test_llm_offline_fallback.py
+++ b/backend/tests/test_llm_offline_fallback.py
@@ -1,0 +1,171 @@
+"""With no internet, routed cloud calls must fall back to the local model.
+
+The app is local-first: losing connectivity should degrade to Ollama rather than
+surface an error. Explicitly pinned models are exempt so evals and per-request
+overrides stay reproducible.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import litellm
+import pytest
+
+from app.services import settings_service as ss
+from app.services.llm import LLMService
+
+
+def _response(text: str) -> MagicMock:
+    message = MagicMock()
+    message.content = text
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = None
+    return response
+
+
+@pytest.fixture
+def cloud_routing():
+    """Route to a cloud provider, as hybrid mode does for interactive calls."""
+    original = dict(ss._cache)
+    ss._cache.update(
+        {
+            "llm_mode": "cloud",
+            "cloud_provider": "openai",
+            "cloud_model": "gpt-5-mini",
+            "openai_api_key": "sk-test-not-a-real-key",
+        }
+    )
+    yield
+    ss._cache.clear()
+    ss._cache.update(original)
+
+
+def _unreachable_then_ok(text: str = "local answer"):
+    """First call fails as if offline; the retry succeeds."""
+    calls: list[dict] = []
+
+    async def side_effect(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise litellm.APIConnectionError(
+                message="offline", llm_provider="openai", model="gpt-5-mini"
+            )
+        return _response(text)
+
+    return side_effect, calls
+
+
+@pytest.mark.asyncio
+async def test_routed_cloud_call_falls_back_to_local(cloud_routing):
+    svc = LLMService()
+    side_effect, calls = _unreachable_then_ok()
+    with patch("litellm.acompletion", side_effect=side_effect):
+        result = await svc.complete([{"role": "user", "content": "hi"}])
+
+    assert result == "local answer"
+    assert len(calls) == 2
+    assert calls[0]["model"].startswith("openai/")
+    assert calls[1]["model"].startswith("ollama/"), "retry must use the local model"
+
+
+@pytest.mark.asyncio
+async def test_pinned_model_does_not_fall_back(cloud_routing):
+    """An explicit model= is a reproducibility contract -- never silently swapped."""
+    svc = LLMService()
+    side_effect, calls = _unreachable_then_ok()
+    with (
+        patch("litellm.acompletion", side_effect=side_effect),
+        pytest.raises(litellm.APIConnectionError),
+    ):
+        await svc.complete([{"role": "user", "content": "hi"}], model="openai/gpt-5-mini")
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_local_call_does_not_fall_back(cloud_routing):
+    """Ollama being down is a real failure; there is nowhere further to go."""
+    svc = LLMService()
+    side_effect, calls = _unreachable_then_ok()
+    with (
+        patch("litellm.acompletion", side_effect=side_effect),
+        pytest.raises(litellm.APIConnectionError),
+    ):
+        await svc.complete([{"role": "user", "content": "hi"}], model="ollama/qwen2.5:14b-instruct")
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_auth_error_is_not_masked_by_fallback(cloud_routing):
+    """A bad key must surface, not be hidden behind a local answer."""
+    svc = LLMService()
+
+    async def side_effect(**kwargs):
+        raise litellm.AuthenticationError(
+            message="bad key", llm_provider="openai", model="gpt-5-mini"
+        )
+
+    with (
+        patch("litellm.acompletion", side_effect=side_effect),
+        pytest.raises(litellm.AuthenticationError),
+    ):
+        await svc.complete([{"role": "user", "content": "hi"}])
+
+
+@pytest.mark.asyncio
+async def test_hybrid_background_call_is_already_local(cloud_routing):
+    """Regression guard for the privacy routing: in hybrid, background is local."""
+    ss._cache["llm_mode"] = "hybrid"
+    svc = LLMService()
+    with patch(
+        "litellm.acompletion", new_callable=AsyncMock, return_value=_response("ok")
+    ) as mock_ac:
+        await svc.complete([{"role": "user", "content": "hi"}], background=True)
+    assert mock_ac.call_args.kwargs["model"].startswith("ollama/")
+
+
+@pytest.mark.asyncio
+async def test_cloud_mode_ignores_background(cloud_routing):
+    """Documents a real gap: `background=True` only routes local in HYBRID mode.
+
+    In cloud mode get_effective_routing returns the cloud model regardless, so the
+    local-only call sites (note tagging, titles, clustering) reach the provider.
+    """
+    svc = LLMService()
+    with patch(
+        "litellm.acompletion", new_callable=AsyncMock, return_value=_response("ok")
+    ) as mock_ac:
+        await svc.complete([{"role": "user", "content": "hi"}], background=True)
+    assert mock_ac.call_args.kwargs["model"].startswith("openai/")
+
+
+@pytest.mark.asyncio
+async def test_streaming_falls_back_to_local(cloud_routing):
+    svc = LLMService()
+    calls: list[dict] = []
+
+    async def chunks():
+        for text in ("local ", "stream"):
+            delta = MagicMock()
+            delta.content = text
+            choice = MagicMock()
+            choice.delta = delta
+            chunk = MagicMock()
+            chunk.choices = [choice]
+            yield chunk
+
+    async def side_effect(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise litellm.APIConnectionError(
+                message="offline", llm_provider="openai", model="gpt-5-mini"
+            )
+        return chunks()
+
+    with patch("litellm.acompletion", side_effect=side_effect):
+        stream = await svc.stream_messages([{"role": "user", "content": "hi"}])
+        out = "".join([token async for token in stream])
+
+    assert out == "local stream"
+    assert calls[1]["model"].startswith("ollama/")

--- a/backend/tests/test_llm_offline_fallback.py
+++ b/backend/tests/test_llm_offline_fallback.py
@@ -10,8 +10,51 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import litellm
 import pytest
 
+from app.services import connectivity
 from app.services import settings_service as ss
-from app.services.llm import LLMService
+from app.services.llm import LLMService, _is_offline_error
+
+
+@pytest.fixture(autouse=True)
+def _online(monkeypatch):
+    """Default to 'provider reachable' so tests exercise the reactive path unless
+    they opt into the proactive offline reroute."""
+    connectivity.reset_cache()
+    monkeypatch.setattr(connectivity, "provider_reachable", lambda model: True)
+    yield
+    connectivity.reset_cache()
+
+
+def _connection_error() -> Exception:
+    """The exception litellm actually raises offline: InternalServerError whose
+    cause chain is a connection failure, NOT APIConnectionError."""
+    import litellm
+
+    root = ConnectionError("Cannot connect to host api.openai.com:443")
+    try:
+        raise litellm.InternalServerError(
+            message="OpenAIException - Connection error",
+            llm_provider="openai",
+            model="gpt-5-mini",
+        ) from root
+    except litellm.InternalServerError as exc:
+        return exc
+
+
+class TestOfflineErrorDetection:
+    def test_litellm_internal_server_error_from_connection_is_offline(self):
+        assert _is_offline_error(_connection_error())
+
+    def test_plain_value_error_is_not_offline(self):
+        assert not _is_offline_error(ValueError("bad json"))
+
+    def test_genuine_internal_server_error_is_not_offline(self):
+        import litellm
+
+        exc = litellm.InternalServerError(
+            message="upstream 500", llm_provider="openai", model="gpt-5-mini"
+        )
+        assert not _is_offline_error(exc)
 
 
 def _response(text: str) -> MagicMock:
@@ -43,15 +86,13 @@ def cloud_routing():
 
 
 def _unreachable_then_ok(text: str = "local answer"):
-    """First call fails as if offline; the retry succeeds."""
+    """First call fails with the exception litellm really raises offline; retry ok."""
     calls: list[dict] = []
 
     async def side_effect(**kwargs):
         calls.append(kwargs)
         if len(calls) == 1:
-            raise litellm.APIConnectionError(
-                message="offline", llm_provider="openai", model="gpt-5-mini"
-            )
+            raise _connection_error()
         return _response(text)
 
     return side_effect, calls
@@ -71,13 +112,32 @@ async def test_routed_cloud_call_falls_back_to_local(cloud_routing):
 
 
 @pytest.mark.asyncio
+async def test_offline_reroutes_before_any_cloud_call(cloud_routing, monkeypatch):
+    """When the probe says offline, no cloud call is attempted at all."""
+    monkeypatch.setattr(connectivity, "provider_reachable", lambda model: False)
+    svc = LLMService()
+    calls: list[dict] = []
+
+    async def side_effect(**kwargs):
+        calls.append(kwargs)
+        return _response("local answer")
+
+    with patch("litellm.acompletion", side_effect=side_effect):
+        result = await svc.complete([{"role": "user", "content": "hi"}])
+
+    assert result == "local answer"
+    assert len(calls) == 1, "must not attempt the cloud call first"
+    assert calls[0]["model"].startswith("ollama/")
+
+
+@pytest.mark.asyncio
 async def test_pinned_model_does_not_fall_back(cloud_routing):
     """An explicit model= is a reproducibility contract -- never silently swapped."""
     svc = LLMService()
     side_effect, calls = _unreachable_then_ok()
     with (
         patch("litellm.acompletion", side_effect=side_effect),
-        pytest.raises(litellm.APIConnectionError),
+        pytest.raises(litellm.InternalServerError),
     ):
         await svc.complete([{"role": "user", "content": "hi"}], model="openai/gpt-5-mini")
     assert len(calls) == 1
@@ -90,7 +150,7 @@ async def test_local_call_does_not_fall_back(cloud_routing):
     side_effect, calls = _unreachable_then_ok()
     with (
         patch("litellm.acompletion", side_effect=side_effect),
-        pytest.raises(litellm.APIConnectionError),
+        pytest.raises(litellm.InternalServerError),
     ):
         await svc.complete([{"role": "user", "content": "hi"}], model="ollama/qwen2.5:14b-instruct")
     assert len(calls) == 1

--- a/backend/tests/test_paper_chunk_node.py
+++ b/backend/tests/test_paper_chunk_node.py
@@ -1,0 +1,182 @@
+"""chunk_node's paper path: routing, reference exclusion, and fallback safety."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+import app.database as db_module
+from app.database import make_engine
+from app.db_init import create_all_tables
+from app.models import ChunkModel, DocumentModel, SectionModel
+from app.workflows.ingestion import chunk_node
+
+PROSE = " ".join(f"Sentence {i} states a claim about the model." for i in range(60))
+
+
+@pytest.fixture
+async def test_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    await create_all_tables(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    orig_engine, orig_factory = db_module._engine, db_module._session_factory
+    db_module._engine, db_module._session_factory = engine, factory
+    yield engine, factory, tmp_path
+    db_module._engine, db_module._session_factory = orig_engine, orig_factory
+    get_settings.cache_clear()
+    await engine.dispose()
+
+
+async def _insert_document(factory, doc_id: str, tmp_path: Path) -> None:
+    async with factory() as session:
+        session.add(
+            DocumentModel(
+                id=doc_id,
+                title="A Research Paper",
+                format="pdf",
+                content_type="paper",
+                word_count=500,
+                page_count=10,
+                file_path=str(tmp_path / "paper.pdf"),
+                stage="chunking",
+            )
+        )
+        await session.commit()
+
+
+def _state(doc_id: str, sections: list[dict], tmp_path: Path) -> dict:
+    return {
+        "document_id": doc_id,
+        "file_path": str(tmp_path / "paper.pdf"),
+        "format": "pdf",
+        "content_type": "paper",
+        "parsed_document": {
+            "title": "A Research Paper",
+            "format": "pdf",
+            "pages": 10,
+            "word_count": 500,
+            "sections": sections,
+            "raw_text": PROSE,
+        },
+        "chunks": None,
+        "status": "chunking",
+        "error": None,
+    }
+
+
+def _section(heading: str, text: str = PROSE) -> dict:
+    return {"heading": heading, "level": 1, "text": text, "page_start": 1, "page_end": 2}
+
+
+PAPER_SECTIONS = [
+    _section("Abstract"),
+    _section("1. Introduction"),
+    _section("2. Methods"),
+    _section("3. Results"),
+    _section("References", "Smith et al. 2020. A Title. In Proceedings.\nJones 2021. Another."),
+]
+
+
+@pytest.mark.asyncio
+async def test_paper_path_excludes_references_from_chunks(test_db):
+    _, factory, tmp_path = test_db
+    doc_id = "paper-refs"
+    await _insert_document(factory, doc_id, tmp_path)
+
+    result = await chunk_node(_state(doc_id, PAPER_SECTIONS, tmp_path))
+    assert result["status"] == "embedding"
+
+    async with factory() as session:
+        refs = (
+            await session.execute(
+                select(SectionModel).where(
+                    SectionModel.document_id == doc_id, SectionModel.heading == "References"
+                )
+            )
+        ).scalar_one()
+        chunks = (
+            (
+                await session.execute(
+                    select(ChunkModel).where(ChunkModel.section_id == refs.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert refs is not None, "the References section must still exist for reading"
+    assert chunks == [], "reference lists must not be indexed"
+
+
+@pytest.mark.asyncio
+async def test_paper_path_sets_context_header(test_db):
+    _, factory, tmp_path = test_db
+    doc_id = "paper-header"
+    await _insert_document(factory, doc_id, tmp_path)
+    await chunk_node(_state(doc_id, PAPER_SECTIONS, tmp_path))
+
+    async with factory() as session:
+        chunk = (
+            (await session.execute(select(ChunkModel).where(ChunkModel.document_id == doc_id)))
+            .scalars()
+            .first()
+        )
+    assert chunk.context_header is not None
+    assert "A Research Paper" in chunk.context_header
+
+
+@pytest.mark.asyncio
+async def test_unrecognised_structure_falls_back_to_generic(test_db):
+    """A misclassified document still ingests, via the generic path."""
+    _, factory, tmp_path = test_db
+    doc_id = "paper-unstructured"
+    await _insert_document(factory, doc_id, tmp_path)
+
+    sections = [_section("Getting Started"), _section("Installing"), _section("FAQ")]
+    result = await chunk_node(_state(doc_id, sections, tmp_path))
+
+    assert result["status"] == "embedding"
+    async with factory() as session:
+        chunks = (
+            (await session.execute(select(ChunkModel).where(ChunkModel.document_id == doc_id)))
+            .scalars()
+            .all()
+        )
+    assert len(chunks) > 0
+
+
+@pytest.mark.asyncio
+async def test_paper_chunker_failure_falls_back_without_duplicating_sections(test_db):
+    """On failure the paper transaction must roll back before the generic retry,
+    or the document ends up with two copies of every section."""
+    _, factory, tmp_path = test_db
+    doc_id = "paper-boom"
+    await _insert_document(factory, doc_id, tmp_path)
+
+    with patch(
+        "app.services.paper_chunker.chunk_paper_section",
+        side_effect=RuntimeError("boom"),
+    ):
+        result = await chunk_node(_state(doc_id, PAPER_SECTIONS, tmp_path))
+
+    assert result["status"] == "embedding"
+    async with factory() as session:
+        sections = (
+            (await session.execute(select(SectionModel).where(SectionModel.document_id == doc_id)))
+            .scalars()
+            .all()
+        )
+        chunks = (
+            (await session.execute(select(ChunkModel).where(ChunkModel.document_id == doc_id)))
+            .scalars()
+            .all()
+        )
+
+    assert len(sections) == len(PAPER_SECTIONS), "sections duplicated by the fallback"
+    assert len(chunks) > 0

--- a/backend/tests/test_paper_chunker.py
+++ b/backend/tests/test_paper_chunker.py
@@ -1,0 +1,117 @@
+"""Structure-aware chunking for research papers, and its fallback gate."""
+
+from app.services.paper_chunker import (
+    chunk_paper_section,
+    is_references_heading,
+    looks_like_paper,
+    segment_section,
+    unwrap_prose,
+)
+
+
+def _sections(*headings: str) -> list[dict]:
+    return [{"heading": h, "text": "body text"} for h in headings]
+
+
+class TestStructureGate:
+    def test_imrad_paper_is_recognised(self):
+        assert looks_like_paper(
+            _sections("Abstract", "Introduction", "Methods", "Results", "Conclusion")
+        )
+
+    def test_numbered_sections_with_anchor_are_recognised(self):
+        assert looks_like_paper(
+            _sections("Abstract", "1. Background", "2.1 Model", "3. Evaluation")
+        )
+
+    def test_numbered_headings_without_paper_anchor_fall_back(self):
+        """Manuals use numbered headings too; they must not take the paper path."""
+        assert not looks_like_paper(
+            _sections("1. Getting Started", "2. Installing", "3. Troubleshooting")
+        )
+
+    def test_too_few_headings_falls_back(self):
+        assert not looks_like_paper(_sections("Abstract", "Introduction"))
+
+    def test_empty_sections_fall_back(self):
+        assert not looks_like_paper([])
+
+
+class TestReferencesDetection:
+    def test_variants_are_detected(self):
+        for heading in ("References", "REFERENCES", "Bibliography", "7. References"):
+            assert is_references_heading(heading), heading
+
+    def test_body_headings_are_not_references(self):
+        for heading in ("Results", "Reference Architecture", ""):
+            assert not is_references_heading(heading)
+
+
+class TestSegmentation:
+    def test_vertical_token_run_is_noise(self):
+        """PDF text layers emit figure axis labels one token per line."""
+        text = "Real prose here that continues.\n" + "\n".join(
+            ["The", "Law", "will", "never", "be", "perfect", "just"]
+        )
+        kinds = [k for k, _ in segment_section(text)]
+        assert "noise" in kinds
+
+    def test_short_token_run_is_not_noise(self):
+        text = "Prose paragraph.\n" + "\n".join(["one", "two", "three"])
+        assert "noise" not in [k for k, _ in segment_section(text)]
+
+    def test_caption_is_its_own_segment(self):
+        text = "Body prose sentence.\n\nFigure 3: A schematic of the system.\n\nMore prose."
+        assert ("caption", "Figure 3: A schematic of the system.") in segment_section(text)
+
+    def test_caption_does_not_swallow_following_pages(self):
+        """Without a bound, a caption runs to the next blank line -- which PDF
+        text layers often never emit."""
+        body = "\n".join(f"continuation line {i} of ordinary prose" for i in range(40))
+        segments = segment_section(f"Figure 1: Short caption\n{body}")
+        caption = next(t for k, t in segments if k == "caption")
+        assert len(caption) < 700
+
+
+class TestUnwrapProse:
+    def test_wrapped_lines_are_rejoined(self):
+        assert unwrap_prose("the model uses\nself-attention layers") == (
+            "the model uses self-attention layers"
+        )
+
+    def test_sentence_end_starts_a_new_line(self):
+        assert unwrap_prose("First sentence.\nSecond sentence") == (
+            "First sentence.\nSecond sentence"
+        )
+
+    def test_hyphenated_break_is_rejoined_without_hyphen(self):
+        assert unwrap_prose("atten-\ntion") == "attention"
+
+    def test_blank_lines_are_preserved(self):
+        assert unwrap_prose("para one\n\npara two") == "para one\n\npara two"
+
+
+class TestChunking:
+    def test_figure_noise_never_reaches_chunks(self):
+        text = "Prose that is long enough to matter here.\n" + "\n".join(
+            ["The", "Law", "will", "never", "be", "perfect", "<EOS>", "<pad>"]
+        )
+        joined = " ".join(chunk_paper_section(text, 900, 150))
+        assert "<EOS>" not in joined
+        assert "<pad>" not in joined
+
+    def test_caption_is_emitted_whole(self):
+        caption = "Figure 2: The encoder maps an input sequence to a continuous representation."
+        chunks = chunk_paper_section(f"Some prose.\n\n{caption}\n\nMore prose.", 900, 150)
+        assert caption in chunks
+
+    def test_chunks_respect_size_budget(self):
+        text = " ".join(f"Sentence number {i} carries some content." for i in range(400))
+        assert all(len(c) <= 900 for c in chunk_paper_section(text, 900, 150))
+
+    def test_chunks_do_not_start_with_split_punctuation(self):
+        text = " ".join(f"Sentence number {i} carries some content." for i in range(200))
+        assert not any(c.lstrip().startswith(".") for c in chunk_paper_section(text, 300, 50))
+
+    def test_empty_text_yields_no_chunks(self):
+        assert chunk_paper_section("   \n\n  ", 900, 150) == []

--- a/backend/tests/test_qa.py
+++ b/backend/tests/test_qa.py
@@ -213,10 +213,7 @@ def test_split_response_strips_leaked_citations_heading():
     """A markdown 'Citations:' heading the model writes before its JSON must not
     leak into the answer body."""
     prose = "Odysseus is inferred to hold authority in Ithaca."
-    full_text = (
-        prose + "\n\n**Citations:**\n"
-        + json.dumps({"citations": [], "confidence": "low"})
-    )
+    full_text = prose + "\n\n**Citations:**\n" + json.dumps({"citations": [], "confidence": "low"})
     answer, _, _ = _split_response(full_text)
     assert answer == prose
     assert "Citations" not in answer
@@ -317,6 +314,54 @@ def test_qa_system_prompt_mentions_citations():
 
 # QAService.stream_answer — normal flow
 # V2: mock the chat graph (graph.ainvoke returns pre-built result)
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_offline_notice_when_cloud_unreachable(test_db, monkeypatch):
+    """When routing would go to the cloud but the provider is unreachable, the Ask
+    stream tells the user it is answering locally."""
+    from app.services import connectivity, settings_service
+
+    _engine, factory, tmp_path = test_db
+    doc_id = str(uuid.uuid4())
+    await _insert_doc(factory, tmp_path, doc_id, "Biology Book")
+
+    monkeypatch.setattr(
+        settings_service, "get_effective_routing", lambda *a, **k: ("openai/gpt-5-mini", None)
+    )
+    connectivity.reset_cache()
+    monkeypatch.setattr(connectivity, "provider_reachable", lambda model: False)
+
+    result = _make_graph_result(answer="Local answer.", citations=[])
+    mock_graph = _make_mock_graph(result)
+    with patch("app.runtime.chat_graph.get_chat_graph", return_value=mock_graph):
+        events = [e async for e in QAService().stream_answer("q?", [doc_id], "single", None)]
+
+    notices = [json.loads(e[len("data: ") :]) for e in events if '"notice"' in e]
+    assert notices, "expected an offline notice event"
+    assert notices[0]["level"] == "offline"
+
+
+@pytest.mark.asyncio
+async def test_stream_no_notice_when_provider_reachable(test_db, monkeypatch):
+    from app.services import connectivity, settings_service
+
+    _engine, factory, tmp_path = test_db
+    doc_id = str(uuid.uuid4())
+    await _insert_doc(factory, tmp_path, doc_id, "Biology Book")
+
+    monkeypatch.setattr(
+        settings_service, "get_effective_routing", lambda *a, **k: ("openai/gpt-5-mini", None)
+    )
+    connectivity.reset_cache()
+    monkeypatch.setattr(connectivity, "provider_reachable", lambda model: True)
+
+    result = _make_graph_result(answer="Cloud answer.", citations=[])
+    mock_graph = _make_mock_graph(result)
+    with patch("app.runtime.chat_graph.get_chat_graph", return_value=mock_graph):
+        events = [e async for e in QAService().stream_answer("q?", [doc_id], "single", None)]
+
+    assert not any('"notice"' in e for e in events)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_section_content_reader.py
+++ b/backend/tests/test_section_content_reader.py
@@ -1,0 +1,98 @@
+"""GET /sections/{id}/content: markdown hazards in extracted text, and page range.
+
+Document text is rendered as markdown by the reader, so layout artifacts from a
+PDF text layer can be read as markup. A hyphen left alone on its own line turned
+whole sentences into headings in the reader.
+"""
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+import app.database as db_module
+from app.database import make_engine
+from app.db_init import create_all_tables
+from app.main import app
+from app.models import DocumentModel, SectionModel
+from app.routers.sections import _reader_safe
+
+
+class TestReaderSafe:
+    def test_hyphen_under_prose_no_longer_forms_a_heading(self):
+        assert _reader_safe("should be just\n-\nthis is what we are missing") == (
+            "should be just\n\n-\nthis is what we are missing"
+        )
+
+    def test_equals_underline_is_also_neutralised(self):
+        assert _reader_safe("Some prose\n===\nmore") == "Some prose\n\n===\nmore"
+
+    def test_deliberate_horizontal_rule_is_preserved(self):
+        assert _reader_safe("para one\n\n---\n\npara two") == "para one\n\n---\n\npara two"
+
+    def test_list_items_are_untouched(self):
+        assert _reader_safe("- first\n- second") == "- first\n- second"
+
+    def test_empty_text_passes_through(self):
+        assert _reader_safe("") == ""
+
+
+@pytest.fixture
+async def test_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    await create_all_tables(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    orig_engine, orig_factory = db_module._engine, db_module._session_factory
+    db_module._engine, db_module._session_factory = engine, factory
+    yield factory
+    db_module._engine, db_module._session_factory = orig_engine, orig_factory
+    get_settings.cache_clear()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_content_endpoint_exposes_page_range_and_sanitises(test_db):
+    """The reader needs page_start/page_end to place figures beside their text."""
+    factory = test_db
+    doc_id = str(uuid.uuid4())
+    async with factory() as session:
+        session.add(
+            DocumentModel(
+                id=doc_id,
+                title="Paper",
+                format="pdf",
+                content_type="paper",
+                word_count=10,
+                page_count=5,
+                file_path="/tmp/p.pdf",
+                stage="complete",
+            )
+        )
+        session.add(
+            SectionModel(
+                id=str(uuid.uuid4()),
+                document_id=doc_id,
+                heading="Results",
+                level=1,
+                page_start=3,
+                page_end=4,
+                section_order=0,
+                preview="trailing prose\n-\nfollowing line",
+            )
+        )
+        await session.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(f"/sections/{doc_id}/content")
+
+    assert resp.status_code == 200
+    item = resp.json()[0]
+    assert item["page_start"] == 3
+    assert item["page_end"] == 4
+    assert "trailing prose\n\n-" in item["content"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.2.2",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.4",

--- a/frontend/src/components/reader/DocumentReader.tsx
+++ b/frontend/src/components/reader/DocumentReader.tsx
@@ -998,8 +998,11 @@ function DocumentReaderBase({ documentId, onBack, initialSectionId, initialChunk
             {confirmDelete && (
               <div className="absolute right-0 top-full z-50 mt-2 w-72 rounded-md border border-destructive/30 bg-popover px-3 py-2.5 shadow-lg">
                 <p className="mb-2 text-xs text-foreground">
-                  Delete <span className="font-semibold">{doc.title}</span>? This
-                  removes its chunks, vectors and highlights, and cannot be undone.
+                  Delete <span className="font-semibold">{doc.title}</span>?
+                </p>
+                <p className="mb-2 text-xs text-muted-foreground">
+                  This also deletes the uploaded file itself, along with its
+                  chunks, vectors, highlights and notes. It cannot be undone.
                 </p>
                 <div className="flex justify-end gap-2">
                   <button

--- a/frontend/src/components/reader/DocumentReader.tsx
+++ b/frontend/src/components/reader/DocumentReader.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { ArrowLeft, ChevronLeft, ChevronRight, GitCompareArrows, Highlighter, MessageSquare, RefreshCw, Sparkles, StickyNote, Target, Trash2, X } from "lucide-react"
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useNavigate } from "react-router-dom"
@@ -190,6 +190,20 @@ function DocumentReaderBase({ documentId, onBack, initialSectionId, initialChunk
 
   // Header "Generate questions" -> in-context flashcard dialog scoped to the whole doc.
   const [genQuestionsOpen, setGenQuestionsOpen] = useState(false)
+
+  // Header "Delete" -> removes the open document without a trip back to the library.
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const deleteDocumentMutation = useMutation({
+    mutationFn: () => apiDelete(`/documents/${documentId}`),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["documents"] })
+      void qc.invalidateQueries({ queryKey: ["documents-recent"] })
+      toast.success("Document deleted")
+      // The document this view is bound to no longer exists, so leave it.
+      onBack()
+    },
+    onError: () => toast.error("Failed to delete document. Please try again."),
+  })
 
   // Audio mini-player state — only active for audio documents
   const audioRef = useRef<HTMLAudioElement | null>(null)
@@ -972,6 +986,42 @@ function DocumentReaderBase({ documentId, onBack, initialSectionId, initialChunk
             <MessageSquare size={14} />
             Chat
           </button>
+          <div className="relative">
+            <button
+              onClick={() => setConfirmDelete((open) => !open)}
+              className="flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30 transition-colors"
+              title="Delete this document"
+            >
+              <Trash2 size={14} />
+              Delete
+            </button>
+            {confirmDelete && (
+              <div className="absolute right-0 top-full z-50 mt-2 w-72 rounded-md border border-destructive/30 bg-popover px-3 py-2.5 shadow-lg">
+                <p className="mb-2 text-xs text-foreground">
+                  Delete <span className="font-semibold">{doc.title}</span>? This
+                  removes its chunks, vectors and highlights, and cannot be undone.
+                </p>
+                <div className="flex justify-end gap-2">
+                  <button
+                    onClick={() => setConfirmDelete(false)}
+                    className="rounded border border-border px-2.5 py-1 text-xs hover:bg-accent"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={() => {
+                      setConfirmDelete(false)
+                      deleteDocumentMutation.mutate()
+                    }}
+                    disabled={deleteDocumentMutation.isPending}
+                    className="rounded bg-destructive px-2.5 py-1 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+                  >
+                    {deleteDocumentMutation.isPending ? "Deleting..." : "Delete"}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
           {(docNotes?.length ?? 0) > 0 && (
             <button
               onClick={() => {

--- a/frontend/src/components/reader/PDFViewer.tsx
+++ b/frontend/src/components/reader/PDFViewer.tsx
@@ -240,6 +240,7 @@ export const PDFViewer = forwardRef<PDFViewerHandle, PDFViewerProps>(
     // rather than harsh #000/#fff; hue-rotate keeps colored links roughly right.
     const canvasFilter = darkPage ? "invert(0.9) hue-rotate(180deg)" : undefined
 
+    const pageCommitTimer = useRef<number | null>(null)
     const canvasRef = useRef<HTMLCanvasElement>(null)
     const textLayerRef = useRef<HTMLDivElement>(null)
     const highlightOverlayRef = useRef<HTMLDivElement>(null)
@@ -606,6 +607,23 @@ export const PDFViewer = forwardRef<PDFViewerHandle, PDFViewerProps>(
       if (!isNaN(n)) goToPage(n)
     }
 
+    // The page field only committed on blur/Enter, so the spinner arrows (and any
+    // edit) changed the number without turning the page. Commit on change too,
+    // debounced so typing "38" navigates once to 38 rather than to 3 then 38.
+    function handlePageInputChange(value: string) {
+      setPageInput(value)
+      if (pageCommitTimer.current) window.clearTimeout(pageCommitTimer.current)
+      const n = parseInt(value, 10)
+      if (isNaN(n)) return
+      pageCommitTimer.current = window.setTimeout(() => {
+        setCurrentPage(Math.max(1, Math.min(n, totalPages)))
+      }, 250)
+    }
+    function commitPageInputNow() {
+      if (pageCommitTimer.current) window.clearTimeout(pageCommitTimer.current)
+      commitPageInput()
+    }
+
     // ── Search helpers ────────────────────────────────────────────────
 
     /** Extract text from a single PDF page and cache it. */
@@ -910,7 +928,7 @@ export const PDFViewer = forwardRef<PDFViewerHandle, PDFViewerProps>(
               className="p-1 rounded hover:bg-accent disabled:opacity-40"
               onClick={() => goToPage(currentPage - 1)}
               disabled={currentPage <= 1}
-              title="Previous page"
+              title="Previous page (←)"
               aria-label="Previous page"
             >
               <ChevronLeft className="h-4 w-4" />
@@ -921,9 +939,9 @@ export const PDFViewer = forwardRef<PDFViewerHandle, PDFViewerProps>(
               value={pageInput}
               min={1}
               max={totalPages}
-              onChange={(e) => setPageInput(e.target.value)}
-              onBlur={commitPageInput}
-              onKeyDown={(e) => { if (e.key === "Enter") commitPageInput() }}
+              onChange={(e) => handlePageInputChange(e.target.value)}
+              onBlur={commitPageInputNow}
+              onKeyDown={(e) => { if (e.key === "Enter") commitPageInputNow() }}
               aria-label="Current page"
             />
             <span className="text-xs text-muted-foreground tabular-nums">/ {totalPages}</span>
@@ -931,7 +949,7 @@ export const PDFViewer = forwardRef<PDFViewerHandle, PDFViewerProps>(
               className="p-1 rounded hover:bg-accent disabled:opacity-40"
               onClick={() => goToPage(currentPage + 1)}
               disabled={currentPage >= totalPages}
-              title="Next page"
+              title="Next page (→)"
               aria-label="Next page"
             >
               <ChevronRight className="h-4 w-4" />

--- a/frontend/src/components/reader/PDFViewer.tsx
+++ b/frontend/src/components/reader/PDFViewer.tsx
@@ -3,8 +3,9 @@ import * as pdfjsLib from "pdfjs-dist"
 import { AnnotationLayer, TextLayer } from "pdfjs-dist"
 import type { PDFDocumentProxy, PDFPageProxy } from "pdfjs-dist"
 import "pdfjs-dist/web/pdf_viewer.css"
-import { ChevronLeft, ChevronRight, Search, ZoomIn } from "lucide-react"
+import { ChevronLeft, ChevronRight, Moon, Search, Sun, ZoomIn } from "lucide-react"
 import { API_BASE, PDFJS_WORKER_URL } from "@/lib/config"
+import { useIsDark } from "@/hooks/useIsDark"
 import { Skeleton } from "@/components/ui/skeleton"
 import type { AnnotationItem, SectionItem } from "./types"
 import {
@@ -228,6 +229,16 @@ export const PDFViewer = forwardRef<PDFViewerHandle, PDFViewerProps>(
     const [zoom, setZoom] = useState(1.0)
     const [loadStatus, setLoadStatus] = useState<LoadStatus>("loading")
     const [pageInput, setPageInput] = useState("1")
+
+    // The PDF renders to a raster canvas, so it ignores the app theme. In dark
+    // mode we invert the canvas to a dark page by default; the user can toggle it
+    // off for figure-heavy pages, where inversion turns photos into negatives.
+    const isDark = useIsDark()
+    const [darkPage, setDarkPage] = useState(isDark)
+    useEffect(() => setDarkPage(isDark), [isDark])
+    // Softened invert (not a full 1.0) so the page is dark-gray on light-gray
+    // rather than harsh #000/#fff; hue-rotate keeps colored links roughly right.
+    const canvasFilter = darkPage ? "invert(0.9) hue-rotate(180deg)" : undefined
 
     const canvasRef = useRef<HTMLCanvasElement>(null)
     const textLayerRef = useRef<HTMLDivElement>(null)
@@ -869,8 +880,14 @@ export const PDFViewer = forwardRef<PDFViewerHandle, PDFViewerProps>(
           {/* Canvas scroll area */}
           <div ref={scrollAreaRef} className="flex-1 overflow-auto p-4">
             <div className="relative" style={{ width: "fit-content", marginInline: "auto" }}>
-              {/* Canvas: pointer-events:none so the text layer receives all mouse events */}
-              <canvas ref={canvasRef} className="shadow-md block" style={{ pointerEvents: "none" }} />
+              {/* Canvas: pointer-events:none so the text layer receives all mouse events.
+                  The filter lives on the canvas alone -- putting it on the parent would
+                  invert the highlight/annotation overlays too. */}
+              <canvas
+                ref={canvasRef}
+                className="shadow-md block"
+                style={{ pointerEvents: "none", filter: canvasFilter }}
+              />
               {/* Highlight overlay: absolutely-positioned colored divs between canvas and text layer.
                   z-index 5 sits above canvas (0) but below text layer (10), so text selection works
                   through the overlay while highlights are visible underneath. */}
@@ -926,6 +943,15 @@ export const PDFViewer = forwardRef<PDFViewerHandle, PDFViewerProps>(
               aria-label="Search in PDF"
             >
               <Search className="h-4 w-4" />
+            </button>
+            <button
+              className="p-1 rounded hover:bg-accent"
+              onClick={() => setDarkPage((v) => !v)}
+              title={darkPage ? "Show original page colors" : "Dark page (invert)"}
+              aria-label="Toggle dark page"
+              aria-pressed={darkPage}
+            >
+              {darkPage ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
             </button>
             <div className="ml-auto relative" ref={zoomPopoverRef}>
               <button

--- a/frontend/src/components/reader/ReadView.tsx
+++ b/frontend/src/components/reader/ReadView.tsx
@@ -3,9 +3,13 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Loader2 } from "lucide-react"
 import { MarkdownRenderer } from "@/components/MarkdownRenderer"
 import { apiGet } from "@/lib/apiClient"
+import { API_BASE } from "@/lib/config"
 import { cn } from "@/lib/utils"
 import { Skeleton } from "@/components/ui/skeleton"
+import type { components } from "@/types/api"
 import type { AnnotationItem, SectionContentItem } from "./types"
+
+type DocumentImage = components["schemas"]["ImageItem"]
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
   yellow: "bg-yellow-200/60 dark:bg-yellow-500/30",
@@ -46,7 +50,34 @@ interface LazySectionProps {
   section: SectionContentItem
   annotations: AnnotationItem[]
   highlightsVisible: boolean
+  images?: DocumentImage[]
 }
+
+// Figures live in the images table with a vision-generated description; the
+// reader previously rendered only text, so diagrams never appeared at all.
+const SectionFigures = memo(({ images }: { images: DocumentImage[] }) => {
+  if (images.length === 0) return null
+  return (
+    <div className="mt-6 space-y-6">
+      {images.map((img) => (
+        <figure key={img.id} className="rounded-lg border border-border bg-muted/20 p-3">
+          <img
+            src={`${API_BASE}/images/${img.id}/raw`}
+            alt={img.description || "Figure from this document"}
+            loading="lazy"
+            className="mx-auto max-h-[520px] w-auto max-w-full rounded"
+          />
+          {img.description && (
+            <figcaption className="mt-2 text-xs leading-relaxed text-muted-foreground">
+              {img.description}
+            </figcaption>
+          )}
+        </figure>
+      ))}
+    </div>
+  )
+})
+SectionFigures.displayName = "SectionFigures"
 
 const HeadingTag = (level: number) => {
   if (level <= 1) return "h2"
@@ -57,7 +88,7 @@ const HeadingTag = (level: number) => {
 
 // LazySection renders heavy Markdown content only when it is near the viewport.
 // This allows 'bulky' books with 1000s of sections to load instantly and stay responsive.
-const LazySection = memo(({ section, annotations, highlightsVisible }: LazySectionProps) => {
+const LazySection = memo(({ section, annotations, highlightsVisible, images = [] }: LazySectionProps) => {
   const [isVisible, setIsVisible] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -96,6 +127,7 @@ const LazySection = memo(({ section, annotations, highlightsVisible }: LazySecti
       {isVisible ? (
         <div className="leading-relaxed anim-fade-in">
           <MarkdownRenderer>{highlighted}</MarkdownRenderer>
+          <SectionFigures images={images} />
         </div>
       ) : (
         <div className="space-y-2 py-4">
@@ -111,6 +143,25 @@ LazySection.displayName = "LazySection"
 
 const fetchSectionContent = (documentId: string): Promise<SectionContentItem[]> =>
   apiGet<SectionContentItem[]>(`/sections/${documentId}/content`)
+
+const fetchDocumentImages = (documentId: string): Promise<DocumentImage[]> =>
+  apiGet<{ items: DocumentImage[] }>(`/documents/${documentId}/images`).then((r) => r.items)
+
+// ImageModel.page is the 0-based pymupdf page index, while SectionModel.page_start
+// is 1-based. Without this the figures land a page off, in the wrong section.
+const imageDisplayPage = (image: DocumentImage) => image.page + 1
+
+function imagesForSection(
+  section: SectionContentItem,
+  images: DocumentImage[],
+): DocumentImage[] {
+  if (!section.page_start) return []
+  const end = section.page_end || section.page_start
+  return images.filter((img) => {
+    const page = imageDisplayPage(img)
+    return page >= section.page_start && page <= end
+  })
+}
 
 /** Normalize whitespace for fuzzy matching: collapse runs to single space, trim. */
 function normalizeWs(s: string): string {
@@ -242,6 +293,14 @@ export function ReadView({ documentId, initialSectionId, annotations = [], highl
     staleTime: 60_000,
   })
 
+  // Figures are supplementary: a failure here must not block the text, so this
+  // query has no error branch and simply yields no images.
+  const { data: docImages } = useQuery({
+    queryKey: ["document-images", documentId],
+    queryFn: () => fetchDocumentImages(documentId),
+    staleTime: 300_000,
+  })
+
   // Pre-group annotations by section_id to avoid O(N*M) lookups in render loops
   const annotationsBySection = useMemo(() => {
     const map = new Map<string, AnnotationItem[]>()
@@ -252,6 +311,22 @@ export function ReadView({ documentId, initialSectionId, annotations = [], highl
     }
     return map
   }, [annotations])
+
+  // An image inside a section's page range renders once, under that section.
+  // Sections without page ranges (non-paginated formats) get none.
+  const imagesBySection = useMemo(() => {
+    const map = new Map<string, DocumentImage[]>()
+    if (!sections || !docImages?.length) return map
+    const claimed = new Set<string>()
+    for (const section of sections) {
+      const matched = imagesForSection(section, docImages).filter((i) => !claimed.has(i.id))
+      if (matched.length) {
+        matched.forEach((i) => claimed.add(i.id))
+        map.set(section.section_id, matched)
+      }
+    }
+    return map
+  }, [sections, docImages])
 
   // Scroll to initial section
   useEffect(() => {
@@ -367,6 +442,7 @@ export function ReadView({ documentId, initialSectionId, annotations = [], highl
               section={section}
               annotations={annotationsBySection.get(section.section_id) || []}
               highlightsVisible={highlightsVisible}
+              images={imagesBySection.get(section.section_id)}
             />
           ))}
           

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -293,3 +293,78 @@
 html {
   transition: background-color 0.3s ease, color 0.2s ease;
 }
+
+/* --- Chat surface -------------------------------------------------------- */
+
+@keyframes lum-msg-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.99);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes lum-typing {
+  0%,
+  60%,
+  100% {
+    opacity: 0.25;
+    transform: translateY(0);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
+}
+
+@keyframes lum-halo {
+  0%,
+  100% {
+    opacity: 0.5;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.85;
+    transform: scale(1.06);
+  }
+}
+
+.lum-msg-enter {
+  animation: lum-msg-in var(--dur-slow) var(--ease-out) both;
+}
+
+.lum-typing-dot {
+  animation: lum-typing 1.2s var(--ease-in-out) infinite;
+}
+.lum-typing-dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.lum-typing-dot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+.lum-halo {
+  animation: lum-halo 4s var(--ease-in-out) infinite;
+}
+
+/* The composer lifts and gains a primary-tinted ring when focused, so the
+   caret target reads as the page's active element without a hard border. */
+.lum-composer {
+  transition: box-shadow var(--dur) var(--ease-out),
+    border-color var(--dur) var(--ease-out);
+}
+.lum-composer:focus-within {
+  border-color: hsl(var(--primary) / 0.45);
+  box-shadow: var(--shadow-md), 0 0 0 4px hsl(var(--primary) / 0.1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lum-msg-enter,
+  .lum-typing-dot,
+  .lum-halo {
+    animation: none;
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -94,26 +94,31 @@
 
   .dark {
     --background: 222 35% 4%;
-    --foreground: 210 40% 98%;
+    /* Cool blue-gray body text. The glare came from near-max lightness (was 98%),
+       not the hue -- softened to 86% so it reads comfortably. Raise/lower the
+       lightness to taste; keep the hue cool. */
+    --foreground: 213 20% 86%;
+    /* Headings sit a touch above body so they pop as structure without glare. */
+    --heading: 213 22% 88%;
     --border: 217 33% 15%;
     --input: 217 33% 15%;
     --ring: 250 82% 65%;
     --primary: 250 82% 65%;
     --primary-foreground: 0 0% 100%;
     --secondary: 217 33% 12%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary-foreground: 213 20% 86%;
     --muted: 217 33% 12%;
     --muted-foreground: 215 20% 65%;
     --accent: 217 33% 12%;
-    --accent-foreground: 210 40% 98%;
+    --accent-foreground: 213 20% 86%;
     --popover: 222 35% 6%;
-    --popover-foreground: 210 40% 98%;
+    --popover-foreground: 213 20% 86%;
     --card: 222 35% 7%;
-    --card-foreground: 210 40% 98%;
+    --card-foreground: 213 20% 86%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
     --sidebar: 222 35% 6%;
-    --sidebar-foreground: 210 40% 98%;
+    --sidebar-foreground: 213 20% 86%;
   }
 }
 
@@ -183,6 +188,12 @@
   background: transparent !important;
   color: #24292e !important;
   padding: 0 !important;
+}
+
+/* Dark-mode prose headings default to pure white via prose-invert, which glares
+   against the softened body. Point them at the --heading token instead. */
+.dark .prose {
+  --tw-prose-invert-headings: hsl(var(--heading));
 }
 
 /* Dark mode: github-dark theme overrides */

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -194,6 +194,9 @@ interface ChatMessage {
   web_sources?: WebSource[]  // S142: web augmentation sources
   source_citations?: SourceCitation[]  // S148: chunk-derived deep-link citations
   transparency?: TransparencyInfo       // S158: retrieval transparency panel
+  notice?: string                       // offline/routing notice, shown above the answer
+  error?: string                        // this turn failed; message shown with a Retry button
+  failedQuestion?: string               // question to re-send on Retry
 }
 
 interface SessionPlanItem {

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { AlertTriangle, ArrowLeft, BookMarked, BookOpen, ChevronDown, Cpu, Globe, Info, PanelLeft, PanelLeftClose, Send, Settings, Sparkles, Trash2, X } from "lucide-react"
+import { AlertTriangle, ArrowLeft, BookMarked, BookOpen, ChevronDown, Cpu, Globe, Info, PanelLeft, PanelLeftClose, Send, Settings, Sparkles, Trash2, WifiOff, X } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
 import { useBackNavigation } from "@/hooks/useBackNavigation"
@@ -889,6 +889,16 @@ export default function Chat() {
               )
             }
 
+            // Offline / routing notice — non-fatal, shown inline above the answer.
+            if (payload["type"] === "notice" && typeof payload["message"] === "string") {
+              const noticeText = payload["message"] as string
+              setMessages((m) =>
+                m.map((msg) =>
+                  msg.id === assistantId ? { ...msg, notice: noticeText } : msg,
+                ),
+              )
+            }
+
             // S158: transparency event arrives before 'done' — silently omit if malformed
             if (payload["type"] === "transparency") {
               try {
@@ -1243,6 +1253,12 @@ export default function Chat() {
                         : "rounded-2xl rounded-tl-md border border-border bg-card text-card-foreground shadow-[var(--shadow-sm)] hover:shadow-[var(--shadow-md)]"
                       }`}
                   >
+                    {msg.notice && msg.role === "assistant" && (
+                      <div className="mb-2 flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5 text-xs text-amber-700 dark:text-amber-400">
+                        <WifiOff size={12} className="shrink-0" />
+                        <span>{msg.notice}</span>
+                      </div>
+                    )}
                     {msg.type === "card" && msg.cardData !== undefined ? (
                       msg.cardData.type === "quiz_question" ? (
                         <QuizQuestionCard

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { AlertTriangle, ArrowLeft, BookMarked, BookOpen, ChevronDown, Cpu, Globe, Info, PanelLeft, PanelLeftClose, Send, Settings, Sparkles, Trash2, WifiOff, X } from "lucide-react"
+import { AlertTriangle, ArrowLeft, BookMarked, BookOpen, ChevronDown, Cpu, Globe, Info, PanelLeft, PanelLeftClose, RefreshCw, Send, Settings, Sparkles, Trash2, WifiOff, X } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
 import { useBackNavigation } from "@/hooks/useBackNavigation"
@@ -780,7 +780,7 @@ export default function Chat() {
     ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`
   }
 
-  async function sendMessage(question: string) {
+  async function sendMessage(question: string, opts?: { reuseUserTurn?: boolean }) {
     if (!question.trim() || isStreaming) return
     setInput("")
     if (textareaRef.current) textareaRef.current.style.height = "auto"
@@ -816,13 +816,19 @@ export default function Chat() {
       }
     }
 
-    const userMsg: ChatMessage = { id: crypto.randomUUID(), role: "user", text: question }
     const assistantId = crypto.randomUUID()
     const assistantMsg: ChatMessage = { id: assistantId, role: "assistant", text: "", isStreaming: true }
-    setMessages((m) => [...m, userMsg, assistantMsg])
+    // On retry the user turn is already in the thread and already persisted, so
+    // reuse it -- re-adding would duplicate the question on the backend session.
+    if (opts?.reuseUserTurn) {
+      setMessages((m) => [...m, assistantMsg])
+    } else {
+      const userMsg: ChatMessage = { id: crypto.randomUUID(), role: "user", text: question }
+      setMessages((m) => [...m, userMsg, assistantMsg])
+    }
     setIsStreaming(true)
 
-    if (sessionId) {
+    if (sessionId && !opts?.reuseUserTurn) {
       void appendChatMessage(sessionId, { role: "user", content: question }).catch(() => {})
     }
 
@@ -920,7 +926,7 @@ export default function Chat() {
               }
             }
 
-            // SSE error event — end streaming, remove placeholder, show banner
+            // SSE error event — mark this turn failed so it can be retried inline.
             if (typeof payload["error"] === "string") {
               const errorCode = payload["error"] as string
               const fallbackMsg = (payload["message"] as string | undefined) ?? "An error occurred."
@@ -933,8 +939,13 @@ export default function Chat() {
                     ? "No relevant content found. Make sure at least one document has been ingested."
                     : fallbackMsg
               setIsStreaming(false)
-              setMessages((m) => m.filter((msg) => msg.id !== assistantId))
-              setQaError(errorMsg)
+              setMessages((m) =>
+                m.map((msg) =>
+                  msg.id === assistantId
+                    ? { ...msg, isStreaming: false, text: "", error: errorMsg, failedQuestion: question }
+                    : msg,
+                ),
+              )
               break
             }
 
@@ -1014,14 +1025,27 @@ export default function Chat() {
     } catch (err: unknown) {
       const errMsg = err instanceof Error ? err.message : String(err)
       logger.error("[Chat] fetch failed", { endpoint: "/qa", error: errMsg })
-      setQaError(
+      const shown =
         errMsg.includes("Failed to fetch") || errMsg.includes("NetworkError")
           ? "Cannot reach the server. Is the backend running on port 7820?"
           : `Could not get a response: ${errMsg}`
+      setMessages((m) =>
+        m.map((msg) =>
+          msg.id === assistantId
+            ? { ...msg, isStreaming: false, text: "", error: shown, failedQuestion: question }
+            : msg,
+        ),
       )
-      setMessages((m) => m.filter((msg) => msg.id !== assistantId))
       setIsStreaming(false)
     }
+  }
+
+  // Re-send a failed turn. The user turn stays (already shown and persisted); we
+  // drop only the errored assistant bubble and stream a fresh answer for it.
+  function retryMessage(assistantId: string, question: string) {
+    if (isStreaming || !question.trim()) return
+    setMessages((m) => m.filter((msg) => msg.id !== assistantId))
+    void sendMessage(question, { reuseUserTurn: true })
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
@@ -1275,6 +1299,21 @@ export default function Chat() {
                       ) : (
                         <p className="text-xs text-muted-foreground">Unknown card type</p>
                       )
+                    ) : msg.error ? (
+                      <div className="space-y-2">
+                        <p className="flex items-start gap-1.5 text-sm text-destructive">
+                          <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                          <span>{msg.error}</span>
+                        </p>
+                        <button
+                          onClick={() => retryMessage(msg.id, msg.failedQuestion ?? "")}
+                          disabled={isStreaming || !msg.failedQuestion}
+                          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground hover:bg-muted disabled:opacity-50"
+                        >
+                          <RefreshCw size={12} />
+                          Retry
+                        </button>
+                      </div>
                     ) : msg.not_found ? (
                       <p className="text-sm text-blue-600">
                         This information was not found in the selected content.

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useSearchParams } from "react-router-dom"
 import { useBackNavigation } from "@/hooks/useBackNavigation"
 import { toast } from "sonner"
 import { ChatSessionList } from "@/components/chat/ChatSessionList"
+import { LuminaryGlyph } from "@/components/icons/LuminaryGlyph"
 import {
   appendChatMessage,
   createChatSession,
@@ -93,30 +94,33 @@ function SuggestionPills({ documentId, onSuggest }: SuggestionPillsProps) {
 
   if (isInitialLoading) {
     return (
-      <div className="flex flex-wrap gap-2 border-t border-border px-6 py-3">
-        <div className="h-7 w-40 animate-pulse rounded-full bg-muted" />
-        <div className="h-7 w-40 animate-pulse rounded-full bg-muted" />
+      <div className="mx-auto flex w-full max-w-3xl flex-wrap gap-2 px-6 py-3">
+        <div className="h-8 w-44 animate-pulse rounded-full bg-muted" />
+        <div className="h-8 w-56 animate-pulse rounded-full bg-muted" />
       </div>
     )
   }
   if (!hasSuggestions) return null
 
   return (
-    <div className="flex flex-wrap gap-2 border-t border-border px-6 py-3">
-      {data.suggestions.map((s) => (
-        <button
-          key={s.id || s.text}
-          onClick={() => {
-            if (s.id) {
-              fetch(`${API_BASE}/chat/suggestions/${s.id}/asked`, { method: "POST" }).catch(() => { /* fire-and-forget: suggestion tracking is best-effort */ })
-            }
-            onSuggest(s.text)
-          }}
-          className="rounded-full border border-primary/30 bg-primary/5 px-3 py-1.5 text-xs text-primary hover:bg-primary/10 transition-colors"
-        >
-          {s.text}
-        </button>
-      ))}
+    <div className="mx-auto w-full max-w-3xl px-6 py-3">
+      <p className="lum-eyebrow mb-2">Try asking</p>
+      <div className="flex flex-wrap gap-2">
+        {data.suggestions.map((s) => (
+          <button
+            key={s.id || s.text}
+            onClick={() => {
+              if (s.id) {
+                fetch(`${API_BASE}/chat/suggestions/${s.id}/asked`, { method: "POST" }).catch(() => { /* fire-and-forget: suggestion tracking is best-effort */ })
+              }
+              onSuggest(s.text)
+            }}
+            className="rounded-full border border-primary/25 bg-primary/5 px-3.5 py-2 text-xs text-primary transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/50 hover:bg-primary/10 hover:shadow-[var(--shadow-md)]"
+          >
+            {s.text}
+          </button>
+        ))}
+      </div>
     </div>
   )
 }
@@ -462,6 +466,23 @@ function DocumentScopeCombobox({ docList, selectedDocId, onSelect }: DocumentSco
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+function ChatEmptyState({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
+      <div className="relative flex h-16 w-16 items-center justify-center">
+        <div className="lum-halo absolute inset-0 rounded-full bg-gradient-to-br from-primary/25 to-purple-500/20 blur-xl" />
+        <div className="relative flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/20 bg-gradient-to-br from-primary/10 to-purple-500/10">
+          <LuminaryGlyph size={30} />
+        </div>
+      </div>
+      <div className="space-y-1.5">
+        <h2 className="lum-h3">{title}</h2>
+        <p className="mx-auto max-w-sm text-sm leading-relaxed text-muted-foreground">{body}</p>
+      </div>
     </div>
   )
 }
@@ -1036,7 +1057,7 @@ export default function Chat() {
       )}
       <div className="flex h-full flex-col flex-1 min-w-0">
       {/* Header controls */}
-      <div className="flex items-center gap-3 border-b border-border px-6 py-3">
+      <div className="sticky top-0 z-20 flex items-center gap-2 border-b border-border bg-background/80 px-6 py-2.5 backdrop-blur-md supports-[backdrop-filter]:bg-background/60">
         {canGoBack && (
           <button
             onClick={goBack}
@@ -1090,50 +1111,54 @@ export default function Chat() {
           />
         )}
 
-        {/* Creative mode -- primary per-question toggle (grounded generative answers) */}
-        <button
-          onClick={() => setCreativeEnabled((prev) => !prev)}
-          aria-pressed={creativeEnabled}
-          title={
-            creativeEnabled
-              ? "Creative mode is on: imaginative answers grounded in your material. Click for strict, cited answers."
-              : "Creative mode: turn answers into stories, poems, and analogies grounded in your own material."
-          }
-          className={`ml-auto flex shrink-0 items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm transition-colors ${
-            creativeEnabled
-              ? "border-purple-300 bg-purple-50 text-purple-700 dark:border-purple-800 dark:bg-purple-950/40 dark:text-purple-300"
-              : "border-border text-muted-foreground hover:bg-accent"
-          }`}
-        >
-          <Sparkles size={14} />
-          Creative
-        </button>
-
-        {/* Web call counter -- shown when web is enabled and conversation is active */}
-        {webEnabled && messages.length > 0 && (
-          <span className="text-xs text-muted-foreground">Web: {webCallsUsed}/3</span>
-        )}
-
-        {/* Clear conversation button -- only shown when there are messages */}
-        {messages.length > 0 && !isStreaming && (
+        <div className="ml-auto flex items-center gap-2">
+          {/* Creative mode -- primary per-question toggle (grounded generative answers) */}
           <button
-            onClick={clearConversation}
-            className="ml-auto flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
-            title="Clear conversation"
+            onClick={() => setCreativeEnabled((prev) => !prev)}
+            aria-pressed={creativeEnabled}
+            title={
+              creativeEnabled
+                ? "Creative mode is on: imaginative answers grounded in your material. Click for strict, cited answers."
+                : "Creative mode: turn answers into stories, poems, and analogies grounded in your own material."
+            }
+            className={`flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+              creativeEnabled
+                ? "border-purple-300 bg-purple-50 text-purple-700 shadow-[0_0_0_3px_rgba(168,85,247,0.12)] dark:border-purple-800 dark:bg-purple-950/40 dark:text-purple-300"
+                : "border-border text-muted-foreground hover:border-purple-200 hover:bg-accent hover:text-foreground"
+            }`}
           >
-            <Trash2 size={13} />
-            Clear
+            <Sparkles size={13} className={creativeEnabled ? "text-purple-500" : ""} />
+            Creative
           </button>
-        )}
 
-        {/* Settings gear icon -- opens ChatSettingsDrawer */}
-        <button
-          onClick={() => setSettingsOpen(true)}
-          className={`${messages.length > 0 && !isStreaming ? "" : "ml-auto"} rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors`}
-          title="Chat settings"
-        >
-          <Settings size={15} />
-        </button>
+          {/* Web call counter -- shown when web is enabled and conversation is active */}
+          {webEnabled && messages.length > 0 && (
+            <span className="rounded-full bg-muted px-2 py-1 text-xs tabular-nums text-muted-foreground">
+              Web {webCallsUsed}/3
+            </span>
+          )}
+
+          {/* Clear conversation button -- only shown when there are messages */}
+          {messages.length > 0 && !isStreaming && (
+            <button
+              onClick={clearConversation}
+              className="flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+              title="Clear conversation"
+            >
+              <Trash2 size={13} />
+              Clear
+            </button>
+          )}
+
+          {/* Settings gear icon -- opens ChatSettingsDrawer */}
+          <button
+            onClick={() => setSettingsOpen(true)}
+            className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            title="Chat settings"
+          >
+            <Settings size={15} />
+          </button>
+        </div>
       </div>
 
       {/* Chat settings drawer -- model selector, web toggle */}
@@ -1167,47 +1192,55 @@ export default function Chat() {
       )}
 
       {/* Message list */}
-      <div className="flex-1 overflow-auto px-6 py-4">
+      <div className="flex-1 overflow-auto px-6 py-6">
         {llmLoading ? (
-          <div className="flex flex-col gap-3 py-4">
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 py-4">
             <Skeleton className="h-10 w-3/4 self-end" />
             <Skeleton className="h-16 w-2/3" />
             <Skeleton className="h-10 w-1/2 self-end" />
           </div>
         ) : noDocumentSelected ? (
-          <div className="flex h-full items-center justify-center">
-            <p className="text-sm text-muted-foreground">
-              Open a document in the Learning tab to ask questions about it.
-            </p>
-          </div>
+          <ChatEmptyState
+            title="Pick something to study"
+            body="Open a document in the Learning tab, then come back here to ask questions about it."
+          />
         ) : messages.length === 0 ? (
-          <div className="flex h-full flex-col items-center justify-center gap-4">
-            {hasDocuments === false ? (
-              <p className="max-w-xs text-center text-sm text-muted-foreground">
-                Upload a document in the Learning tab to start chatting about it.
-              </p>
-            ) : (
-              <p className="text-sm text-muted-foreground">Ask a question to get started.</p>
-            )}
-          </div>
+          hasDocuments === false ? (
+            <ChatEmptyState
+              title="Your library is empty"
+              body="Upload a document in the Learning tab and Luminary will answer from it, with citations."
+            />
+          ) : (
+            <ChatEmptyState
+              title="Ask anything about your material"
+              body="Every answer is grounded in your own documents and cites where it came from."
+            />
+          )
         ) : (
-          <div className="flex flex-col gap-4">
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-5">
             {messages.map((msg) => (
               msg.type === "divider" ? (
                 <div key={msg.id} className="flex items-center gap-3 py-1">
-                  <div className="h-px flex-1 bg-border" />
-                  <span className="text-xs text-muted-foreground">{msg.text}</span>
-                  <div className="h-px flex-1 bg-border" />
+                  <div className="h-px flex-1 bg-gradient-to-r from-transparent to-border" />
+                  <span className="rounded-full border border-border bg-muted/50 px-2.5 py-0.5 text-xs text-muted-foreground">
+                    {msg.text}
+                  </span>
+                  <div className="h-px flex-1 bg-gradient-to-l from-transparent to-border" />
                 </div>
               ) : (
                 <div
                   key={msg.id}
-                  className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+                  className={`lum-msg-enter flex items-start gap-3 ${msg.role === "user" ? "justify-end" : "justify-start"}`}
                 >
+                  {msg.role !== "user" && (
+                    <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-primary/20 bg-gradient-to-br from-primary/15 to-purple-500/10">
+                      <LuminaryGlyph size={16} />
+                    </div>
+                  )}
                   <div
-                    className={`max-w-[80%] rounded-lg px-4 py-3 ${msg.role === "user"
-                        ? "bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-100"
-                        : "border border-border bg-card text-card-foreground shadow-sm"
+                    className={`max-w-[80%] px-4 py-3 transition-shadow ${msg.role === "user"
+                        ? "rounded-2xl rounded-br-md bg-primary text-primary-foreground shadow-[var(--shadow-md)]"
+                        : "rounded-2xl rounded-tl-md border border-border bg-card text-card-foreground shadow-[var(--shadow-sm)] hover:shadow-[var(--shadow-md)]"
                       }`}
                   >
                     {msg.type === "card" && msg.cardData !== undefined ? (
@@ -1233,12 +1266,12 @@ export default function Chat() {
                     ) : msg.role === "user" ? (
                       <p className="whitespace-pre-wrap text-sm">{msg.text}</p>
                     ) : msg.isStreaming && msg.text === "" ? (
-                      // Skeleton shown while waiting for a card SSE event (e.g. quiz, teach-back, gap)
+                      // Shown while waiting for a card SSE event (e.g. quiz, teach-back, gap)
                       // or before the first token of a streamed text response arrives.
-                      <div className="flex flex-col gap-2">
-                        <Skeleton className="h-4 w-48" />
-                        <Skeleton className="h-4 w-64" />
-                        <Skeleton className="h-4 w-40" />
+                      <div className="flex items-center gap-1.5 py-1" role="status" aria-label="Thinking">
+                        <span className="lum-typing-dot h-2 w-2 rounded-full bg-primary" />
+                        <span className="lum-typing-dot h-2 w-2 rounded-full bg-primary" />
+                        <span className="lum-typing-dot h-2 w-2 rounded-full bg-primary" />
                       </div>
                     ) : (
                       <div className="[&_p]:text-sm [&_p]:leading-relaxed [&_p]:my-1
@@ -1250,7 +1283,9 @@ export default function Chat() {
                       [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:mt-2 [&_h2]:mb-1
                       [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:mt-1">
                         <MarkdownRenderer>{msg.text}</MarkdownRenderer>
-                        {msg.isStreaming && <span className="animate-pulse">▍</span>}
+                        {msg.isStreaming && (
+                          <span className="ml-0.5 inline-block h-4 w-[3px] animate-pulse rounded-full bg-primary align-text-bottom" />
+                        )}
                       </div>
                     )}
 
@@ -1419,30 +1454,35 @@ export default function Chat() {
       </div>
 
       {/* Input area */}
-      <div className="border-t border-border px-6 py-4">
-        <div className="flex items-end gap-3">
-          <textarea
-            ref={textareaRef}
-            value={input}
-            onChange={(e) => {
-              setInput(e.target.value)
-              autoResize()
-            }}
-            onKeyDown={handleKeyDown}
-            placeholder={noDocumentSelected ? "Select a document first..." : "Ask a question..."}
-            disabled={noDocumentSelected || isStreaming}
-            rows={1}
-            className="flex-1 resize-none rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-          />
-          <button
-            onClick={() => void sendMessage(input)}
-            disabled={!input.trim() || isStreaming || noDocumentSelected}
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
-          >
-            <Send size={14} />
-          </button>
+      <div className="border-t border-border bg-background px-6 py-4">
+        <div className="mx-auto w-full max-w-3xl">
+          <div className="lum-composer flex items-end gap-2 rounded-2xl border border-border bg-card p-2 shadow-[var(--shadow-sm)]">
+            <textarea
+              ref={textareaRef}
+              value={input}
+              onChange={(e) => {
+                setInput(e.target.value)
+                autoResize()
+              }}
+              onKeyDown={handleKeyDown}
+              placeholder={noDocumentSelected ? "Select a document first..." : "Ask a question about your material..."}
+              disabled={noDocumentSelected || isStreaming}
+              rows={1}
+              className="flex-1 resize-none bg-transparent px-2 py-1.5 text-sm leading-relaxed text-foreground placeholder:text-muted-foreground focus:outline-none disabled:opacity-50"
+            />
+            <button
+              onClick={() => void sendMessage(input)}
+              disabled={!input.trim() || isStreaming || noDocumentSelected}
+              aria-label="Send message"
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-[var(--shadow-sm)] transition-all duration-200 hover:bg-primary/90 hover:shadow-[var(--shadow-md)] active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none disabled:hover:bg-primary"
+            >
+              <Send size={15} />
+            </button>
+          </div>
+          <p className="mt-2 text-center text-xs text-muted-foreground/70">
+            Enter to send · Shift+Enter for newline
+          </p>
         </div>
-        <p className="mt-1 text-xs text-muted-foreground">Enter to send · Shift+Enter for newline</p>
       </div>
       </div>
     </div>

--- a/frontend/src/pages/Chat/qaStream.ts
+++ b/frontend/src/pages/Chat/qaStream.ts
@@ -37,6 +37,7 @@ export interface QaStreamHandlers {
   onCard: (card: AnyCardData) => void
   onToken: (token: string) => void
   onTransparency: (transparency: TransparencyInfo) => void
+  onNotice?: (message: string) => void
   onError: (errorCode: string, fallback: string) => void
   onDone: (done: QaDoneEvent) => void
 }
@@ -74,6 +75,11 @@ export async function streamQa(req: QaStreamRequest, handlers: QaStreamHandlers)
 
         if (typeof payload["token"] === "string") {
           handlers.onToken(payload["token"] as string)
+        }
+
+        // Offline / routing notice — non-fatal, shown inline above the answer.
+        if (payload["type"] === "notice" && typeof payload["message"] === "string") {
+          handlers.onNotice?.(payload["message"] as string)
         }
 
         // transparency event arrives before 'done' — silently omit if malformed

--- a/frontend/src/pages/Chat/types.ts
+++ b/frontend/src/pages/Chat/types.ts
@@ -75,6 +75,10 @@ export interface ChatMessage {
   // Non-fatal routing notice, e.g. answered locally because the cloud provider
   // was unreachable. Shown inline above the answer.
   notice?: string
+  // Set when this turn failed (network, LLM unavailable, ...). Carries the
+  // message to show and the question to re-send via the inline Retry button.
+  error?: string
+  failedQuestion?: string
 }
 
 export type SessionPlanItem = components["schemas"]["SessionPlanItem"]

--- a/frontend/src/pages/Chat/types.ts
+++ b/frontend/src/pages/Chat/types.ts
@@ -72,6 +72,9 @@ export interface ChatMessage {
   web_sources?: WebSource[]
   source_citations?: SourceCitation[]
   transparency?: TransparencyInfo
+  // Non-fatal routing notice, e.g. answered locally because the cloud provider
+  // was unreachable. Shown inline above the answer.
+  notice?: string
 }
 
 export type SessionPlanItem = components["schemas"]["SessionPlanItem"]

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -3347,6 +3347,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/notes/{note_id}/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export Note
+         * @description Export a single note as a Markdown file.
+         *
+         *     ?format=markdown -- returns .md with YAML frontmatter and Obsidian [[title]] wikilinks
+         *     (PDF export is rendered client-side via the browser's print dialog.)
+         */
+        get: operations["export_note_notes__note_id__export_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/notes/flashcards/generate/preview": {
         parameters: {
             query?: never;
@@ -5833,7 +5856,7 @@ export interface components {
              * Content Type
              * @enum {string}
              */
-            content_type: "book" | "conversation" | "notes" | "audio" | "video" | "epub" | "kindle_clippings" | "tech_book" | "tech_article";
+            content_type: "book" | "conversation" | "notes" | "paper" | "audio" | "video" | "epub" | "kindle_clippings" | "tech_book" | "tech_article" | "technical";
         };
         /** Body_ingest_kindle_documents_ingest_kindle_post */
         Body_ingest_kindle_documents_ingest_kindle_post: {
@@ -8120,7 +8143,7 @@ export interface components {
             /** Tags */
             tags?: string[] | null;
             /** Content Type */
-            content_type?: ("book" | "conversation" | "notes" | "audio" | "video" | "epub" | "kindle_clippings" | "tech_book" | "tech_article") | null;
+            content_type?: ("book" | "conversation" | "notes" | "paper" | "audio" | "video" | "epub" | "kindle_clippings" | "tech_book" | "tech_article" | "technical") | null;
         };
         /** PatchTagsRequest */
         PatchTagsRequest: {
@@ -8425,6 +8448,16 @@ export interface components {
             section_order: number;
             /** Content */
             content: string;
+            /**
+             * Page Start
+             * @default 0
+             */
+            page_start: number;
+            /**
+             * Page End
+             * @default 0
+             */
+            page_end: number;
         };
         /** SectionHeatmapItem */
         SectionHeatmapItem: {
@@ -15257,6 +15290,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["NoteEntityItem"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    export_note_notes__note_id__export_get: {
+        parameters: {
+            query?: {
+                format?: string;
+            };
+            header?: never;
+            path: {
+                note_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
Work across ingestion, the reader, offline behavior, and dark-mode theming. Backend suite green at 2105 passed / 1 skipped; frontend 453 passed; tsc clean.

## Ingestion
- **Structure-aware chunking for research papers.** Papers had no dedicated chunker and fell through to the generic splitter (no sentence separator, 300-char budget → mid-word cuts, 65% of chunks starting mid-sentence). New `paper_chunker`: drops figure-internal token runs, keeps captions atomic, unwraps PDF line-wrapping before splitting, excludes reference lists from the index. Falls back to the generic path when structure isn't recognised or on any error. On the reference paper: 159→64 chunks, mid-sentence starts 65%→6%. **Re-ingest papers to benefit.**
- **Web-article extraction:** recover lazy-loaded images (`<picture>/<source>`, `data-*`) and fix list/heading structure that trafilatura's markdown serializer dropped.
- **Vision default** corrected to `qwen2.5vl:7b` (config, env example, and the test that pinned a stale `llava`).

## Reader
- **Delete a document from the reader header**, with an inline confirmation that names what's removed (including the uploaded file).
- **Sanitize extracted text** so a stray hyphen line no longer renders as a setext heading; **render figures inline** in the Read view (data already existed; 0-based image page vs 1-based section page reconciled).
- **PDF dark-page mode**: softened invert on the canvas only, on by default in dark mode with a Sun/Moon toggle for figure-heavy pages.
- **Page-number field now navigates** (spinner/typing committed on change, debounced); arrow-key nav surfaced in tooltips.

## Offline / privacy
- **Keep note and document work on the local model** — seven user-triggered call sites that sent note/document content to the cloud in hybrid mode now route local.
- **Offline resilience**: proactive provider-reachability check routes Ask to the local model before a doomed cloud call; reactive fallback fixed to catch the exception litellm actually raises (`InternalServerError` wrapping a connection error, not `APIConnectionError`). Ask shows an inline "answering locally" notice, and a failed question can be **retried inline**.

## Theme
- Dark-mode body text softened from 98%→86% lightness (same cool blue-gray hue); headings given a dedicated token that pops just above the body.

## Test infra
- Marked the real-vision enricher test `e2e` so it stops wedging local suite runs (it was `skipif`-guarded but unmarked, so it ran wherever the model was pulled and blew the timeout).

## Notes for review
- Numbers for the paper chunker are **structural, not retrieval-quality** — the golden corpus is books, so a paper golden set is still owed before claiming a retrieval win.
- The reader/PDF/theme changes are typechecked and lint-clean but **not exercised in a running app**; worth a manual pass.
- `background=True` only routes local in *hybrid* mode; in cloud mode it still reaches the provider (pinned by test, flagged as a product decision rather than changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)