### PR TITLE
fix: dead onboarding suggestion chips + silent loss of JS-rendered article figures

### DIFF
--- a/backend/app/routers/chat_meta.py
+++ b/backend/app/routers/chat_meta.py
@@ -6,7 +6,7 @@ import re
 
 from fastapi import APIRouter, Path, Query, Response
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from app.database import get_session_factory
 from app.models import ChatSuggestionHistoryModel, DocumentModel, SectionModel
@@ -33,13 +33,6 @@ class ExplorationSuggestion(BaseModel):
 
 
 # Template-based suggestion generation (fallback, no LLM)
-
-_ONBOARDING_SUGGESTIONS = [
-    "Upload a document in the Learning tab to get started",
-    "Try importing a PDF, EPUB, or text file",
-    "You can also paste a YouTube URL to analyze a video",
-    "Explore the Knowledge Graph in the Viz tab after uploading",
-]
 
 
 # A content_type='book' can be narrative fiction (Odyssey) OR a technical textbook
@@ -152,6 +145,17 @@ def _generic_suggestions(entities: dict[str, list[str]], headings: list[str]) ->
     return suggestions[:4]
 
 
+# Answerable all-scope questions that don't depend on any specific entity — used
+# when the library has documents but no entity is shared across 2+ of them (common
+# after entity disambiguation). These run against the corpus; onboarding chips do not.
+_GENERIC_CROSS_DOC_SUGGESTIONS = [
+    "What are the common themes across my documents?",
+    "Summarize the key ideas across my library",
+    "What questions should I be exploring in my material?",
+    "Which topics connect the documents in my library?",
+]
+
+
 def _cross_document_suggestions(shared_entities: list[str]) -> list[str]:
     """Generate suggestions for all-scope (no specific document)."""
     suggestions: list[str] = []
@@ -163,8 +167,29 @@ def _cross_document_suggestions(shared_entities: list[str]) -> list[str]:
         )
     if len(shared_entities) >= 3:
         suggestions.append(f"Summarize everything you know about {shared_entities[2]}")
-    suggestions.append("What are the common themes across my documents?")
+    for fb in _GENERIC_CROSS_DOC_SUGGESTIONS:
+        if len(suggestions) >= 4:
+            break
+        if fb not in suggestions:
+            suggestions.append(fb)
     return suggestions[:4]
+
+
+async def _library_has_ready_documents() -> bool:
+    """True when at least one document has reached a queryable stage.
+
+    Onboarding suggestions are correct only for a genuinely empty library — a
+    populated corpus with no cross-document entity overlap must NOT be told to
+    "upload a document to get started".
+    """
+    factory = get_session_factory()
+    async with factory() as session:
+        count = await session.scalar(
+            select(func.count())
+            .select_from(DocumentModel)
+            .where(DocumentModel.stage.in_(("complete", "enriching")))
+        )
+        return bool(count)
 
 
 def _template_to_items(suggestions: list[str]) -> list[SuggestionItem]:
@@ -240,8 +265,12 @@ async def get_suggestions(
 async def _handle_all_scope(svc) -> SuggestionResponse:  # noqa: ANN001
     """Handle cross-document (all-scope) suggestions."""
     shared = await asyncio.to_thread(get_graph_service().get_cross_document_entities, limit=10)
-    if not shared:
-        return SuggestionResponse(suggestions=_template_to_items(_ONBOARDING_SUGGESTIONS[:4]))
+
+    # An empty library gets NO pills — the chat empty state ("Your library is
+    # empty, upload a document...") is the correct, non-clickable guidance. Fake
+    # onboarding "questions" submit their own text to /qa and never work.
+    if not shared and not await _library_has_ready_documents():
+        return SuggestionResponse(suggestions=[])
 
     try:
         target_bloom = await svc.get_target_bloom_level(None)
@@ -278,8 +307,10 @@ async def _handle_single_doc(svc, document_id: str) -> SuggestionResponse:  # no
             await session.execute(select(DocumentModel).where(DocumentModel.id == document_id))
         ).scalar_one_or_none()
 
+        # Stale/missing doc id (e.g. the selected document was deleted): no pills
+        # rather than onboarding chips that submit their own text as a dead question.
         if doc is None:
-            return SuggestionResponse(suggestions=_template_to_items(_ONBOARDING_SUGGESTIONS[:4]))
+            return SuggestionResponse(suggestions=[])
 
         content_type = doc.content_type or "unknown"
 

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -743,7 +743,7 @@ async def ingest_url(
             ),
         )
         logger.info("Article ingestion started", extra={"doc_id": doc_id, "url": body.url})
-        return {"document_id": doc_id, "status": "processing"}
+        return {"document_id": doc_id, "status": "processing", "warnings": parsed.warnings}
 
     # 2. YouTube: Existing logic
     if not _yt_module.check_ytdlp_available():

--- a/backend/app/services/article_extractor.py
+++ b/backend/app/services/article_extractor.py
@@ -28,6 +28,29 @@ USER_AGENTS = [
 
 _BOILERPLATE_CONTAINERS = ("nav", "header", "footer", "aside")
 
+# Substrings that betray a client-hydrated JavaScript page across the common
+# SSR frameworks. Their presence means the initial HTML we fetch is a hydration
+# shell: prose is often server-rendered, but figures drawn by client-only
+# components (charts, diagrams, canvases) exist only after JS runs in a browser,
+# which a static fetch never does. Matched case-insensitively.
+_JS_HYDRATION_MARKERS = (
+    "__next_data__",
+    "self.__next_f",
+    "__nuxt__",
+    "data-server-rendered",
+    "data-reactroot",
+    "astro-island",
+    "data-sveltekit",
+    "dehydratedstate",
+    "dehydrateddata",
+    "dehydratedqueryclient",
+    "stream-barrier",
+)
+
+# Below this word count the page is not a real article, so a lack of images is
+# unremarkable and must not trigger a warning.
+_MIN_ARTICLE_WORDS_FOR_VISUAL_WARNING = 200
+
 _INLINE_MARKERS = {
     "strong": "**",
     "b": "**",
@@ -101,6 +124,11 @@ class ArticleExtractor:
         # 5. Normalize Markdown (The "### Fix")
         markdown_text = self._normalize_markdown(markdown_text)
 
+        word_count = len(markdown_text.split())
+        warnings = self._detect_uncaptured_visuals(html_content, markdown_text, word_count)
+        for warning in warnings:
+            logger.info("ArticleExtractor notice for %s: %s", url, warning)
+
         # For Articles, we keep them as one primary "Section" to ensure unified flow in UI
         sections = [Section(heading=title, level=1, text=markdown_text, page_start=0, page_end=0)]
 
@@ -108,10 +136,36 @@ class ArticleExtractor:
             title=title,
             format="md",
             pages=1,
-            word_count=len(markdown_text.split()),
+            word_count=word_count,
             sections=sections,
             raw_text=markdown_text,
+            warnings=warnings,
         )
+
+    def _detect_uncaptured_visuals(self, html: str, markdown: str, word_count: int) -> list[str]:
+        """Warns when a page's figures were almost certainly lost to static fetching.
+
+        A static HTTP fetch cannot run JavaScript, so figures drawn by client-only
+        components (chart/diagram widgets, canvases) are absent from the HTML we
+        receive and vanish silently. We cannot see those unrendered components to
+        count them, so we infer the loss from a conservative signature: a real
+        article's worth of prose came through, yet not a single image did, on a
+        page that is a client-hydrated JS app. A plain static text-only article
+        trips none of these (no hydration markers), and any page from which we did
+        mirror an image is left alone -- keeping false positives rare.
+        """
+        if word_count < _MIN_ARTICLE_WORDS_FOR_VISUAL_WARNING:
+            return []
+        if "![" in markdown:
+            return []
+        lowered = html.lower()
+        if not any(marker in lowered for marker in _JS_HYDRATION_MARKERS):
+            return []
+        return [
+            "Some figures on this page are drawn by JavaScript in the browser and "
+            "could not be captured. The text was imported in full; interactive "
+            "charts or diagrams may be missing."
+        ]
 
     def _prepare_html(self, html: str) -> str:
         """Repairs markup that trafilatura's extractor silently drops."""

--- a/backend/app/types.py
+++ b/backend/app/types.py
@@ -23,6 +23,9 @@ class ParsedDocument:
     raw_text: str = ""
     # Character offsets in raw_text where each new page begins
     page_breaks: list[int] = field(default_factory=list)
+    # Non-fatal extraction notices surfaced to the user (e.g. visuals that a
+    # static fetch could not capture). Empty when extraction was clean.
+    warnings: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/backend/tests/test_article_extractor.py
+++ b/backend/tests/test_article_extractor.py
@@ -109,6 +109,35 @@ class TestInlineFormatting:
         assert "``" not in extracted
 
 
+class TestUncapturedVisualDetection:
+    PROSE = "word " * 300  # comfortably above the article-length floor
+
+    def _detect(self, html: str, markdown: str) -> list[str]:
+        extractor = ArticleExtractor()
+        return extractor._detect_uncaptured_visuals(html, markdown, len(markdown.split()))
+
+    def test_js_app_with_prose_but_no_images_warns(self):
+        html = "<html><body><script>self.__next_f.push([])</script></body></html>"
+        assert self._detect(html, self.PROSE)
+
+    def test_dehydrated_streaming_app_warns(self):
+        html = "<html><body>...dehydratedQueryClient...stream-barrier...</body></html>"
+        assert self._detect(html, self.PROSE)
+
+    def test_static_text_only_article_does_not_warn(self):
+        html = "<html><body><article><p>plain server-rendered prose</p></article></body></html>"
+        assert self._detect(html, self.PROSE) == []
+
+    def test_js_app_that_yielded_an_image_does_not_warn(self):
+        html = "<html><body><script>self.__next_f.push([])</script></body></html>"
+        md = self.PROSE + "\n\n![](__LUMINARY_IMG__/doc/a.png)"
+        assert self._detect(html, md) == []
+
+    def test_short_page_does_not_warn(self):
+        html = "<html><body><script>self.__next_f.push([])</script></body></html>"
+        assert self._detect(html, "too short to be an article") == []
+
+
 class TestBestSrcsetUrl:
     @pytest.mark.parametrize(
         ("srcset", "expected"),

--- a/backend/tests/test_suggestions.py
+++ b/backend/tests/test_suggestions.py
@@ -5,7 +5,9 @@ Covers:
   (b) test_suggestions_null_document_id: null document_id returns cross-document suggestions
   (c) test_suggestions_technical_document: tech doc returns concept/tradeoff suggestions
   (d) test_suggestions_video_document: video doc returns argument/evidence suggestions
-  (e) test_suggestions_empty_library: no documents returns onboarding suggestions
+  (e) test_suggestions_empty_library: no documents returns NO pills (empty state guides);
+      populated library with no shared entities returns real cross-doc suggestions;
+      missing document id returns NO pills
   (f) test_suggestions_returns_four: always returns exactly 4 suggestions
   (g) test_suggestions_not_in_history: AC11 -- returned suggestions not in recent history
   (h) test_bloom_level_decrease: AC12 -- bloom level decreases per 4 asked questions
@@ -185,7 +187,41 @@ async def test_suggestions_video_document(db_session):
 
 @pytest.mark.asyncio
 async def test_suggestions_empty_library(db_session):
-    """No cross-document entities returns onboarding suggestions."""
+    """A genuinely empty library (no documents) returns NO pills -- the chat empty
+    state provides the (non-clickable) onboarding guidance instead."""
+    with patch("app.routers.chat_meta.get_graph_service") as mock_graph:
+        mock_graph.return_value.get_cross_document_entities.return_value = []
+
+        from app.routers.chat_meta import get_suggestions
+
+        result = await get_suggestions(document_id=None)
+
+    assert result.suggestions == []
+
+
+@pytest.mark.asyncio
+async def test_suggestions_missing_document_returns_no_pills(db_session):
+    """A stale/missing document id (e.g. deleted doc) returns NO pills, never fake
+    onboarding chips that would submit their own text as a dead question."""
+    with patch("app.routers.chat_meta.get_graph_service") as mock_graph:
+        mock_graph.return_value.get_entities_by_type_for_document.return_value = {}
+
+        from app.routers.chat_meta import get_suggestions
+
+        result = await get_suggestions(document_id="does-not-exist")
+
+    assert result.suggestions == []
+
+
+@pytest.mark.asyncio
+async def test_suggestions_populated_library_no_shared_entities(db_session):
+    """A library WITH documents but no cross-document entity overlap must get real,
+    answerable questions -- never the onboarding "upload a document" chips."""
+    doc = _make_doc("doc-ready-1", "Some Book", "book")
+    doc.stage = "complete"
+    db_session.add(doc)
+    await db_session.commit()
+
     with patch("app.routers.chat_meta.get_graph_service") as mock_graph:
         mock_graph.return_value.get_cross_document_entities.return_value = []
 
@@ -195,7 +231,8 @@ async def test_suggestions_empty_library(db_session):
 
     assert len(result.suggestions) == 4
     all_text = " ".join(s.text for s in result.suggestions)
-    assert "Upload" in all_text or "import" in all_text.lower()
+    assert "Upload" not in all_text and "YouTube" not in all_text
+    assert "Viz tab" not in all_text
 
 
 # (f) Always returns exactly 4 suggestions

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1669,7 +1669,7 @@ wheels = [
 
 [[package]]
 name = "luminary-backend"
-version = "0.2.6"
+version = "0.2.7"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/src/components/library/UploadDialog.tsx
+++ b/frontend/src/components/library/UploadDialog.tsx
@@ -301,9 +301,14 @@ export function UploadDialog({ open, onClose }: UploadDialogProps) {
     setDocTitle(urlValue)
     logger.info("[Upload] url start", { url: urlValue })
     try {
-      const docId = await submitUrl(urlValue)
-      track(docId, urlValue)
-      setTrackedDocId(docId)
+      const { documentId, warnings } = await submitUrl(urlValue)
+      track(documentId, urlValue)
+      setTrackedDocId(documentId)
+      // The dialog closes immediately, so any extraction notices need a long
+      // dwell to survive the transition and stay readable.
+      for (const warning of warnings) {
+        toast.warning(warning, { duration: 12000 })
+      }
       // Close the dialog immediately — progress is shown via the
       // IngestionProgressPills widget in the bottom-left corner.
       reset()

--- a/frontend/src/lib/ingestionApi.ts
+++ b/frontend/src/lib/ingestionApi.ts
@@ -67,12 +67,18 @@ export async function submitKindleFile(file: File): Promise<KindleIngestResult> 
   }
 }
 
-export async function submitUrl(url: string): Promise<string> {
+export interface UrlIngestResult {
+  documentId: string
+  warnings: string[]
+}
+
+export async function submitUrl(url: string): Promise<UrlIngestResult> {
   try {
-    const data = await apiPost<{ document_id: string }>("/documents/ingest-url", {
-      url,
-    })
-    return data.document_id
+    const data = await apiPost<{ document_id: string; warnings?: string[] }>(
+      "/documents/ingest-url",
+      { url },
+    )
+    return { documentId: data.document_id, warnings: data.warnings ?? [] }
   } catch (err) {
     throw detailFromError(err, "Ingestion failed")
   }


### PR DESCRIPTION
Two demo bugfixes that were left uncommitted in the working tree when PR #29 merged. Rebased onto `master` at 0.2.7.

## 1. Onboarding chips were rendered as clickable questions

`GET /chat/suggestions` fell back to onboarding text ("Upload a document in the Learning tab...") whenever there were no cross-document entities, or when the selected `document_id` no longer existed. That text was rendered as suggestion pills, so clicking one submitted the onboarding sentence to `/qa` as a question — a guaranteed dead end.

Worse, the same fallback fired for a **populated** library that simply had no entity shared across 2+ documents (common after entity disambiguation), telling the user to upload a document they had already uploaded.

- Genuinely empty library → **no pills**. The chat empty state (`Chat.tsx:1247`, "Your library is empty / Upload a document in the Learning tab…") is the correct, non-clickable guidance.
- Stale/missing `document_id` → **no pills**, for the same reason.
- Populated library, no shared entities → real, answerable cross-corpus questions instead of onboarding text.

Emptiness is now decided by an actual document count at a queryable stage (`complete`/`enriching`), not inferred from the absence of graph entities. `SuggestionPills` already renders `null` on an empty list, so no bare pill bar appears.

## 2. JS-rendered article figures vanished silently

A static HTTP fetch cannot run JavaScript, so figures drawn by client-only components (chart/diagram widgets, canvases) are simply absent from the HTML we receive. Articles imported as text-only with no indication anything had been lost.

`ArticleExtractor` cannot see unrendered components to count them, so it infers the loss from a conservative signature — a real article's worth of prose came through, **not a single image did**, and the page is a client-hydrated JS app (Next/Nuxt/Astro/SvelteKit/React hydration markers). The notice rides `ParsedDocument.warnings` → `POST /documents/ingest-url` → a toast in the upload dialog.

False positives are held down by three independent guards: short pages are exempt, any page from which we *did* mirror an image is exempt, and a plain static article trips no hydration marker.

## Verification

- Backend suite: **2136 passed, 1 skipped, 102 deselected** (4m33s)
- Frontend: **453 passed** (36 files)
- `ruff check` clean; `tsc --noEmit` clean; `eslint` clean on changed files
- New coverage: 5 cases for visual detection (warn / no-warn on static, image-yielding, and short pages), 3 for suggestion behaviour (empty library, missing doc id, populated-but-no-overlap)

Checked against `docs/invariants.md` — I-10 (empty state) is satisfied by the existing chat empty state; the new count query opens its own session (I-1).

Note: `documents.py` carries pre-existing `ruff format` drift unrelated to the one-line change here, left untouched to avoid diff noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)