### PR TITLE
Add lightweight /healthz liveness endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -385,9 +385,9 @@ async def health():
 @app.get("/healthz")
 async def healthz():
     """Lightweight liveness probe for containers and monitors (no DB)."""
-    from datetime import datetime, timezone
+    from datetime import UTC, datetime
 
-    return {"status": "ok", "timestamp": datetime.now(timezone.utc).isoformat()}
+    return {"status": "ok", "timestamp": datetime.now(UTC).isoformat()}
 
 
 @misc_router.get("/settings")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -382,6 +382,14 @@ async def health():
     return {"status": "ok", "version": _APP_VERSION}
 
 
+@app.get("/healthz")
+async def healthz():
+    """Lightweight liveness probe for containers and monitors (no DB)."""
+    from datetime import datetime, timezone
+
+    return {"status": "ok", "timestamp": datetime.now(timezone.utc).isoformat()}
+
+
 @misc_router.get("/settings")
 async def read_settings(settings: Settings = Depends(get_settings)):
     def mask(value: str) -> str:

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -15,6 +15,18 @@ async def test_health_returns_ok():
 
 
 @pytest.mark.asyncio
+async def test_healthz_returns_ok_without_db():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/healthz")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert "timestamp" in body
+    assert isinstance(body["timestamp"], str)
+    assert len(body["timestamp"]) > 0
+
+
+@pytest.mark.asyncio
 async def test_settings_masks_api_keys(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-key-value")
     # Clear the lru_cache to pick up monkeypatched env


### PR DESCRIPTION
## Summary
- Adds `GET /healthz` returning `{"status": "ok", "timestamp": <UTC ISO>}` with no database dependencies.
- Keeps existing `/health` unchanged; adds an async test for the new probe.

Fixes #27

## Test plan
- [x] `/healthz` returns 200 with `status` and `timestamp`