### PR TITLE
Demo prep: PDF glyph spacing, collections management, flashcard dedup, eval + chat fixes

### DIFF
--- a/backend/app/repos/collection_repo.py
+++ b/backend/app/repos/collection_repo.py
@@ -11,7 +11,7 @@ from sqlalchemy import delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.models import CollectionMemberModel, CollectionModel
+from app.models import CollectionMemberModel, CollectionModel, DocumentModel, NoteModel
 from app.services.repo_helpers import get_or_404
 
 
@@ -43,17 +43,26 @@ class CollectionRepo:
         return result.scalars().all()
 
     async def member_counts(self) -> dict[tuple[str, str], int]:
-        """Return {(collection_id, member_type): count}."""
-        result = await self.session.execute(
-            select(
-                CollectionMemberModel.collection_id,
-                CollectionMemberModel.member_type,
-                func.count(CollectionMemberModel.member_id),
-            ).group_by(
-                CollectionMemberModel.collection_id, CollectionMemberModel.member_type
+        """Return {(collection_id, member_type): count} of members that still exist.
+
+        Joins each membership back to its target: a row whose note or document
+        was deleted must not inflate the badge. The delete paths clear
+        memberships, but other writers reach this table too.
+        """
+        counts: dict[tuple[str, str], int] = {}
+        for member_type, target in (("note", NoteModel), ("document", DocumentModel)):
+            result = await self.session.execute(
+                select(
+                    CollectionMemberModel.collection_id,
+                    func.count(CollectionMemberModel.member_id),
+                )
+                .join(target, target.id == CollectionMemberModel.member_id)
+                .where(CollectionMemberModel.member_type == member_type)
+                .group_by(CollectionMemberModel.collection_id)
             )
-        )
-        return {(cid, mtype): count for cid, mtype, count in result.all()}
+            for cid, count in result.all():
+                counts[(cid, member_type)] = count
+        return counts
 
     async def child_ids(self, parent_id: str) -> list[str]:
         result = await self.session.execute(

--- a/backend/app/repos/note_repo.py
+++ b/backend/app/repos/note_repo.py
@@ -97,6 +97,14 @@ class NoteRepo:
         await self.session.commit()
 
     async def delete_by_id(self, note_id: str) -> None:
+        # SQLite cannot ALTER ADD FK, so membership is cascaded here; orphaned
+        # rows inflated every collection's note badge.
+        await self.session.execute(
+            delete(CollectionMemberModel).where(
+                CollectionMemberModel.member_id == note_id,
+                CollectionMemberModel.member_type == "note",
+            )
+        )
         await self.session.execute(delete(NoteModel).where(NoteModel.id == note_id))
         await self.session.commit()
 

--- a/backend/app/routers/collections.py
+++ b/backend/app/routers/collections.py
@@ -291,9 +291,8 @@ async def get_collection_tree(
         if col is None:
             return None
         scoped = inclusive_scoped(cid)
-        # ?contains scopes the count, never the list. Pruning a note-only
-        # collection made it impossible to drop a document into it, or rename
-        # it, from the Library rail. Callers read relevance off the counts.
+        # ?contains scopes the count, never the list: pruning a note-only
+        # collection makes it undroppable and unmanageable from the Library.
         children: list[CollectionTreeItem] = []
         if depth < 1:
             for child_id in children_by_parent.get(cid, []):

--- a/backend/app/routers/collections.py
+++ b/backend/app/routers/collections.py
@@ -276,19 +276,10 @@ async def get_collection_tree(
             return note_counts.get(cid, 0)
         return note_counts.get(cid, 0) + doc_counts.get(cid, 0)
 
-    def direct_total(cid: str) -> int:
-        return note_counts.get(cid, 0) + doc_counts.get(cid, 0)
-
     def inclusive_scoped(cid: str) -> int:
         total = direct_scoped(cid)
         for child_id in children_by_parent.get(cid, []):
             total += inclusive_scoped(child_id)
-        return total
-
-    def inclusive_total(cid: str) -> int:
-        total = direct_total(cid)
-        for child_id in children_by_parent.get(cid, []):
-            total += inclusive_total(child_id)
         return total
 
     col_by_id: dict[str, CollectionModel] = {c.id: c for c in all_cols}
@@ -300,11 +291,12 @@ async def get_collection_tree(
         if col is None:
             return None
         scoped = inclusive_scoped(cid)
-        # Empty collections (no members of any type) must survive every scope
-        # filter -- otherwise a brand-new collection vanishes from the rail
-        # that created it before any members are added.
-        if contains is not None and scoped == 0 and inclusive_total(cid) > 0:
-            return None
+        # No pruning: ?contains scopes the COUNT, never the membership of the
+        # list. A collection holds documents and notes in one container, and a
+        # rail is a drop target and a management surface as well as a filter --
+        # hiding a note-only collection from the Library rail made it
+        # impossible to drop a document into it or rename it from there.
+        # Callers distinguish relevance from the returned per-type counts.
         children: list[CollectionTreeItem] = []
         if depth < 1:
             for child_id in children_by_parent.get(cid, []):

--- a/backend/app/routers/collections.py
+++ b/backend/app/routers/collections.py
@@ -291,12 +291,9 @@ async def get_collection_tree(
         if col is None:
             return None
         scoped = inclusive_scoped(cid)
-        # No pruning: ?contains scopes the COUNT, never the membership of the
-        # list. A collection holds documents and notes in one container, and a
-        # rail is a drop target and a management surface as well as a filter --
-        # hiding a note-only collection from the Library rail made it
-        # impossible to drop a document into it or rename it from there.
-        # Callers distinguish relevance from the returned per-type counts.
+        # ?contains scopes the count, never the list. Pruning a note-only
+        # collection made it impossible to drop a document into it, or rename
+        # it, from the Library rail. Callers read relevance off the counts.
         children: list[CollectionTreeItem] = []
         if depth < 1:
             for child_id in children_by_parent.get(cid, []):

--- a/backend/app/routers/evals.py
+++ b/backend/app/routers/evals.py
@@ -335,7 +335,7 @@ async def _run_eval_subprocess(
                 "eval subprocess finished OK: dataset=%s\n%s", dataset, stdout_tail
             )
             if stderr_tail.strip():
-                logger.warning(
+                logger.debug(
                     "eval subprocess (rc=0) STDERR for dataset=%s:\n%s",
                     dataset, stderr_tail,
                 )
@@ -411,7 +411,9 @@ async def _run_generated_eval_subprocess(
                 "eval subprocess finished OK: dataset_id=%s\n%s", dataset_id, stdout_tail
             )
             if stderr_tail.strip():
-                logger.warning(
+                # The run succeeded; stderr here is RAGAS/tqdm progress, not a
+                # fault. Logging it at WARNING made every clean run look broken.
+                logger.debug(
                     "eval subprocess (rc=0) STDERR for dataset_id=%s:\n%s",
                     dataset_id, stderr_tail,
                 )

--- a/backend/app/routers/evals.py
+++ b/backend/app/routers/evals.py
@@ -411,8 +411,7 @@ async def _run_generated_eval_subprocess(
                 "eval subprocess finished OK: dataset_id=%s\n%s", dataset_id, stdout_tail
             )
             if stderr_tail.strip():
-                # The run succeeded; stderr here is RAGAS/tqdm progress, not a
-                # fault. Logging it at WARNING made every clean run look broken.
+                # rc=0, so this is RAGAS/tqdm progress, not a fault.
                 logger.debug(
                     "eval subprocess (rc=0) STDERR for dataset_id=%s:\n%s",
                     dataset_id, stderr_tail,

--- a/backend/app/services/document_deletion_service.py
+++ b/backend/app/services/document_deletion_service.py
@@ -30,6 +30,7 @@ from app.models import (
     ChunkModel,
     ClipModel,
     CodeSnippetModel,
+    CollectionMemberModel,
     DocumentModel,
     EnrichmentJobModel,
     FlashcardModel,
@@ -122,6 +123,14 @@ class DocumentDeletionService:
         await session.execute(
             delete(StudySessionModel).where(
                 StudySessionModel.document_id == document_id
+            )
+        )
+        # Keyed on (member_id, member_type), not document_id, so the loop above
+        # misses it; orphaned rows inflate every collection's badge.
+        await session.execute(
+            delete(CollectionMemberModel).where(
+                CollectionMemberModel.member_id == document_id,
+                CollectionMemberModel.member_type == "document",
             )
         )
         await session.delete(doc)

--- a/backend/app/services/flashcard.py
+++ b/backend/app/services/flashcard.py
@@ -7,7 +7,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any, Literal
 
-from sqlalchemy import select, text
+from sqlalchemy import false, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
@@ -446,20 +446,55 @@ def _filter_chunks_by_classification(
     return [(chunks[i], labels[i]) for i in sorted(eligible_indices)]
 
 
-async def _fetch_existing_embeddings(
-    deck: str, session: AsyncSession
-) -> "tuple[list[str], list] | tuple[list, None]":
-    """Fetch all existing questions in *deck* and embed them in one batch.
+async def _study_scope_member_ids(document_id: str, session: AsyncSession) -> list[str]:
+    """Ids of every document and note sharing a collection with *document_id*.
 
-    Returns (questions, vectors) or ([], None) when the deck is empty or embedding fails.
+    A study session draws on a whole collection, so those cards are exactly the
+    ones a newly generated question can end up sitting beside.
+    """
+    from app.models import CollectionMemberModel  # noqa: PLC0415
+
+    owning = select(CollectionMemberModel.collection_id).where(
+        CollectionMemberModel.member_id == document_id,
+        CollectionMemberModel.member_type == "document",
+    )
+    result = await session.execute(
+        select(CollectionMemberModel.member_id).where(
+            CollectionMemberModel.collection_id.in_(owning)
+        )
+    )
+    return [row[0] for row in result.all()]
+
+
+async def _fetch_existing_embeddings(
+    deck: str, session: AsyncSession, document_id: str | None = None
+) -> "tuple[list[str], list] | tuple[list, None]":
+    """Embed the questions a new card could be a duplicate of, in one batch.
+
+    Deck alone is too narrow: note-derived cards land in a tag-named deck while
+    document-derived ones land in "default", so the two never compared even
+    though a collection session interleaves them. When *document_id* is given,
+    the scope widens to that document and everything sharing a collection with
+    it.
+
+    Returns (questions, vectors) or ([], None) when nothing to compare against
+    or embedding fails.
     """
     import numpy as np  # noqa: PLC0415
 
     from app.services.embedder import get_embedding_service  # noqa: PLC0415
 
-    result = await session.execute(
-        select(FlashcardModel.question).where(FlashcardModel.deck == deck)
-    )
+    scope = FlashcardModel.deck == deck
+    if document_id is not None:
+        member_ids = await _study_scope_member_ids(document_id, session)
+        scope = or_(
+            scope,
+            FlashcardModel.document_id == document_id,
+            FlashcardModel.document_id.in_(member_ids) if member_ids else false(),
+            FlashcardModel.note_id.in_(member_ids) if member_ids else false(),
+        )
+
+    result = await session.execute(select(FlashcardModel.question).where(scope))
     existing_questions = [row[0] for row in result.all()]
     if not existing_questions:
         return [], None

--- a/backend/app/services/flashcard_generators.py
+++ b/backend/app/services/flashcard_generators.py
@@ -562,7 +562,9 @@ async def generate(
 
     from app.services.embedder import get_embedding_service  # noqa: PLC0415
 
-    _existing_qs, existing_vecs = await _fetch_existing_embeddings("default", session)
+    _existing_qs, existing_vecs = await _fetch_existing_embeddings(
+        "default", session, document_id=document_id
+    )
 
     if not candidates:
         logger.warning(

--- a/backend/app/services/parser.py
+++ b/backend/app/services/parser.py
@@ -44,20 +44,17 @@ def _norm_ws(s: str) -> str:
     return _RE_WHITESPACE.sub(" ", s).strip()
 
 
-# A real inter-word gap is a sizeable fraction of an em; kerning between glyphs
-# of one word is near zero and frequently negative. 0.2em sits well clear of
-# both, since a space glyph is typically 0.25-0.33em.
+# Kerning within a word is ~0 (often negative); a space glyph is 0.25-0.33em.
 _SPACE_GAP_EM = 0.2
 
 
 def _join_spans(spans: list[dict]) -> str:
     """Rebuild a line's text from its spans, inferring word gaps from geometry.
 
-    PyMuPDF opens a new span at every style change, so a PDF that alternates
-    Type3 font subsets glyph by glyph splits each word across dozens of spans.
-    Joining those on a space corrupts every word on the page; joining on nothing
-    instead welds together words that the PDF separates by position rather than
-    by a space character. Only the horizontal gap distinguishes the two cases.
+    PyMuPDF opens a new span at every style change, so a PDF alternating Type3
+    font subsets per glyph splits words across dozens of spans. Joining on a
+    space corrupts every word; joining on nothing welds together words a PDF
+    separates by position alone. Only the gap tells the two apart.
     """
     parts: list[str] = []
     prev_x1: float | None = None

--- a/backend/app/services/parser.py
+++ b/backend/app/services/parser.py
@@ -44,6 +44,42 @@ def _norm_ws(s: str) -> str:
     return _RE_WHITESPACE.sub(" ", s).strip()
 
 
+# A real inter-word gap is a sizeable fraction of an em; kerning between glyphs
+# of one word is near zero and frequently negative. 0.2em sits well clear of
+# both, since a space glyph is typically 0.25-0.33em.
+_SPACE_GAP_EM = 0.2
+
+
+def _join_spans(spans: list[dict]) -> str:
+    """Rebuild a line's text from its spans, inferring word gaps from geometry.
+
+    PyMuPDF opens a new span at every style change, so a PDF that alternates
+    Type3 font subsets glyph by glyph splits each word across dozens of spans.
+    Joining those on a space corrupts every word on the page; joining on nothing
+    instead welds together words that the PDF separates by position rather than
+    by a space character. Only the horizontal gap distinguishes the two cases.
+    """
+    parts: list[str] = []
+    prev_x1: float | None = None
+    prev_text = ""
+    for span in spans:
+        text = span.get("text", "")
+        if not text:
+            continue
+        x0, x1 = span["bbox"][0], span["bbox"][2]
+        if (
+            prev_x1 is not None
+            and not prev_text[-1:].isspace()
+            and not text[:1].isspace()
+            and x0 - prev_x1 > _SPACE_GAP_EM * span.get("size", 12.0)
+        ):
+            parts.append(" ")
+        parts.append(text)
+        prev_x1 = x1
+        prev_text = text
+    return "".join(parts)
+
+
 def _heading_is_prose(heading: str) -> bool:
     h = heading.strip()
     if len(h) > 100:
@@ -156,7 +192,7 @@ class DocumentParser:
                             spans = line.get("spans", [])
                             if not spans:
                                 continue
-                            line_text = " ".join(s["text"] for s in spans).strip()
+                            line_text = _join_spans(spans).strip()
                             if not line_text:
                                 continue
                             texts.append(line_text)
@@ -242,7 +278,7 @@ class DocumentParser:
                     if not spans:
                         continue
                     max_size = max(s["size"] for s in spans)
-                    line_text = " ".join(s["text"] for s in spans).strip()
+                    line_text = _join_spans(spans).strip()
                     if not line_text:
                         continue
                     if max_size >= heading_threshold and len(line_text) < 120:

--- a/backend/tests/test_ablation_eval.py
+++ b/backend/tests/test_ablation_eval.py
@@ -90,8 +90,9 @@ async def test_retriever_strategy_graph_expands_then_vector(monkeypatch):
     assert rows[0].chunk_id == "graph-1"
 
 
-def test_run_eval_ablation_produces_five_metric_sets(monkeypatch):
+def test_run_eval_ablation_produces_one_metric_set_per_arm(monkeypatch):
     strategies_seen: list[str] = []
+    expand_flags: list[bool] = []
     history_rows: list[tuple[str, dict]] = []
     store_rows: list[tuple[str, dict]] = []
 
@@ -112,8 +113,11 @@ def test_run_eval_ablation_produces_five_metric_sets(monkeypatch):
     monkeypatch.setattr(
         run_eval,
         "search_chunks",
-        lambda *args, **kwargs: strategies_seen.append(kwargs.get("strategy", "rrf"))
-        or ["answer hint"],
+        lambda *args, **kwargs: (
+            strategies_seen.append(kwargs.get("strategy", "rrf")),
+            expand_flags.append(kwargs.get("graph_expand", True)),
+        )
+        and ["answer hint"],
     )
     monkeypatch.setattr(
         run_eval,
@@ -138,13 +142,16 @@ def test_run_eval_ablation_produces_five_metric_sets(monkeypatch):
 
     run_eval.main()
 
-    # Two rerank passes issue strategy="rrf" (rerank=True) -- rrf+rerank-ce
-    # (pure CE, blend=0) and the shipped rrf+rerank -- and the L1 pool-recall
-    # arm adds one more raw-rrf pass at the end.
-    assert strategies_seen == ["vector", "fts", "graph", "rrf", "rrf", "rrf", "rrf"]
+    # Five arms issue strategy="rrf" -- rrf, rrf-nogx, rrf+rerank-ce,
+    # rrf+rerank, rrf+rerank-nogx -- and the L1 pool-recall arm adds one more.
+    assert strategies_seen == ["vector", "fts", "graph"] + ["rrf"] * 6
+    # Only the -nogx arms switch expansion off; everything else inherits the
+    # /search default, which is what the shipped pipeline runs with.
+    assert expand_flags == [True, True, True, True, False, True, True, False, True]
     assert history_rows[0][0] == "ablation"
     assert set(history_rows[0][1]["ablation_metrics"]) == {
-        "vector", "fts", "graph", "rrf", "rrf+rerank-ce", "rrf+rerank", "rrf-pool",
+        "vector", "fts", "graph", "rrf", "rrf-nogx",
+        "rrf+rerank-ce", "rrf+rerank", "rrf+rerank-nogx", "rrf-pool",
     }
     assert history_rows[0][1]["ablation_metrics"]["rrf-pool"] == {
         "recall_50": 1.0, "recall_100": 1.0, "recall_200": 1.0,

--- a/backend/tests/test_collection_repo.py
+++ b/backend/tests/test_collection_repo.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.database import make_engine
 from app.db_init import create_all_tables
+from app.models import DocumentModel, NoteModel
 from app.repos.collection_repo import CollectionRepo
 
 
@@ -19,6 +20,31 @@ async def repo():
     async with factory() as session:
         yield CollectionRepo(session)
     await engine.dispose()
+
+
+async def _add_notes(repo: CollectionRepo, ids: list[str]) -> None:
+    """member_counts joins memberships to their targets, so the rows must exist."""
+    for note_id in ids:
+        repo.session.add(NoteModel(id=note_id, content=note_id, tags=[]))
+    await repo.session.commit()
+
+
+async def _add_documents(repo: CollectionRepo, ids: list[str]) -> None:
+    for doc_id in ids:
+        repo.session.add(
+            DocumentModel(
+                id=doc_id,
+                title=doc_id,
+                format="txt",
+                content_type="book",
+                word_count=1,
+                page_count=0,
+                file_path=f"/tmp/{doc_id}.txt",
+                stage="complete",
+                tags=[],
+            )
+        )
+    await repo.session.commit()
 
 
 @pytest.mark.asyncio
@@ -79,11 +105,26 @@ async def test_remove_member(repo: CollectionRepo) -> None:
 @pytest.mark.asyncio
 async def test_member_counts_groups_by_type(repo: CollectionRepo) -> None:
     col = await repo.create(name="C")
+    await _add_notes(repo, ["n1", "n2"])
+    await _add_documents(repo, ["d1"])
     await repo.add_members(col.id, ["n1", "n2"], member_type="note")
     await repo.add_members(col.id, ["d1"], member_type="document")
     counts = await repo.member_counts()
     assert counts[(col.id, "note")] == 2
     assert counts[(col.id, "document")] == 1
+
+
+@pytest.mark.asyncio
+async def test_member_counts_skips_members_that_no_longer_exist(repo: CollectionRepo) -> None:
+    """A membership whose note or document is gone must not be counted."""
+    col = await repo.create(name="C")
+    await _add_notes(repo, ["real-note"])
+    await repo.add_members(col.id, ["real-note", "deleted-note"], member_type="note")
+    await repo.add_members(col.id, ["deleted-doc"], member_type="document")
+
+    counts = await repo.member_counts()
+    assert counts[(col.id, "note")] == 1
+    assert (col.id, "document") not in counts
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_collections_tree_contains.py
+++ b/backend/tests/test_collections_tree_contains.py
@@ -101,10 +101,8 @@ async def test_tree_unscoped_scoped_count_sums_direct_members(test_db):
 async def test_tree_contains_scopes_counts_without_hiding_collections(test_db):
     """?contains scopes scoped_count; it never removes a collection from the list.
 
-    A note-only collection must still reach the Library rail: one container holds
-    both member types, and the rail is a drop target and a management surface, so
-    hiding the row would make it impossible to add a document to that collection
-    or rename it from there. Relevance is expressed by the counts, not by absence.
+    A note-only collection must stay reachable from the Library rail, or a
+    document can never be dropped into it.
     """
     _, factory = test_db
     doc_id = str(uuid.uuid4())
@@ -133,8 +131,6 @@ async def test_tree_contains_scopes_counts_without_hiding_collections(test_db):
 
         docs_node = next(n for n in tree if n["id"] == docs_only)
         assert docs_node["scoped_count"] == 1
-        # Scoped to documents, the note-only collection reads as zero documents
-        # while still reporting the note it holds.
         notes_node = next(n for n in tree if n["id"] == notes_only)
         assert notes_node["scoped_count"] == 0
         assert notes_node["note_count"] == 1
@@ -177,6 +173,58 @@ async def test_tree_contains_keeps_empty_collections(test_db):
         assert empty_id in ids
         node = next(n for n in tree if n["id"] == empty_id)
         assert node["scoped_count"] == 0
+
+
+@pytest.mark.anyio
+async def test_counts_ignore_members_whose_target_was_deleted(test_db):
+    """A deleted note must leave no trace in its collection's badge.
+
+    Membership keys on (member_id, member_type), so nothing cascades to it
+    automatically. When that was missed, a 2-note collection reported five.
+    """
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        col_id = await _create_collection(c, "Survivors")
+
+        note_ids = []
+        for i in range(3):
+            r = await c.post("/notes", json={"content": f"n{i}", "tags": [], "document_id": None})
+            note_ids.append(r.json()["id"])
+        await c.post(
+            f"/collections/{col_id}/members",
+            json={"member_ids": note_ids, "member_type": "note"},
+        )
+
+        node = next(n for n in (await c.get("/collections/tree")).json() if n["id"] == col_id)
+        assert node["note_count"] == 3
+
+        assert (await c.delete(f"/notes/{note_ids[0]}")).status_code in (200, 204)
+
+        node = next(n for n in (await c.get("/collections/tree")).json() if n["id"] == col_id)
+        assert node["note_count"] == 2, "deleted note still counted in the collection badge"
+
+
+@pytest.mark.anyio
+async def test_deleting_a_document_clears_its_memberships(test_db):
+    """The document delete cascade must reach collection_members too."""
+    _, factory = test_db
+    doc_id = str(uuid.uuid4())
+    async with factory() as s:
+        s.add(_doc(doc_id))
+        await s.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        col_id = await _create_collection(c, "Docs")
+        await c.post(
+            f"/collections/{col_id}/members",
+            json={"member_ids": [doc_id], "member_type": "document"},
+        )
+        node = next(n for n in (await c.get("/collections/tree")).json() if n["id"] == col_id)
+        assert node["document_count"] == 1
+
+        assert (await c.delete(f"/documents/{doc_id}")).status_code in (200, 204)
+
+        node = next(n for n in (await c.get("/collections/tree")).json() if n["id"] == col_id)
+        assert node["document_count"] == 0
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_collections_tree_contains.py
+++ b/backend/tests/test_collections_tree_contains.py
@@ -98,9 +98,14 @@ async def test_tree_unscoped_scoped_count_sums_direct_members(test_db):
 
 
 @pytest.mark.anyio
-async def test_tree_contains_document_filters_to_doc_holders(test_db):
-    """Top collection has only a note child collection that has only notes:
-    ?contains=document should prune both."""
+async def test_tree_contains_scopes_counts_without_hiding_collections(test_db):
+    """?contains scopes scoped_count; it never removes a collection from the list.
+
+    A note-only collection must still reach the Library rail: one container holds
+    both member types, and the rail is a drop target and a management surface, so
+    hiding the row would make it impossible to add a document to that collection
+    or rename it from there. Relevance is expressed by the counts, not by absence.
+    """
     _, factory = test_db
     doc_id = str(uuid.uuid4())
     async with factory() as s:
@@ -124,10 +129,15 @@ async def test_tree_contains_document_filters_to_doc_holders(test_db):
         tree = (await c.get("/collections/tree?contains=document")).json()
         ids = {n["id"] for n in tree}
         assert docs_only in ids
-        assert notes_only not in ids
-        # scoped_count on docs_only is the doc count (1), not the note count.
+        assert notes_only in ids, "a note-only collection must stay droppable from the Library"
+
         docs_node = next(n for n in tree if n["id"] == docs_only)
         assert docs_node["scoped_count"] == 1
+        # Scoped to documents, the note-only collection reads as zero documents
+        # while still reporting the note it holds.
+        notes_node = next(n for n in tree if n["id"] == notes_only)
+        assert notes_node["scoped_count"] == 0
+        assert notes_node["note_count"] == 1
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_flashcard_dedup_scope.py
+++ b/backend/tests/test_flashcard_dedup_scope.py
@@ -1,0 +1,105 @@
+"""Dedup scope for flashcard generation.
+
+A collection study session interleaves cards generated from a document with
+cards generated from the notes in that collection, but the two land in
+different decks. Comparing only within a deck let near-duplicates be created.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.database import make_engine
+from app.db_init import create_all_tables
+from app.models import CollectionMemberModel, CollectionModel, FlashcardModel
+from app.services.flashcard import _study_scope_member_ids
+
+
+@pytest.fixture
+async def session():
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    await create_all_tables(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+def _card(card_id: str, question: str, *, deck: str, document_id=None, note_id=None):
+    return FlashcardModel(
+        id=card_id,
+        document_id=document_id,
+        note_id=note_id,
+        source="document" if document_id else "note",
+        deck=deck,
+        question=question,
+        answer="a",
+        source_excerpt="",
+    )
+
+
+async def _collection_with(s, collection_id: str, members: list[tuple[str, str]]):
+    s.add(CollectionModel(id=collection_id, name=collection_id, color="#fff"))
+    for member_id, member_type in members:
+        s.add(
+            CollectionMemberModel(
+                id=f"{collection_id}-{member_id}",
+                collection_id=collection_id,
+                member_id=member_id,
+                member_type=member_type,
+            )
+        )
+    await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_scope_spans_documents_and_notes_of_the_collection(session):
+    await _collection_with(
+        session, "col-1", [("doc-1", "document"), ("note-1", "note"), ("doc-2", "document")]
+    )
+    members = await _study_scope_member_ids("doc-1", session)
+    assert set(members) == {"doc-1", "note-1", "doc-2"}
+
+
+@pytest.mark.asyncio
+async def test_scope_excludes_unrelated_collections(session):
+    await _collection_with(session, "col-1", [("doc-1", "document"), ("note-1", "note")])
+    await _collection_with(session, "col-2", [("doc-9", "document"), ("note-9", "note")])
+    members = await _study_scope_member_ids("doc-1", session)
+    assert "note-9" not in members and "doc-9" not in members
+
+
+@pytest.mark.asyncio
+async def test_document_in_no_collection_yields_no_members(session):
+    assert await _study_scope_member_ids("orphan-doc", session) == []
+
+
+@pytest.mark.asyncio
+async def test_note_cards_in_another_deck_become_comparable(session, monkeypatch):
+    """The regression: a note card in deck 'search' was invisible to a document
+    generating into deck 'default', so a near-duplicate question was created."""
+    await _collection_with(session, "col-1", [("doc-1", "document"), ("note-1", "note")])
+    session.add(_card("c1", "Deck-mate question", deck="default", document_id="doc-other"))
+    session.add(_card("c2", "What does a Bi-encoder do?", deck="search", note_id="note-1"))
+    await session.commit()
+
+    captured: list[list[str]] = []
+
+    class _Embedder:
+        def encode(self, texts):
+            captured.append(list(texts))
+            return [[1.0, 0.0] for _ in texts]
+
+    import app.services.embedder as embedder_module
+
+    monkeypatch.setattr(embedder_module, "get_embedding_service", lambda: _Embedder())
+
+    from app.services.flashcard import _fetch_existing_embeddings
+
+    deck_only, _ = await _fetch_existing_embeddings("default", session)
+    assert "What does a Bi-encoder do?" not in deck_only
+
+    scoped, _ = await _fetch_existing_embeddings("default", session, document_id="doc-1")
+    assert "What does a Bi-encoder do?" in scoped
+    assert "Deck-mate question" in scoped, "deck-based comparison must still apply"

--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -229,8 +229,8 @@ def _span(text: str, x0: float, x1: float, size: float = 12.0) -> dict:
 
 class TestJoinSpans:
     def test_glyph_split_word_is_not_broken_by_spaces(self):
-        """A PDF alternating Type3 font subsets splits one word across many spans
-        with no horizontal gap; joining on a space corrupted every word."""
+        """Type3 subsets split one word across many spans with no gap between
+        them; joining on a space corrupted every word."""
         spans = [
             _span("The C", 27.750, 74.964, 16.5),
             _span("on", 74.980, 95.581, 16.5),

--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -3,6 +3,7 @@ import pytest
 from app.services.parser import (
     DocumentParser,
     _heading_is_prose,
+    _join_spans,
     _norm_ws,
     _sections_plausible,
 )
@@ -220,3 +221,53 @@ def test_pdf_preface_prose_not_mistaken_for_headings(parser, prose_trap_pdf):
 )
 def test_norm_ws(raw, expected):
     assert _norm_ws(raw) == expected
+
+
+def _span(text: str, x0: float, x1: float, size: float = 12.0) -> dict:
+    return {"text": text, "bbox": (x0, 0.0, x1, size), "size": size}
+
+
+class TestJoinSpans:
+    def test_glyph_split_word_is_not_broken_by_spaces(self):
+        """A PDF alternating Type3 font subsets splits one word across many spans
+        with no horizontal gap; joining on a space corrupted every word."""
+        spans = [
+            _span("The C", 27.750, 74.964, 16.5),
+            _span("on", 74.980, 95.581, 16.5),
+            _span("ce", 95.424, 113.169, 16.5),
+            _span("ptu", 113.177, 141.037, 16.5),
+            _span("al F", 141.045, 169.697, 16.5),
+            _span("oun", 169.028, 200.460, 16.5),
+            _span("da", 200.303, 220.153, 16.5),
+            _span("t", 219.748, 226.282, 16.5),
+            _span("i", 226.299, 231.562, 16.5),
+            _span("ons", 231.570, 260.296, 16.5),
+        ]
+        assert _join_spans(spans) == "The Conceptual Foundations"
+
+    def test_negative_kerning_does_not_insert_a_space(self):
+        assert _join_spans([_span("Ke", 10.0, 20.0), _span("rn", 19.4, 30.0)]) == "Kern"
+
+    def test_positional_word_gap_becomes_a_space(self):
+        """Words separated by position rather than a space glyph must not weld."""
+        spans = [_span("Hello", 10.0, 40.0), _span("world", 44.0, 74.0)]
+        assert _join_spans(spans) == "Hello world"
+
+    def test_existing_space_is_not_doubled(self):
+        spans = [_span("Hello ", 10.0, 43.0), _span("world", 44.0, 74.0)]
+        assert _join_spans(spans) == "Hello world"
+
+    def test_leading_space_on_next_span_is_not_doubled(self):
+        spans = [_span("Hello", 10.0, 40.0), _span(" world", 44.0, 78.0)]
+        assert _join_spans(spans) == "Hello world"
+
+    def test_empty_spans_are_skipped(self):
+        assert _join_spans([_span("a", 10.0, 15.0), _span("", 15.0, 15.0)]) == "a"
+
+    def test_no_spans(self):
+        assert _join_spans([]) == ""
+
+    def test_gap_threshold_scales_with_font_size(self):
+        """A 3pt gap is a word break at 12pt but mere kerning at 24pt."""
+        assert _join_spans([_span("a", 0.0, 10.0, 12.0), _span("b", 13.0, 20.0, 12.0)]) == "a b"
+        assert _join_spans([_span("a", 0.0, 10.0, 24.0), _span("b", 13.0, 20.0, 24.0)]) == "ab"

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -206,6 +206,7 @@ def search_chunks(
     strategy: str = "rrf",
     limit: int | None = None,
     expand_context: bool = True,
+    graph_expand: bool = True,
 ) -> list[str]:
     """Run GET /search and return up to top-10 chunk texts.
 
@@ -248,6 +249,10 @@ def search_chunks(
             params["rerank_adaptive"] = "true"
     if strategy != "rrf":
         params["strategy"] = strategy
+    # /search defaults graph_expand to true, so every arm carries expansion
+    # unless it is switched off explicitly.
+    if not graph_expand:
+        params["graph_expand"] = "false"
     try:
         request_timeout = 60.0 if (hyde or rerank or limit) else 30.0
         resp = httpx.get(f"{backend_url}/search", params=params, timeout=request_timeout)
@@ -627,13 +632,18 @@ def main() -> None:
         # RERANK_BLEND_ALPHA). "rrf+rerank-ce" pins blend=0 to isolate the pure
         # cross-encoder, so the run always records what the RRF/CE blend buys
         # over CE alone -- the L2 analogue of the rrf-pool recall arm.
+        # /search enables graph_expand by default, so every rrf arm below
+        # carries it. The -nogx pairs switch it off to price what the entity
+        # aliases actually buy, before and after the cross-encoder.
         strategy_specs = [
-            ("vector", "vector", False, None, None),
-            ("fts", "fts", False, None, None),
-            ("graph", "graph", False, None, None),
-            ("rrf", "rrf", False, None, None),
-            ("rrf+rerank-ce", "rrf", True, args.rerank_depth, 0.0),
-            ("rrf+rerank", "rrf", True, args.rerank_depth, None),
+            ("vector", "vector", False, None, None, True),
+            ("fts", "fts", False, None, None, True),
+            ("graph", "graph", False, None, None, True),
+            ("rrf", "rrf", False, None, None, True),
+            ("rrf-nogx", "rrf", False, None, None, False),
+            ("rrf+rerank-ce", "rrf", True, args.rerank_depth, 0.0, True),
+            ("rrf+rerank", "rrf", True, args.rerank_depth, None, True),
+            ("rrf+rerank-nogx", "rrf", True, args.rerank_depth, None, False),
         ]
         # Depth sweep arms measure the L2 recall ceiling directly: reranked
         # HR@5 is bounded by HR@depth of the RRF pool, so if HR@5 climbs with
@@ -641,9 +651,9 @@ def main() -> None:
         # were never in ANY leg's candidates and no L2 tuning can recover them.
         for depth_str in (s.strip() for s in args.rerank_depths.split(",") if s.strip()):
             depth = int(depth_str)
-            strategy_specs.append((f"rrf+rerank@{depth}", "rrf", True, depth, None))
+            strategy_specs.append((f"rrf+rerank@{depth}", "rrf", True, depth, None, True))
         ablation_metrics: dict[str, dict[str, float]] = {}
-        for label, search_strategy, do_rerank, depth, blend in strategy_specs:
+        for label, search_strategy, do_rerank, depth, blend, gx in strategy_specs:
             samples: list[dict] = []
             for i, row in enumerate(rows, start=1):
                 question = row["question"]
@@ -665,6 +675,7 @@ def main() -> None:
                     rerank_threshold=args.rerank_threshold,
                     rerank_blend=blend,
                     strategy=search_strategy,
+                    graph_expand=gx,
                 )
                 samples.append(
                     {

--- a/frontend/src/components/CollectionTree.tsx
+++ b/frontend/src/components/CollectionTree.tsx
@@ -39,6 +39,17 @@ export type { CollectionTreeItem }
 export { flattenCollectionTree }
 
 export type CollectionTreeContains = "document" | "note"
+export type CollectionMemberType = "document" | "note"
+
+/** dataTransfer key each surface uses when dragging one of its rows. */
+export const NOTE_DRAG_MIME = "text/plain"
+export const DOC_DRAG_MIME = "application/x-luminary-doc-id"
+
+/** The list query a membership change invalidates, per member type. */
+const MEMBER_LIST_QUERY: Record<CollectionMemberType, string> = {
+  note: "notes",
+  document: "documents",
+}
 
 const fetchCollectionTree = (
   contains?: CollectionTreeContains,
@@ -51,13 +62,14 @@ const renameCollection = (id: string, name: string): Promise<void> =>
 const deleteCollection = (id: string): Promise<void> =>
   apiDelete(`/collections/${id}`)
 
-const addNoteToCollection = (
+const addMemberToCollection = (
   collectionId: string,
-  noteId: string,
+  memberId: string,
+  memberType: CollectionMemberType,
 ): Promise<void> =>
   apiPost(`/collections/${collectionId}/members`, {
-    member_ids: [noteId],
-    member_type: "note",
+    member_ids: [memberId],
+    member_type: memberType,
   })
 
 // Single tree item row
@@ -69,6 +81,9 @@ interface CollectionTreeItemRowProps {
   onToggleExpand: () => void
   isActive: boolean
   onSelect: () => void
+  memberType: CollectionMemberType
+  dragMime: string
+  onDeleted: () => void
 }
 
 function CollectionTreeItemRow({
@@ -78,6 +93,9 @@ function CollectionTreeItemRow({
   onToggleExpand,
   isActive,
   onSelect,
+  memberType,
+  dragMime,
+  onDeleted,
 }: CollectionTreeItemRowProps) {
   const [renaming, setRenaming] = useState(false)
   const [renameValue, setRenameValue] = useState(item.name)
@@ -88,8 +106,7 @@ function CollectionTreeItemRow({
   const [exportLoading, setExportLoading] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const qc = useQueryClient()
-  const activeCollectionId = useAppStore((s) => s.activeCollectionId)
-  const setActiveCollectionId = useAppStore((s) => s.setActiveCollectionId)
+  const listQueryKey = MEMBER_LIST_QUERY[memberType]
 
   const renameMut = useMutation({
     mutationFn: (name: string) => renameCollection(item.id, name),
@@ -103,19 +120,21 @@ function CollectionTreeItemRow({
   const deleteMut = useMutation({
     mutationFn: () => deleteCollection(item.id),
     onSuccess: () => {
-      if (activeCollectionId === item.id) setActiveCollectionId(null)
+      onDeleted()
       void qc.invalidateQueries({ queryKey: ["collections-tree"] })
-      void qc.invalidateQueries({ queryKey: ["notes"] })
+      void qc.invalidateQueries({ queryKey: [listQueryKey] })
       setConfirmDelete(false)
     },
   })
 
   const dropMut = useMutation({
-    mutationFn: (noteId: string) => addNoteToCollection(item.id, noteId),
+    mutationFn: (memberId: string) => addMemberToCollection(item.id, memberId, memberType),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ["notes"] })
+      void qc.invalidateQueries({ queryKey: [listQueryKey] })
       void qc.invalidateQueries({ queryKey: ["collections-tree"] })
+      toast.success("Added to collection")
     },
+    onError: () => toast.error("Could not add to collection"),
   })
 
   function commitRename() {
@@ -177,6 +196,19 @@ function CollectionTreeItemRow({
   const hasChildren = item.children.length > 0
   const paddingLeft = depth * 12 + 8
 
+  const isEmpty = item.document_count === 0 && item.note_count === 0
+  const kindLabel = isEmpty
+    ? "Empty collection"
+    : item.document_count > 0 && item.note_count > 0
+      ? `${item.document_count} document${item.document_count === 1 ? "" : "s"}, ` +
+        `${item.note_count} note${item.note_count === 1 ? "" : "s"}`
+      : item.document_count > 0
+        ? `${item.document_count} document${item.document_count === 1 ? "" : "s"}`
+        : `${item.note_count} note${item.note_count === 1 ? "" : "s"}`
+  // Holds nothing of the kind this rail deals in. Still a valid drop target and
+  // still manageable, so it is de-emphasised rather than hidden.
+  const offKind = !isEmpty && (memberType === "document" ? item.document_count : item.note_count) === 0
+
   return (
     <>
       <div
@@ -201,8 +233,8 @@ function CollectionTreeItemRow({
         onDrop={(e) => {
           e.preventDefault()
           setIsDragOver(false)
-          const noteId = e.dataTransfer.getData("text/plain")
-          if (noteId) dropMut.mutate(noteId)
+          const memberId = e.dataTransfer.getData(dragMime)
+          if (memberId) dropMut.mutate(memberId)
         }}
       >
         {/* Expand/collapse chevron */}
@@ -244,20 +276,35 @@ function CollectionTreeItemRow({
             className="flex-1 min-w-0 rounded border border-primary bg-background px-1 text-xs text-foreground focus:outline-none"
           />
         ) : (
-          <span className="flex-1 min-w-0 truncate text-sm">{item.name}</span>
+          <span
+            className={`flex-1 min-w-0 truncate text-sm ${
+              offKind && !isActive ? "opacity-60" : ""
+            }`}
+          >
+            {item.name}
+          </span>
         )}
 
-        {/* Counts pill */}
+        {/* Kind + counts. Which pills are present IS the kind: documents only,
+            notes only, or both. A zero pill is never rendered, so the row reads
+            at a glance instead of every collection showing a "0n". */}
         {!renaming && (
-          <div className="ml-auto flex items-center gap-1 shrink-0">
+          <div className="ml-auto flex items-center gap-1 shrink-0" title={kindLabel}>
             {item.document_count > 0 && (
-              <span className="rounded-full bg-blue-100/50 dark:bg-blue-900/30 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:text-blue-300">
+              <span className="rounded-full bg-sky-100/60 dark:bg-sky-900/30 px-1.5 py-0.5 text-[10px] font-medium text-sky-700 dark:text-sky-300">
                 {item.document_count}d
               </span>
             )}
-            <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-              {item.note_count}n
-            </span>
+            {item.note_count > 0 && (
+              <span className="rounded-full bg-amber-100/60 dark:bg-amber-900/30 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-300">
+                {item.note_count}n
+              </span>
+            )}
+            {isEmpty && (
+              <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground/70">
+                empty
+              </span>
+            )}
           </div>
         )}
 
@@ -356,7 +403,8 @@ function CollectionTreeItemRow({
           <DialogHeader>
             <DialogTitle>Delete collection?</DialogTitle>
             <DialogDescription>
-              Delete &ldquo;{item.name}&rdquo;? Notes are not deleted.
+              Delete &ldquo;{item.name}&rdquo;? Your documents and notes are not deleted —
+              only the collection and its membership list.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -383,18 +431,42 @@ function CollectionTreeItemRow({
 
 
 interface CollectionTreeProps {
-  /** Restrict tree to collections containing this member type. Empty
-   * collections always survive so create-then-add still works. Defaults
-   * to undefined (unscoped) so existing call sites keep current behavior;
-   * Notes opts in to "note" to focus the sidebar. */
+  /** Scopes each row's count badge to this member type. Every collection is
+   * still listed: a rail is a drop target and a management surface, not only a
+   * filter, so hiding a collection would make it unreachable from here. */
   contains?: CollectionTreeContains
+  /** What a drop onto a row adds, and which list query that invalidates. */
+  memberType?: CollectionMemberType
+  /** dataTransfer key carrying the dragged row's id. */
+  dragMime?: string
+  /** Controlled selection. Omit to use the global activeCollectionId. */
+  selectedId?: string | null
+  onSelect?: (id: string | null) => void
 }
 
-export function CollectionTree({ contains }: CollectionTreeProps = {}) {
+export function CollectionTree({
+  contains,
+  memberType = "note",
+  dragMime = NOTE_DRAG_MIME,
+  selectedId,
+  onSelect,
+}: CollectionTreeProps = {}) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
-  const activeCollectionId = useAppStore((s) => s.activeCollectionId)
+  const storeCollectionId = useAppStore((s) => s.activeCollectionId)
   const setActiveCollectionId = useAppStore((s) => s.setActiveCollectionId)
   const setActiveTag = useAppStore((s) => s.setActiveTag)
+
+  const isControlled = onSelect !== undefined
+  const activeCollectionId = isControlled ? (selectedId ?? null) : storeCollectionId
+
+  function select(id: string | null) {
+    if (isControlled) {
+      onSelect(id)
+      return
+    }
+    setActiveTag(null)
+    setActiveCollectionId(id)
+  }
 
   const {
     data: tree,
@@ -405,6 +477,10 @@ export function CollectionTree({ contains }: CollectionTreeProps = {}) {
     queryKey: ["collections-tree", contains ? `contains:${contains}` : "contains:all"],
     queryFn: () => fetchCollectionTree(contains),
     staleTime: 30_000,
+    // A collection created on another surface must be present the moment this
+    // one mounts; serving it from a still-fresh cache is what made the rail
+    // look like it needed a manual refresh.
+    refetchOnMount: "always",
   })
 
   function toggleExpand(id: string) {
@@ -459,9 +535,11 @@ export function CollectionTree({ contains }: CollectionTreeProps = {}) {
             isExpanded={expanded.has(item.id)}
             onToggleExpand={() => toggleExpand(item.id)}
             isActive={activeCollectionId === item.id}
-            onSelect={() => {
-              setActiveTag(null)
-              setActiveCollectionId(activeCollectionId === item.id ? null : item.id)
+            onSelect={() => select(activeCollectionId === item.id ? null : item.id)}
+            memberType={memberType}
+            dragMime={dragMime}
+            onDeleted={() => {
+              if (activeCollectionId === item.id) select(null)
             }}
           />
           {expanded.has(item.id) &&
@@ -473,9 +551,11 @@ export function CollectionTree({ contains }: CollectionTreeProps = {}) {
                 isExpanded={false}
                 onToggleExpand={() => {}}
                 isActive={activeCollectionId === child.id}
-                onSelect={() => {
-                  setActiveTag(null)
-                  setActiveCollectionId(activeCollectionId === child.id ? null : child.id)
+                onSelect={() => select(activeCollectionId === child.id ? null : child.id)}
+                memberType={memberType}
+                dragMime={dragMime}
+                onDeleted={() => {
+                  if (activeCollectionId === child.id) select(null)
                 }}
               />
             ))}

--- a/frontend/src/components/CollectionTree.tsx
+++ b/frontend/src/components/CollectionTree.tsx
@@ -203,8 +203,6 @@ function CollectionTreeItemRow({
       : item.document_count > 0
         ? `${item.document_count} document${item.document_count === 1 ? "" : "s"}`
         : `${item.note_count} note${item.note_count === 1 ? "" : "s"}`
-  // Nothing of this rail's kind: de-emphasised, never hidden -- still a drop
-  // target and still manageable from here.
   const offKind = !isEmpty && (memberType === "document" ? item.document_count : item.note_count) === 0
 
   return (
@@ -428,8 +426,7 @@ function CollectionTreeItemRow({
 
 
 interface CollectionTreeProps {
-  /** Scopes the count badge only. Every collection stays listed, since a rail
-   * is a drop target and management surface, not just a filter. */
+  /** Scopes the count badge only; every collection stays listed. */
   contains?: CollectionTreeContains
   /** What a drop onto a row adds, and which list query that invalidates. */
   memberType?: CollectionMemberType
@@ -473,8 +470,7 @@ export function CollectionTree({
     queryKey: ["collections-tree", contains ? `contains:${contains}` : "contains:all"],
     queryFn: () => fetchCollectionTree(contains),
     staleTime: 30_000,
-    // Without this, a collection created on another surface is served from the
-    // still-fresh cache and the rail looks like it needs a manual refresh.
+    // Else a collection created on another surface waits out the staleTime.
     refetchOnMount: "always",
   })
 

--- a/frontend/src/components/CollectionTree.tsx
+++ b/frontend/src/components/CollectionTree.tsx
@@ -41,11 +41,9 @@ export { flattenCollectionTree }
 export type CollectionTreeContains = "document" | "note"
 export type CollectionMemberType = "document" | "note"
 
-/** dataTransfer key each surface uses when dragging one of its rows. */
 export const NOTE_DRAG_MIME = "text/plain"
 export const DOC_DRAG_MIME = "application/x-luminary-doc-id"
 
-/** The list query a membership change invalidates, per member type. */
 const MEMBER_LIST_QUERY: Record<CollectionMemberType, string> = {
   note: "notes",
   document: "documents",
@@ -205,8 +203,8 @@ function CollectionTreeItemRow({
       : item.document_count > 0
         ? `${item.document_count} document${item.document_count === 1 ? "" : "s"}`
         : `${item.note_count} note${item.note_count === 1 ? "" : "s"}`
-  // Holds nothing of the kind this rail deals in. Still a valid drop target and
-  // still manageable, so it is de-emphasised rather than hidden.
+  // Nothing of this rail's kind: de-emphasised, never hidden -- still a drop
+  // target and still manageable from here.
   const offKind = !isEmpty && (memberType === "document" ? item.document_count : item.note_count) === 0
 
   return (
@@ -285,9 +283,8 @@ function CollectionTreeItemRow({
           </span>
         )}
 
-        {/* Kind + counts. Which pills are present IS the kind: documents only,
-            notes only, or both. A zero pill is never rendered, so the row reads
-            at a glance instead of every collection showing a "0n". */}
+        {/* Which pills are present IS the kind: documents, notes, or both. A
+            zero pill is never rendered. */}
         {!renaming && (
           <div className="ml-auto flex items-center gap-1 shrink-0" title={kindLabel}>
             {item.document_count > 0 && (
@@ -431,9 +428,8 @@ function CollectionTreeItemRow({
 
 
 interface CollectionTreeProps {
-  /** Scopes each row's count badge to this member type. Every collection is
-   * still listed: a rail is a drop target and a management surface, not only a
-   * filter, so hiding a collection would make it unreachable from here. */
+  /** Scopes the count badge only. Every collection stays listed, since a rail
+   * is a drop target and management surface, not just a filter. */
   contains?: CollectionTreeContains
   /** What a drop onto a row adds, and which list query that invalidates. */
   memberType?: CollectionMemberType
@@ -477,9 +473,8 @@ export function CollectionTree({
     queryKey: ["collections-tree", contains ? `contains:${contains}` : "contains:all"],
     queryFn: () => fetchCollectionTree(contains),
     staleTime: 30_000,
-    // A collection created on another surface must be present the moment this
-    // one mounts; serving it from a still-fresh cache is what made the rail
-    // look like it needed a manual refresh.
+    // Without this, a collection created on another surface is served from the
+    // still-fresh cache and the rail looks like it needs a manual refresh.
     refetchOnMount: "always",
   })
 

--- a/frontend/src/components/CreateCollectionDialog.tsx
+++ b/frontend/src/components/CreateCollectionDialog.tsx
@@ -4,8 +4,7 @@
  * Fields: name (required), description, 8-swatch color picker, parent select
  * (top-level collections only -- max 2-level nesting).
  *
- * POST /collections to create, PUT /collections/{id} to edit. The parent select
- * is create-only: the update endpoint takes no parent.
+ * The parent select is create-only: the update endpoint takes no parent.
  */
 
 import { useState } from "react"
@@ -91,14 +90,10 @@ export function CreateCollectionDialog({
   onSaved,
 }: CreateCollectionDialogProps) {
   const isEdit = collection !== null
-  // Only typed values live in state; the rest derive from `collection`. Syncing
-  // props into state via an effect would clobber typing when `detail` lands, or
-  // leave stale values when the dialog reopens on a different row.
   const [edits, setEdits] = useState<FormEdits>({})
   const qc = useQueryClient()
 
-  // /collections/tree carries no description, so edit mode reads the full row
-  // rather than showing an empty box for a collection that has one.
+  // /collections/tree carries no description; edit mode needs the full row.
   const { data: detail } = useQuery({
     queryKey: ["collection-detail", collection?.id],
     queryFn: () => apiGet<EditableCollection>(`/collections/${collection?.id}`),

--- a/frontend/src/components/CreateCollectionDialog.tsx
+++ b/frontend/src/components/CreateCollectionDialog.tsx
@@ -1,10 +1,12 @@
 /**
- * CreateCollectionDialog -- dialog for creating a new collection.
+ * CreateCollectionDialog -- dialog for creating or editing a collection.
  *
  * Fields: name (required), description, 8-swatch color picker, parent select
  * (top-level collections only -- max 2-level nesting).
  *
- * POST /collections on save. Invalidates ["collections-tree"] on success.
+ * POST /collections to create, PUT /collections/{id} to edit. Invalidates
+ * ["collections-tree"] on success. The parent select is create-only: the update
+ * endpoint does not accept a parent, so re-parenting is not offered.
  */
 
 import { useState } from "react"
@@ -17,7 +19,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { apiGet, apiPost } from "@/lib/apiClient"
+import { apiGet, apiPost, apiPut } from "@/lib/apiClient"
 import type { CollectionTreeItem } from "@/lib/collectionUtils"
 import { normalizeCollectionName } from "@/lib/tagUtils"
 
@@ -42,24 +44,82 @@ async function fetchCollectionTree(): Promise<CollectionTreeItem[]> {
   }
 }
 
+export interface CreatedCollection {
+  id: string
+  name: string
+}
+
 const createCollection = (payload: {
   name: string
   description: string | null
   color: string
   parent_collection_id: string | null
-}): Promise<void> => apiPost("/collections", payload)
+}): Promise<CreatedCollection> => apiPost("/collections", payload)
+
+const updateCollection = (
+  id: string,
+  payload: { name: string; description: string | null; color: string },
+): Promise<CreatedCollection> => apiPut(`/collections/${id}`, payload)
+
+interface FormEdits {
+  name?: string
+  description?: string
+  color?: string
+  parentId?: string
+}
+
+/** An existing collection to edit. Omit to create a new one. */
+export interface EditableCollection {
+  id: string
+  name: string
+  description?: string | null
+  color: string
+}
 
 interface CreateCollectionDialogProps {
   open: boolean
   onClose: () => void
+  collection?: EditableCollection | null
+  /** Pre-seeds the name field when creating. */
+  defaultName?: string
+  onSaved?: (collection: CreatedCollection) => void
 }
 
-export function CreateCollectionDialog({ open, onClose }: CreateCollectionDialogProps) {
-  const [name, setName] = useState("")
-  const [description, setDescription] = useState("")
-  const [color, setColor] = useState(COLLECTION_COLORS[0])
-  const [parentId, setParentId] = useState<string>("")
+export function CreateCollectionDialog({
+  open,
+  onClose,
+  collection = null,
+  defaultName = "",
+  onSaved,
+}: CreateCollectionDialogProps) {
+  const isEdit = collection !== null
+  // Only what the user has actually typed is held in state; everything else is
+  // derived from the collection being edited. Syncing props into state via an
+  // effect would either clobber in-flight typing when the detail fetch lands or
+  // leave stale values behind when the dialog reopens on a different row.
+  const [edits, setEdits] = useState<FormEdits>({})
   const qc = useQueryClient()
+
+  // Callers list collections from /collections/tree, which carries no
+  // description, so edit mode reads the full row rather than showing an empty
+  // description box for a collection that has one.
+  const { data: detail } = useQuery({
+    queryKey: ["collection-detail", collection?.id],
+    queryFn: () => apiGet<EditableCollection>(`/collections/${collection?.id}`),
+    enabled: open && isEdit,
+    staleTime: 30_000,
+  })
+
+  const source = detail ?? collection
+  const name = edits.name ?? source?.name ?? defaultName
+  const description = edits.description ?? source?.description ?? ""
+  const color = edits.color ?? source?.color ?? COLLECTION_COLORS[0]
+  const parentId = edits.parentId ?? ""
+
+  const setName = (v: string) => setEdits((e) => ({ ...e, name: v }))
+  const setDescription = (v: string) => setEdits((e) => ({ ...e, description: v }))
+  const setColor = (v: string) => setEdits((e) => ({ ...e, color: v }))
+  const setParentId = (v: string) => setEdits((e) => ({ ...e, parentId: v }))
 
   const { data: tree = [] } = useQuery({
     queryKey: ["collections-tree"],
@@ -75,23 +135,28 @@ export function CreateCollectionDialog({ open, onClose }: CreateCollectionDialog
 
   const createMut = useMutation({
     mutationFn: () =>
-      createCollection({
-        name: normalizedName,
-        description: description.trim() || null,
-        color,
-        parent_collection_id: parentId || null,
-      }),
-    onSuccess: () => {
+      isEdit
+        ? updateCollection(collection.id, {
+            name: normalizedName,
+            description: description.trim() || null,
+            color,
+          })
+        : createCollection({
+            name: normalizedName,
+            description: description.trim() || null,
+            color,
+            parent_collection_id: parentId || null,
+          }),
+    onSuccess: (saved) => {
       void qc.invalidateQueries({ queryKey: ["collections-tree"] })
+      void qc.invalidateQueries({ queryKey: ["collection-detail"] })
+      onSaved?.(saved)
       handleClose()
     },
   })
 
   function handleClose() {
-    setName("")
-    setDescription("")
-    setColor(COLLECTION_COLORS[0])
-    setParentId("")
+    setEdits({})
     onClose()
   }
 
@@ -99,8 +164,12 @@ export function CreateCollectionDialog({ open, onClose }: CreateCollectionDialog
     <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
       <DialogContent className="max-w-sm">
         <DialogHeader>
-          <DialogTitle>New Collection</DialogTitle>
-          <DialogDescription>Organise notes into a named collection.</DialogDescription>
+          <DialogTitle>{isEdit ? "Edit Collection" : "New Collection"}</DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Rename this collection or change its colour and description."
+              : "Group documents and notes under a named collection."}
+          </DialogDescription>
         </DialogHeader>
 
         <div className="flex flex-col gap-3">
@@ -150,25 +219,29 @@ export function CreateCollectionDialog({ open, onClose }: CreateCollectionDialog
             </div>
           </div>
 
-          {/* Parent select */}
-          <div className="flex flex-col gap-1">
-            <label className="text-xs font-medium text-foreground">Parent collection</label>
-            <select
-              value={parentId}
-              onChange={(e) => setParentId(e.target.value)}
-              className="rounded border border-border bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
-            >
-              <option value="">None (top-level)</option>
-              {topLevelCollections.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              ))}
-            </select>
-          </div>
+          {/* Parent select -- create only; the update endpoint takes no parent. */}
+          {!isEdit && (
+            <div className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-foreground">Parent collection</label>
+              <select
+                value={parentId}
+                onChange={(e) => setParentId(e.target.value)}
+                className="rounded border border-border bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+              >
+                <option value="">None (top-level)</option>
+                {topLevelCollections.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
 
           {createMut.isError && (
-            <p className="text-xs text-red-600">Failed to create collection. Please try again.</p>
+            <p className="text-xs text-red-600">
+              Failed to {isEdit ? "update" : "create"} collection. Please try again.
+            </p>
           )}
         </div>
 
@@ -184,7 +257,7 @@ export function CreateCollectionDialog({ open, onClose }: CreateCollectionDialog
             disabled={!normalizedName || createMut.isPending}
             className="rounded bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
           >
-            Create
+            {isEdit ? "Save" : "Create"}
           </button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/CreateCollectionDialog.tsx
+++ b/frontend/src/components/CreateCollectionDialog.tsx
@@ -4,9 +4,8 @@
  * Fields: name (required), description, 8-swatch color picker, parent select
  * (top-level collections only -- max 2-level nesting).
  *
- * POST /collections to create, PUT /collections/{id} to edit. Invalidates
- * ["collections-tree"] on success. The parent select is create-only: the update
- * endpoint does not accept a parent, so re-parenting is not offered.
+ * POST /collections to create, PUT /collections/{id} to edit. The parent select
+ * is create-only: the update endpoint takes no parent.
  */
 
 import { useState } from "react"
@@ -80,7 +79,6 @@ interface CreateCollectionDialogProps {
   open: boolean
   onClose: () => void
   collection?: EditableCollection | null
-  /** Pre-seeds the name field when creating. */
   defaultName?: string
   onSaved?: (collection: CreatedCollection) => void
 }
@@ -93,16 +91,14 @@ export function CreateCollectionDialog({
   onSaved,
 }: CreateCollectionDialogProps) {
   const isEdit = collection !== null
-  // Only what the user has actually typed is held in state; everything else is
-  // derived from the collection being edited. Syncing props into state via an
-  // effect would either clobber in-flight typing when the detail fetch lands or
-  // leave stale values behind when the dialog reopens on a different row.
+  // Only typed values live in state; the rest derive from `collection`. Syncing
+  // props into state via an effect would clobber typing when `detail` lands, or
+  // leave stale values when the dialog reopens on a different row.
   const [edits, setEdits] = useState<FormEdits>({})
   const qc = useQueryClient()
 
-  // Callers list collections from /collections/tree, which carries no
-  // description, so edit mode reads the full row rather than showing an empty
-  // description box for a collection that has one.
+  // /collections/tree carries no description, so edit mode reads the full row
+  // rather than showing an empty box for a collection that has one.
   const { data: detail } = useQuery({
     queryKey: ["collection-detail", collection?.id],
     queryFn: () => apiGet<EditableCollection>(`/collections/${collection?.id}`),

--- a/frontend/src/components/evals/ResultsDashboard.tsx
+++ b/frontend/src/components/evals/ResultsDashboard.tsx
@@ -480,7 +480,7 @@ export function ResultsDashboard({ selection }: { selection: DatasetSelection | 
             label="Faithfulness"
             value={faith?.faithfulness}
             threshold={THRESHOLDS.faithfulness}
-            hint={faith ? "generated answers grounded in context" : "run with a judge — answers come from live /qa"}
+            hint={faith ? "grounded in context · collapse floor, not a quality bar" : "run with a judge — answers come from live /qa"}
             sub={
               faith
                 ? `judge ${faith.model_used.split("/").pop()} · answers ${String(

--- a/frontend/src/components/evals/StrategyFunnel.tsx
+++ b/frontend/src/components/evals/StrategyFunnel.tsx
@@ -19,7 +19,7 @@ const STAGES: { id: string; label: string; hint: string; arms: string[] }[] = [
   {
     id: "single",
     label: "1 · Single retriever",
-    hint: "one signal, no fusion — the choice of base retriever",
+    hint: "one signal, no fusion — two indexes, plus vector over an expanded query",
     arms: ["vector", "fts", "graph"],
   },
   {
@@ -39,7 +39,8 @@ const STAGES: { id: string; label: string; hint: string; arms: string[] }[] = [
 const ARM_LABEL: Record<string, string> = {
   vector: "Vector (embeddings)",
   fts: "Full-text (BM25)",
-  graph: "Graph",
+  // Not a third index: vector search over a graph-expanded query.
+  graph: "Vector + graph-expanded query",
   rrf: "RRF fusion",
   "rrf+rerank-ce": "+ Rerank (CE only)",
   "rrf+rerank": "+ Rerank (blended)",

--- a/frontend/src/components/evals/thresholds.test.ts
+++ b/frontend/src/components/evals/thresholds.test.ts
@@ -1,3 +1,6 @@
+// Node types are scoped to this file rather than added to tsconfig.app.json,
+// so app code still cannot reach for filesystem APIs.
+/// <reference types="node" />
 import { readFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"

--- a/frontend/src/components/evals/thresholds.test.ts
+++ b/frontend/src/components/evals/thresholds.test.ts
@@ -1,5 +1,3 @@
-// Node types are scoped to this file rather than added to tsconfig.app.json,
-// so app code still cannot reach for filesystem APIs.
 /// <reference types="node" />
 import { readFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
@@ -9,7 +7,6 @@ import { describe, expect, it } from "vitest"
 import { isStale, metricColor, shippedAblationArm, THRESHOLDS, timeAgo } from "./thresholds"
 import type { EvalRunFull } from "./types"
 
-/** Parse THRESHOLDS out of evals/run_eval.py, the source of truth. */
 function backendThresholds(): Record<string, number> {
   const root = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..")
   const src = readFileSync(resolve(root, "evals/run_eval.py"), "utf8")
@@ -45,10 +42,7 @@ function run(overrides: Partial<EvalRunFull>): EvalRunFull {
 }
 
 describe("THRESHOLDS", () => {
-  // Read the backend rather than restate it. The previous version asserted
-  // against copied literals, so when the backend re-baselined faithfulness to
-  // a 0.30 collapse floor this kept passing on the retired 0.65 bar and the UI
-  // painted healthy runs amber.
+  // Read the backend rather than restate it: copied literals cannot detect drift.
   it("matches the backend gates in evals/run_eval.py", () => {
     const backend = backendThresholds()
     expect(Object.keys(backend).length).toBeGreaterThan(0)

--- a/frontend/src/components/evals/thresholds.test.ts
+++ b/frontend/src/components/evals/thresholds.test.ts
@@ -1,6 +1,23 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
 import { describe, expect, it } from "vitest"
 import { isStale, metricColor, shippedAblationArm, THRESHOLDS, timeAgo } from "./thresholds"
 import type { EvalRunFull } from "./types"
+
+/** Parse THRESHOLDS out of evals/run_eval.py, the source of truth. */
+function backendThresholds(): Record<string, number> {
+  const root = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..")
+  const src = readFileSync(resolve(root, "evals/run_eval.py"), "utf8")
+  const block = /^THRESHOLDS\s*=\s*\{([\s\S]*?)^\}/m.exec(src)
+  if (!block) throw new Error("THRESHOLDS block not found in evals/run_eval.py")
+  const out: Record<string, number> = {}
+  for (const m of block[1].matchAll(/"([a-z_0-9]+)"\s*:\s*([0-9.]+)/g)) {
+    out[m[1]] = Number(m[2])
+  }
+  return out
+}
 
 const NOW = Date.parse("2026-07-02T12:00:00Z")
 
@@ -25,10 +42,16 @@ function run(overrides: Partial<EvalRunFull>): EvalRunFull {
 }
 
 describe("THRESHOLDS", () => {
+  // Read the backend rather than restate it. The previous version asserted
+  // against copied literals, so when the backend re-baselined faithfulness to
+  // a 0.30 collapse floor this kept passing on the retired 0.65 bar and the UI
+  // painted healthy runs amber.
   it("matches the backend gates in evals/run_eval.py", () => {
-    expect(THRESHOLDS.hit_rate_5).toBe(0.5)
-    expect(THRESHOLDS.mrr).toBe(0.35)
-    expect(THRESHOLDS.faithfulness).toBe(0.65)
+    const backend = backendThresholds()
+    expect(Object.keys(backend).length).toBeGreaterThan(0)
+    for (const [metric, value] of Object.entries(THRESHOLDS)) {
+      expect(backend[metric], `${metric} drifted from evals/run_eval.py`).toBe(value)
+    }
   })
 })
 

--- a/frontend/src/components/evals/thresholds.ts
+++ b/frontend/src/components/evals/thresholds.ts
@@ -8,10 +8,8 @@ export const THRESHOLDS = {
   hit_rate_5: 0.5,
   mrr: 0.35,
   ndcg_10: 0.4,
-  // 0.30 is a COLLAPSE DETECTOR on the dataset mean, not a quality bar: HHEM
-  // scores have no absolute meaning without labels, so only a floor is
-  // defensible. This read 0.65 -- the pre-re-baseline value -- and painted
-  // healthy runs amber against a bar that had been retired in the backend.
+  // A collapse floor on the dataset mean, not a quality bar: unlabelled HHEM
+  // scores have no absolute meaning. Do not raise this into a target.
   faithfulness: 0.3,
   answer_relevance: 0.5,
 } as const

--- a/frontend/src/components/evals/thresholds.ts
+++ b/frontend/src/components/evals/thresholds.ts
@@ -8,7 +8,11 @@ export const THRESHOLDS = {
   hit_rate_5: 0.5,
   mrr: 0.35,
   ndcg_10: 0.4,
-  faithfulness: 0.65,
+  // 0.30 is a COLLAPSE DETECTOR on the dataset mean, not a quality bar: HHEM
+  // scores have no absolute meaning without labels, so only a floor is
+  // defensible. This read 0.65 -- the pre-re-baseline value -- and painted
+  // healthy runs amber against a bar that had been retired in the backend.
+  faithfulness: 0.3,
   answer_relevance: 0.5,
 } as const
 

--- a/frontend/src/components/library/DocumentCard.tsx
+++ b/frontend/src/components/library/DocumentCard.tsx
@@ -160,6 +160,7 @@ export function DocumentCard({
   const [collectionsLoading, setCollectionsLoading] = useState(false)
   const [addedCollectionIds, setAddedCollectionIds] = useState<Set<string>>(new Set())
   const [newCollectionOpen, setNewCollectionOpen] = useState(false)
+  const [collectionFilter, setCollectionFilter] = useState("")
   const [retagState, setRetagState] = useState<"idle" | "running" | "done">("idle")
   const [retagAdded, setRetagAdded] = useState<number | null>(null)
 
@@ -193,8 +194,17 @@ export function DocumentCard({
     onSelect?.(doc.id, e.target.checked)
   }
 
+  const flatCollections = collections ? flattenCollectionTree(collections) : []
+  const showCollectionFilter = flatCollections.length > 7
+  const visibleCollections = collectionFilter.trim()
+    ? flatCollections.filter((c) =>
+        c.name.toLowerCase().includes(collectionFilter.trim().toLowerCase()),
+      )
+    : flatCollections
+
   async function handleOpenCollectionPicker() {
     setCollectionPickerOpen(true)
+    setCollectionFilter("")
     if (collections !== null || collectionsLoading) return
     setCollectionsLoading(true)
     try {
@@ -373,15 +383,36 @@ export function DocumentCard({
                           <X size={12} />
                         </button>
                       </div>
-                      <div className="max-h-56 overflow-y-auto">
+                      {/* Sub-collections sit under their parents, so the list is
+                          not alphabetical and a name can fall well below the
+                          fold. Filtering beats scrolling past nesting. */}
+                      {showCollectionFilter && (
+                        <input
+                          autoFocus
+                          value={collectionFilter}
+                          onChange={(e) => setCollectionFilter(e.target.value)}
+                          onClick={(e) => e.stopPropagation()}
+                          placeholder="Filter collections…"
+                          className="mx-2 mb-1 rounded border border-border bg-background px-2 py-1 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                        />
+                      )}
+                      <div className="max-h-72 overflow-y-auto">
                         {collectionsLoading && (
                           <p className="px-2 py-1.5 text-xs text-muted-foreground">Loading…</p>
                         )}
                         {!collectionsLoading && collections && collections.length === 0 && (
                           <p className="px-2 py-1.5 text-xs text-muted-foreground">No collections yet</p>
                         )}
+                        {!collectionsLoading &&
+                          collections &&
+                          collections.length > 0 &&
+                          visibleCollections.length === 0 && (
+                            <p className="px-2 py-1.5 text-xs text-muted-foreground">
+                              No collection matches “{collectionFilter.trim()}”
+                            </p>
+                          )}
                         {!collectionsLoading && collections && collections.length > 0 && (
-                          flattenCollectionTree(collections).map((col) => {
+                          visibleCollections.map((col) => {
                             const added = addedCollectionIds.has(col.id)
                             const isChild = !collections.some((root) => root.id === col.id)
                             return (

--- a/frontend/src/components/library/DocumentCard.tsx
+++ b/frontend/src/components/library/DocumentCard.tsx
@@ -19,6 +19,7 @@ import {
   MoreVertical,
   Network,
   Newspaper,
+  Plus,
   StickyNote,
   Trash2, 
   X, 
@@ -45,6 +46,8 @@ import {
 } from "./utils"
 
 import { apiPatch } from "@/lib/apiClient"
+import { toast } from "sonner"
+import { CreateCollectionDialog } from "@/components/CreateCollectionDialog"
 
 function ProgressRing({ pct, size = 24 }: { pct: number; size?: number }) {
   const r = (size - 4) / 2
@@ -156,6 +159,7 @@ export function DocumentCard({
   const [collections, setCollections] = useState<CollectionTreeItem[] | null>(null)
   const [collectionsLoading, setCollectionsLoading] = useState(false)
   const [addedCollectionIds, setAddedCollectionIds] = useState<Set<string>>(new Set())
+  const [newCollectionOpen, setNewCollectionOpen] = useState(false)
   const [retagState, setRetagState] = useState<"idle" | "running" | "done">("idle")
   const [retagAdded, setRetagAdded] = useState<number | null>(null)
 
@@ -209,6 +213,14 @@ export function DocumentCard({
     } catch {
       // Silent — POST is idempotent server-side; surface failure only if needed later.
     }
+  }
+
+  // Creating from here is only worth the interruption if the document lands in
+  // the new collection, which is the whole reason the user opened this picker.
+  async function handleCollectionCreated(created: { id: string; name: string }) {
+    await handleAddToCollection(created.id)
+    setCollections(await fetchCollectionTree())
+    toast.success(`Added to ${created.name}`)
   }
 
   async function handleRetag() {
@@ -396,6 +408,18 @@ export function DocumentCard({
                           })
                         )}
                       </div>
+                      {/* Outside the scroll area so it stays reachable however
+                          many collections exist -- this is the path out of the
+                          "No collections yet" dead end. */}
+                      {!collectionsLoading && collections && (
+                        <button
+                          onClick={() => setNewCollectionOpen(true)}
+                          className="mt-1 flex w-full items-center gap-2 border-t border-border px-2 py-1.5 text-left text-sm text-primary hover:bg-accent"
+                        >
+                          <Plus size={12} className="shrink-0" />
+                          <span className="flex-1 truncate">New collection…</span>
+                        </button>
+                      )}
                     </div>
                   )}
                 </div>
@@ -589,6 +613,15 @@ export function DocumentCard({
           <span>{Math.round(doc.objective_progress_pct)}% objectives covered</span>
         </div>
       )}
+
+      {/* Card click-through would open the document behind the dialog. */}
+      <div onClick={(e) => e.stopPropagation()}>
+        <CreateCollectionDialog
+          open={newCollectionOpen}
+          onClose={() => setNewCollectionOpen(false)}
+          onSaved={(created) => void handleCollectionCreated(created)}
+        />
+      </div>
 
       {/* Inline delete confirmation */}
       {confirmDelete && (

--- a/frontend/src/components/library/DocumentCard.tsx
+++ b/frontend/src/components/library/DocumentCard.tsx
@@ -25,7 +25,8 @@ import {
   X, 
   Zap 
 } from "lucide-react"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
 import { useNavigate } from "react-router-dom"
 import type { DocAction } from "@/lib/docActionUtils"
 import { DOC_ACTIONS } from "@/lib/docActionUtils"
@@ -161,6 +162,8 @@ export function DocumentCard({
   const [addedCollectionIds, setAddedCollectionIds] = useState<Set<string>>(new Set())
   const [newCollectionOpen, setNewCollectionOpen] = useState(false)
   const [collectionFilter, setCollectionFilter] = useState("")
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
   const [retagState, setRetagState] = useState<"idle" | "running" | "done">("idle")
   const [retagAdded, setRetagAdded] = useState<number | null>(null)
 
@@ -171,7 +174,13 @@ export function DocumentCard({
       if (typePopoverOpen && popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
         setTypePopoverOpen(false)
       }
-      if (actionMenuOpen && actionMenuRef.current && !actionMenuRef.current.contains(e.target as Node)) {
+      // The menu is portalled to body, so it is not inside actionMenuRef.
+      if (
+        actionMenuOpen &&
+        actionMenuRef.current &&
+        !actionMenuRef.current.contains(e.target as Node) &&
+        !menuRef.current?.contains(e.target as Node)
+      ) {
         setActionMenuOpen(false)
         setCollectionPickerOpen(false)
       }
@@ -179,6 +188,39 @@ export function DocumentCard({
     document.addEventListener("mousedown", handleClick)
     return () => document.removeEventListener("mousedown", handleClick)
   }, [typePopoverOpen, actionMenuOpen])
+
+  const flatCollections = collections ? flattenCollectionTree(collections) : []
+  const showCollectionFilter = flatCollections.length > 7
+  const visibleCollections = collectionFilter.trim()
+    ? flatCollections.filter((c) =>
+        c.name.toLowerCase().includes(collectionFilter.trim().toLowerCase()),
+      )
+    : flatCollections
+
+  // The card clips its children (overflow-hidden), so the menu is portalled to
+  // body and anchored here instead. Written straight to style: going through
+  // state would re-render the menu on every scroll frame.
+  useLayoutEffect(() => {
+    if (!actionMenuOpen) return
+    const place = () => {
+      const trigger = triggerRef.current
+      const menu = menuRef.current
+      if (!trigger || !menu) return
+      const rect = trigger.getBoundingClientRect()
+      const top = rect.bottom + 4
+      menu.style.top = `${top}px`
+      menu.style.right = `${Math.max(8, window.innerWidth - rect.right)}px`
+      menu.style.maxHeight = `${Math.max(180, window.innerHeight - top - 12)}px`
+    }
+    place()
+    // Capture phase: the scroller is an ancestor, not window.
+    window.addEventListener("scroll", place, true)
+    window.addEventListener("resize", place)
+    return () => {
+      window.removeEventListener("scroll", place, true)
+      window.removeEventListener("resize", place)
+    }
+  }, [actionMenuOpen, collectionPickerOpen, showCollectionFilter])
 
   function handleCardClick(e: React.MouseEvent) {
     if (selectMode && onSelect) {
@@ -193,14 +235,6 @@ export function DocumentCard({
     e.stopPropagation()
     onSelect?.(doc.id, e.target.checked)
   }
-
-  const flatCollections = collections ? flattenCollectionTree(collections) : []
-  const showCollectionFilter = flatCollections.length > 7
-  const visibleCollections = collectionFilter.trim()
-    ? flatCollections.filter((c) =>
-        c.name.toLowerCase().includes(collectionFilter.trim().toLowerCase()),
-      )
-    : flatCollections
 
   async function handleOpenCollectionPicker() {
     setCollectionPickerOpen(true)
@@ -315,6 +349,7 @@ export function DocumentCard({
           {onAction && !selectMode && (
             <div className="relative" ref={actionMenuRef}>
               <button
+                ref={triggerRef}
                 onClick={(e) => {
                   e.stopPropagation()
                   setActionMenuOpen((v) => !v)
@@ -324,9 +359,10 @@ export function DocumentCard({
               >
                 <MoreVertical size={14} />
               </button>
-              {actionMenuOpen && (
+              {actionMenuOpen && createPortal(
                 <div
-                  className="absolute right-0 top-full z-30 mt-1 w-56 rounded-lg border border-border bg-background p-1 shadow-lg"
+                  ref={menuRef}
+                  className="fixed z-50 flex w-56 flex-col overflow-hidden rounded-lg border border-border bg-background p-1 shadow-lg"
                   onClick={(e) => e.stopPropagation()}
                 >
                   {!collectionPickerOpen && (
@@ -372,8 +408,8 @@ export function DocumentCard({
                     </>
                   )}
                   {collectionPickerOpen && (
-                    <div className="flex flex-col">
-                      <div className="flex items-center justify-between px-2 py-1 text-xs text-muted-foreground">
+                    <div className="flex min-h-0 flex-1 flex-col">
+                      <div className="flex shrink-0 items-center justify-between px-2 py-1 text-xs text-muted-foreground">
                         <span>Add to collection</span>
                         <button
                           onClick={() => setCollectionPickerOpen(false)}
@@ -393,10 +429,10 @@ export function DocumentCard({
                           onChange={(e) => setCollectionFilter(e.target.value)}
                           onClick={(e) => e.stopPropagation()}
                           placeholder="Filter collections…"
-                          className="mx-2 mb-1 rounded border border-border bg-background px-2 py-1 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                          className="mx-2 mb-1 shrink-0 rounded border border-border bg-background px-2 py-1 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
                         />
                       )}
-                      <div className="max-h-72 overflow-y-auto">
+                      <div className="min-h-0 flex-1 overflow-y-auto">
                         {collectionsLoading && (
                           <p className="px-2 py-1.5 text-xs text-muted-foreground">Loading…</p>
                         )}
@@ -438,12 +474,11 @@ export function DocumentCard({
                         )}
                       </div>
                       {/* Outside the scroll area so it stays reachable however
-                          many collections exist -- this is the path out of the
-                          "No collections yet" dead end. */}
+                          many collections exist. */}
                       {!collectionsLoading && collections && (
                         <button
                           onClick={() => setNewCollectionOpen(true)}
-                          className="mt-1 flex w-full items-center gap-2 border-t border-border px-2 py-1.5 text-left text-sm text-primary hover:bg-accent"
+                          className="mt-1 flex w-full shrink-0 items-center gap-2 border-t border-border px-2 py-1.5 text-left text-sm text-primary hover:bg-accent"
                         >
                           <Plus size={12} className="shrink-0" />
                           <span className="flex-1 truncate">New collection…</span>
@@ -451,7 +486,8 @@ export function DocumentCard({
                       )}
                     </div>
                   )}
-                </div>
+                </div>,
+                document.body,
               )}
             </div>
           )}

--- a/frontend/src/components/library/DocumentCard.tsx
+++ b/frontend/src/components/library/DocumentCard.tsx
@@ -164,8 +164,7 @@ export function DocumentCard({
   const [collectionPickerOpen, setCollectionPickerOpen] = useState(false)
   const [collections, setCollections] = useState<CollectionTreeItem[] | null>(null)
   const [collectionsLoading, setCollectionsLoading] = useState(false)
-  // Optimistic overlay on doc.collections, which is the source of truth and is
-  // refetched after every change. Keyed id -> is-member.
+  // Optimistic overlay on doc.collections, which stays the source of truth.
   const [pendingMembership, setPendingMembership] = useState<Map<string, boolean>>(new Map())
   const [newCollectionOpen, setNewCollectionOpen] = useState(false)
   const [collectionFilter, setCollectionFilter] = useState("")
@@ -205,9 +204,8 @@ export function DocumentCard({
       )
     : flatCollections
 
-  // The card clips its children (overflow-hidden), so the menu is portalled to
-  // body and anchored here instead. Written straight to style: going through
-  // state would re-render the menu on every scroll frame.
+  // The card sets overflow-hidden, so the menu is portalled to body and
+  // anchored here. Styles are written directly to avoid a re-render per frame.
   useLayoutEffect(() => {
     if (!actionMenuOpen) return
     const place = () => {
@@ -273,8 +271,7 @@ export function DocumentCard({
       // The card's own chips and the rail's badges live in other queries.
       void queryClient.invalidateQueries({ queryKey: ["collections-tree"] })
       void queryClient.invalidateQueries({ queryKey: ["documents"] })
-      // Long enough for the tick to register, then the picker closes: leaving
-      // it open read as an unsubmitted multi-select.
+      // Hold long enough for the tick to register, then close.
       window.setTimeout(() => {
         setCollectionPickerOpen(false)
         setActionMenuOpen(false)

--- a/frontend/src/components/library/DocumentCard.tsx
+++ b/frontend/src/components/library/DocumentCard.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react"
 import { useEffect, useLayoutEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
+import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "react-router-dom"
 import type { DocAction } from "@/lib/docActionUtils"
 import { DOC_ACTIONS } from "@/lib/docActionUtils"
@@ -164,6 +165,7 @@ export function DocumentCard({
   const [collectionFilter, setCollectionFilter] = useState("")
   const triggerRef = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+  const queryClient = useQueryClient()
   const [retagState, setRetagState] = useState<"idle" | "running" | "done">("idle")
   const [retagAdded, setRetagAdded] = useState<number | null>(null)
 
@@ -249,20 +251,29 @@ export function DocumentCard({
     }
   }
 
-  async function handleAddToCollection(collectionId: string) {
+  async function handleAddToCollection(collectionId: string, name: string) {
     if (addedCollectionIds.has(collectionId)) return
     try {
       await addDocumentToCollection(collectionId, doc.id)
       setAddedCollectionIds((prev) => new Set(prev).add(collectionId))
+      toast.success(`Added to ${name}`)
+      // Refresh the rail's count badges, which this menu does not own.
+      void queryClient.invalidateQueries({ queryKey: ["collections-tree"] })
+      void queryClient.invalidateQueries({ queryKey: ["documents"] })
+      // Long enough for the tick to register, then the picker closes: leaving
+      // it open read as an unsubmitted multi-select.
+      window.setTimeout(() => {
+        setCollectionPickerOpen(false)
+        setActionMenuOpen(false)
+      }, 450)
     } catch {
-      // Silent — POST is idempotent server-side; surface failure only if needed later.
+      toast.error(`Could not add to ${name}`)
     }
   }
 
   async function handleCollectionCreated(created: { id: string; name: string }) {
-    await handleAddToCollection(created.id)
+    await handleAddToCollection(created.id, created.name)
     setCollections(await fetchCollectionTree())
-    toast.success(`Added to ${created.name}`)
   }
 
   async function handleRetag() {
@@ -454,7 +465,7 @@ export function DocumentCard({
                             return (
                               <button
                                 key={col.id}
-                                onClick={() => void handleAddToCollection(col.id)}
+                                onClick={() => void handleAddToCollection(col.id, col.name)}
                                 disabled={added}
                                 className={cn(
                                   "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors",

--- a/frontend/src/components/library/DocumentCard.tsx
+++ b/frontend/src/components/library/DocumentCard.tsx
@@ -215,8 +215,6 @@ export function DocumentCard({
     }
   }
 
-  // Creating from here is only worth the interruption if the document lands in
-  // the new collection, which is the whole reason the user opened this picker.
   async function handleCollectionCreated(created: { id: string; name: string }) {
     await handleAddToCollection(created.id)
     setCollections(await fetchCollectionTree())

--- a/frontend/src/components/library/DocumentCard.tsx
+++ b/frontend/src/components/library/DocumentCard.tsx
@@ -32,7 +32,11 @@ import { useNavigate } from "react-router-dom"
 import type { DocAction } from "@/lib/docActionUtils"
 import { DOC_ACTIONS } from "@/lib/docActionUtils"
 import { isSurfaceVisible } from "@/lib/surfaceManifest"
-import { addDocumentToCollection, fetchCollectionTree } from "@/lib/notesApi"
+import {
+  addDocumentToCollection,
+  fetchCollectionTree,
+  removeDocumentFromCollection,
+} from "@/lib/notesApi"
 import { retagDocument } from "@/pages/Learning/api"
 import { flattenCollectionTree, type CollectionTreeItem } from "@/lib/collectionUtils"
 import type { ContentType, DocumentListItem } from "./types"
@@ -160,7 +164,9 @@ export function DocumentCard({
   const [collectionPickerOpen, setCollectionPickerOpen] = useState(false)
   const [collections, setCollections] = useState<CollectionTreeItem[] | null>(null)
   const [collectionsLoading, setCollectionsLoading] = useState(false)
-  const [addedCollectionIds, setAddedCollectionIds] = useState<Set<string>>(new Set())
+  // Optimistic overlay on doc.collections, which is the source of truth and is
+  // refetched after every change. Keyed id -> is-member.
+  const [pendingMembership, setPendingMembership] = useState<Map<string, boolean>>(new Map())
   const [newCollectionOpen, setNewCollectionOpen] = useState(false)
   const [collectionFilter, setCollectionFilter] = useState("")
   const triggerRef = useRef<HTMLButtonElement>(null)
@@ -251,13 +257,20 @@ export function DocumentCard({
     }
   }
 
-  async function handleAddToCollection(collectionId: string, name: string) {
-    if (addedCollectionIds.has(collectionId)) return
+  function isMember(collectionId: string): boolean {
+    const pending = pendingMembership.get(collectionId)
+    if (pending !== undefined) return pending
+    return (doc.collections ?? []).some((c) => c.id === collectionId)
+  }
+
+  async function handleToggleCollection(collectionId: string, name: string) {
+    const adding = !isMember(collectionId)
+    setPendingMembership((prev) => new Map(prev).set(collectionId, adding))
     try {
-      await addDocumentToCollection(collectionId, doc.id)
-      setAddedCollectionIds((prev) => new Set(prev).add(collectionId))
-      toast.success(`Added to ${name}`)
-      // Refresh the rail's count badges, which this menu does not own.
+      if (adding) await addDocumentToCollection(collectionId, doc.id)
+      else await removeDocumentFromCollection(collectionId, doc.id)
+      toast.success(adding ? `Added to ${name}` : `Removed from ${name}`)
+      // The card's own chips and the rail's badges live in other queries.
       void queryClient.invalidateQueries({ queryKey: ["collections-tree"] })
       void queryClient.invalidateQueries({ queryKey: ["documents"] })
       // Long enough for the tick to register, then the picker closes: leaving
@@ -267,12 +280,17 @@ export function DocumentCard({
         setActionMenuOpen(false)
       }, 450)
     } catch {
-      toast.error(`Could not add to ${name}`)
+      setPendingMembership((prev) => {
+        const next = new Map(prev)
+        next.delete(collectionId)
+        return next
+      })
+      toast.error(adding ? `Could not add to ${name}` : `Could not remove from ${name}`)
     }
   }
 
   async function handleCollectionCreated(created: { id: string; name: string }) {
-    await handleAddToCollection(created.id, created.name)
+    await handleToggleCollection(created.id, created.name)
     setCollections(await fetchCollectionTree())
   }
 
@@ -460,16 +478,15 @@ export function DocumentCard({
                           )}
                         {!collectionsLoading && collections && collections.length > 0 && (
                           visibleCollections.map((col) => {
-                            const added = addedCollectionIds.has(col.id)
+                            const member = isMember(col.id)
                             const isChild = !collections.some((root) => root.id === col.id)
                             return (
                               <button
                                 key={col.id}
-                                onClick={() => void handleAddToCollection(col.id, col.name)}
-                                disabled={added}
+                                onClick={() => void handleToggleCollection(col.id, col.name)}
+                                title={member ? `Remove from ${col.name}` : `Add to ${col.name}`}
                                 className={cn(
-                                  "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors",
-                                  added ? "text-muted-foreground" : "hover:bg-accent",
+                                  "group/row flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent",
                                   isChild && "pl-5",
                                 )}
                               >
@@ -478,7 +495,18 @@ export function DocumentCard({
                                   style={{ backgroundColor: col.color }}
                                 />
                                 <span className="flex-1 truncate">{col.name}</span>
-                                {added && <Check size={12} className="shrink-0 text-primary" />}
+                                {member && (
+                                  <>
+                                    <Check
+                                      size={12}
+                                      className="shrink-0 text-primary group-hover/row:hidden"
+                                    />
+                                    <X
+                                      size={12}
+                                      className="hidden shrink-0 text-destructive group-hover/row:block"
+                                    />
+                                  </>
+                                )}
                               </button>
                             )
                           })

--- a/frontend/src/components/library/LibraryCollectionsRail.tsx
+++ b/frontend/src/components/library/LibraryCollectionsRail.tsx
@@ -10,10 +10,6 @@ interface LibraryCollectionsRailProps {
   onSelect: (id: string | null) => void
 }
 
-/**
- * The Notes sidebar's CollectionTree, wired for documents. The two rails differ
- * only in what a drop adds and in this header.
- */
 export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollectionsRailProps) {
   const [formOpen, setFormOpen] = useState(false)
   const navigate = useNavigate()

--- a/frontend/src/components/library/LibraryCollectionsRail.tsx
+++ b/frontend/src/components/library/LibraryCollectionsRail.tsx
@@ -1,10 +1,21 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { ChevronDown, ChevronRight, ExternalLink } from "lucide-react"
+import { ChevronDown, ChevronRight, ExternalLink, Pencil, Plus, Trash2 } from "lucide-react"
 import { useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { toast } from "sonner"
 
+import { CreateCollectionDialog } from "@/components/CreateCollectionDialog"
+import type { EditableCollection } from "@/components/CreateCollectionDialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { Skeleton } from "@/components/ui/skeleton"
+import { apiDelete } from "@/lib/apiClient"
 import { addDocumentToCollection, fetchCollectionTree } from "@/lib/notesApi"
 import type { CollectionTreeItem } from "@/lib/collectionUtils"
 import { cn } from "@/lib/utils"
@@ -18,6 +29,9 @@ interface LibraryCollectionsRailProps {
 
 export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollectionsRailProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [formOpen, setFormOpen] = useState(false)
+  const [editing, setEditing] = useState<EditableCollection | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<CollectionTreeItem | null>(null)
   const navigate = useNavigate()
   const queryClient = useQueryClient()
 
@@ -41,6 +55,29 @@ export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollecti
     },
     onError: () => toast.error("Could not add to collection"),
   })
+
+  const deleteMut = useMutation({
+    mutationFn: (collectionId: string) => apiDelete(`/collections/${collectionId}`),
+    onSuccess: (_data, collectionId) => {
+      void queryClient.invalidateQueries({ queryKey: ["collections-tree"] })
+      void queryClient.invalidateQueries({ queryKey: ["documents"] })
+      // Clear the filter if the collection currently narrowing the grid is gone.
+      if (selectedId === collectionId) onSelect(null)
+      setPendingDelete(null)
+      toast.success("Collection deleted")
+    },
+    onError: () => toast.error("Could not delete collection"),
+  })
+
+  function openCreate() {
+    setEditing(null)
+    setFormOpen(true)
+  }
+
+  function openEdit(item: CollectionTreeItem) {
+    setEditing({ id: item.id, name: item.name, color: item.color })
+    setFormOpen(true)
+  }
 
   function toggleExpand(id: string) {
     setExpanded((prev) => {
@@ -73,6 +110,13 @@ export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollecti
               Clear
             </button>
           )}
+          <button
+            onClick={openCreate}
+            className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-primary hover:bg-accent"
+            title="New collection"
+          >
+            <Plus size={12} /> New
+          </button>
         </div>
       </div>
 
@@ -97,7 +141,15 @@ export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollecti
       )}
 
       {!isLoading && !isError && (!data || data.length === 0) && (
-        <p className="py-2 text-xs text-muted-foreground">No collections yet</p>
+        <div className="flex flex-col items-start gap-1.5 py-2">
+          <p className="text-xs text-muted-foreground">No collections yet</p>
+          <button
+            onClick={openCreate}
+            className="flex items-center gap-1 rounded border border-border px-2 py-1 text-xs text-foreground hover:bg-accent"
+          >
+            <Plus size={12} /> New collection
+          </button>
+        </div>
       )}
 
       {!isLoading && !isError && data && data.length > 0 && (
@@ -112,6 +164,8 @@ export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollecti
               selectedId={selectedId}
               onSelect={onSelect}
               onDropDoc={(docId) => dropMut.mutate({ collectionId: item.id, docId })}
+              onEdit={() => openEdit(item)}
+              onDelete={() => setPendingDelete(item)}
             >
               {expanded.has(item.id) &&
                 item.children.map((child) => (
@@ -126,12 +180,60 @@ export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollecti
                     onDropDoc={(docId) =>
                       dropMut.mutate({ collectionId: child.id, docId })
                     }
+                    onEdit={() => openEdit(child)}
+                    onDelete={() => setPendingDelete(child)}
                   />
                 ))}
             </RailItem>
           ))}
         </div>
       )}
+
+      <CreateCollectionDialog
+        open={formOpen}
+        collection={editing}
+        onClose={() => {
+          setFormOpen(false)
+          setEditing(null)
+        }}
+      />
+
+      <Dialog
+        open={pendingDelete !== null}
+        onOpenChange={(o) => {
+          if (!o) setPendingDelete(null)
+        }}
+      >
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete &ldquo;{pendingDelete?.name}&rdquo;?</DialogTitle>
+            <DialogDescription>
+              {pendingDelete && pendingDelete.children.length > 0
+                ? `This also deletes its ${pendingDelete.children.length} sub-collection${
+                    pendingDelete.children.length === 1 ? "" : "s"
+                  }. `
+                : ""}
+              Your documents and notes are not deleted — only the collection and its
+              membership list. This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <button
+              onClick={() => setPendingDelete(null)}
+              className="rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => pendingDelete && deleteMut.mutate(pendingDelete.id)}
+              disabled={deleteMut.isPending}
+              className="rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-60"
+            >
+              {deleteMut.isPending ? "Deleting…" : "Delete"}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </aside>
   )
 }
@@ -144,6 +246,8 @@ interface RailItemProps {
   selectedId: string | null
   onSelect: (id: string | null) => void
   onDropDoc: (docId: string) => void
+  onEdit: () => void
+  onDelete: () => void
   children?: React.ReactNode
 }
 
@@ -155,6 +259,8 @@ function RailItem({
   selectedId,
   onSelect,
   onDropDoc,
+  onEdit,
+  onDelete,
   children,
 }: RailItemProps) {
   const [isDragOver, setIsDragOver] = useState(false)
@@ -211,12 +317,41 @@ function RailItem({
         <span className="flex-1 min-w-0 truncate">{item.name}</span>
         {item.scoped_count > 0 && (
           <span
-            className="ml-auto shrink-0 rounded-full bg-blue-100/60 dark:bg-blue-900/30 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:text-blue-300"
+            className="ml-auto shrink-0 rounded-full bg-blue-100/60 dark:bg-blue-900/30 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:text-blue-300 group-hover:hidden"
             title={`${item.scoped_count} document${item.scoped_count === 1 ? "" : "s"} (inclusive of subcollections)`}
           >
             {item.scoped_count}
           </span>
         )}
+        {/* role=button rather than <button>: this row is itself a button. */}
+        <span className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover:flex">
+          <span
+            role="button"
+            tabIndex={0}
+            aria-label={`Edit ${item.name}`}
+            title="Edit collection"
+            onClick={(e) => {
+              e.stopPropagation()
+              onEdit()
+            }}
+            className="rounded p-0.5 text-muted-foreground hover:bg-background hover:text-foreground"
+          >
+            <Pencil size={11} />
+          </span>
+          <span
+            role="button"
+            tabIndex={0}
+            aria-label={`Delete ${item.name}`}
+            title="Delete collection"
+            onClick={(e) => {
+              e.stopPropagation()
+              onDelete()
+            }}
+            className="rounded p-0.5 text-muted-foreground hover:bg-background hover:text-destructive"
+          >
+            <Trash2 size={11} />
+          </span>
+        </span>
       </button>
       {children}
     </>

--- a/frontend/src/components/library/LibraryCollectionsRail.tsx
+++ b/frontend/src/components/library/LibraryCollectionsRail.tsx
@@ -112,10 +112,10 @@ export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollecti
           )}
           <button
             onClick={openCreate}
-            className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-primary hover:bg-accent"
+            className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
             title="New collection"
           >
-            <Plus size={12} /> New
+            <Plus size={12} />
           </button>
         </div>
       </div>
@@ -141,15 +141,7 @@ export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollecti
       )}
 
       {!isLoading && !isError && (!data || data.length === 0) && (
-        <div className="flex flex-col items-start gap-1.5 py-2">
-          <p className="text-xs text-muted-foreground">No collections yet</p>
-          <button
-            onClick={openCreate}
-            className="flex items-center gap-1 rounded border border-border px-2 py-1 text-xs text-foreground hover:bg-accent"
-          >
-            <Plus size={12} /> New collection
-          </button>
-        </div>
+        <p className="py-2 text-xs text-muted-foreground">No collections yet</p>
       )}
 
       {!isLoading && !isError && data && data.length > 0 && (

--- a/frontend/src/components/library/LibraryCollectionsRail.tsx
+++ b/frontend/src/components/library/LibraryCollectionsRail.tsx
@@ -1,92 +1,24 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { ChevronDown, ChevronRight, ExternalLink, Pencil, Plus, Trash2 } from "lucide-react"
+import { ExternalLink, Plus } from "lucide-react"
 import { useState } from "react"
 import { useNavigate } from "react-router-dom"
-import { toast } from "sonner"
 
+import { CollectionTree, DOC_DRAG_MIME } from "@/components/CollectionTree"
 import { CreateCollectionDialog } from "@/components/CreateCollectionDialog"
-import type { EditableCollection } from "@/components/CreateCollectionDialog"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
-import { Skeleton } from "@/components/ui/skeleton"
-import { apiDelete } from "@/lib/apiClient"
-import { addDocumentToCollection, fetchCollectionTree } from "@/lib/notesApi"
-import type { CollectionTreeItem } from "@/lib/collectionUtils"
-import { cn } from "@/lib/utils"
-
-const DOC_DRAG_MIME = "application/x-luminary-doc-id"
 
 interface LibraryCollectionsRailProps {
   selectedId: string | null
   onSelect: (id: string | null) => void
 }
 
+/**
+ * Library-side collections rail: the same CollectionTree the Notes sidebar
+ * uses, wired for documents. Rows carry inline rename, delete, export and
+ * health there, so they carry them here too -- the two rails only differ in
+ * what a drop adds and in this header.
+ */
 export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollectionsRailProps) {
-  const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [formOpen, setFormOpen] = useState(false)
-  const [editing, setEditing] = useState<EditableCollection | null>(null)
-  const [pendingDelete, setPendingDelete] = useState<CollectionTreeItem | null>(null)
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
-
-  // scope=document: hide note-only collections so the Library rail stays
-  // focused on doc-relevant memberships. The unscoped invalidations elsewhere
-  // (queryKey starts with "collections-tree") still hit this query via the
-  // default prefix-match behavior of invalidateQueries.
-  const { data, isLoading, isError, refetch } = useQuery({
-    queryKey: ["collections-tree", "contains:document"],
-    queryFn: () => fetchCollectionTree("document"),
-    staleTime: 30_000,
-  })
-
-  const dropMut = useMutation({
-    mutationFn: ({ collectionId, docId }: { collectionId: string; docId: string }) =>
-      addDocumentToCollection(collectionId, docId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["collections-tree"] })
-      void queryClient.invalidateQueries({ queryKey: ["documents"] })
-      toast.success("Added to collection")
-    },
-    onError: () => toast.error("Could not add to collection"),
-  })
-
-  const deleteMut = useMutation({
-    mutationFn: (collectionId: string) => apiDelete(`/collections/${collectionId}`),
-    onSuccess: (_data, collectionId) => {
-      void queryClient.invalidateQueries({ queryKey: ["collections-tree"] })
-      void queryClient.invalidateQueries({ queryKey: ["documents"] })
-      // Clear the filter if the collection currently narrowing the grid is gone.
-      if (selectedId === collectionId) onSelect(null)
-      setPendingDelete(null)
-      toast.success("Collection deleted")
-    },
-    onError: () => toast.error("Could not delete collection"),
-  })
-
-  function openCreate() {
-    setEditing(null)
-    setFormOpen(true)
-  }
-
-  function openEdit(item: CollectionTreeItem) {
-    setEditing({ id: item.id, name: item.name, color: item.color })
-    setFormOpen(true)
-  }
-
-  function toggleExpand(id: string) {
-    setExpanded((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }
 
   return (
     <aside className="flex flex-col gap-3 rounded-lg border border-border bg-card p-3">
@@ -111,7 +43,7 @@ export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollecti
             </button>
           )}
           <button
-            onClick={openCreate}
+            onClick={() => setFormOpen(true)}
             className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
             title="New collection"
           >
@@ -120,232 +52,15 @@ export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollecti
         </div>
       </div>
 
-      {isLoading && (
-        <div className="flex flex-col gap-1">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <Skeleton key={i} className="h-6 w-full rounded" />
-          ))}
-        </div>
-      )}
-
-      {isError && (
-        <div className="flex flex-col gap-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-1.5 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300">
-          <span>Could not load collections</span>
-          <button
-            onClick={() => void refetch()}
-            className="self-start rounded border border-amber-300 bg-white px-2 py-0.5 text-xs text-amber-700 hover:bg-amber-50 dark:border-amber-800 dark:bg-transparent dark:text-amber-300 dark:hover:bg-amber-900/40"
-          >
-            Retry
-          </button>
-        </div>
-      )}
-
-      {!isLoading && !isError && (!data || data.length === 0) && (
-        <p className="py-2 text-xs text-muted-foreground">No collections yet</p>
-      )}
-
-      {!isLoading && !isError && data && data.length > 0 && (
-        <div className="flex flex-col gap-0.5">
-          {data.map((item) => (
-            <RailItem
-              key={item.id}
-              item={item}
-              depth={0}
-              isExpanded={expanded.has(item.id)}
-              onToggleExpand={() => toggleExpand(item.id)}
-              selectedId={selectedId}
-              onSelect={onSelect}
-              onDropDoc={(docId) => dropMut.mutate({ collectionId: item.id, docId })}
-              onEdit={() => openEdit(item)}
-              onDelete={() => setPendingDelete(item)}
-            >
-              {expanded.has(item.id) &&
-                item.children.map((child) => (
-                  <RailItem
-                    key={child.id}
-                    item={child}
-                    depth={1}
-                    isExpanded={false}
-                    onToggleExpand={() => {}}
-                    selectedId={selectedId}
-                    onSelect={onSelect}
-                    onDropDoc={(docId) =>
-                      dropMut.mutate({ collectionId: child.id, docId })
-                    }
-                    onEdit={() => openEdit(child)}
-                    onDelete={() => setPendingDelete(child)}
-                  />
-                ))}
-            </RailItem>
-          ))}
-        </div>
-      )}
-
-      <CreateCollectionDialog
-        open={formOpen}
-        collection={editing}
-        onClose={() => {
-          setFormOpen(false)
-          setEditing(null)
-        }}
+      <CollectionTree
+        contains="document"
+        memberType="document"
+        dragMime={DOC_DRAG_MIME}
+        selectedId={selectedId}
+        onSelect={onSelect}
       />
 
-      <Dialog
-        open={pendingDelete !== null}
-        onOpenChange={(o) => {
-          if (!o) setPendingDelete(null)
-        }}
-      >
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Delete &ldquo;{pendingDelete?.name}&rdquo;?</DialogTitle>
-            <DialogDescription>
-              {pendingDelete && pendingDelete.children.length > 0
-                ? `This also deletes its ${pendingDelete.children.length} sub-collection${
-                    pendingDelete.children.length === 1 ? "" : "s"
-                  }. `
-                : ""}
-              Your documents and notes are not deleted — only the collection and its
-              membership list. This cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <button
-              onClick={() => setPendingDelete(null)}
-              className="rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={() => pendingDelete && deleteMut.mutate(pendingDelete.id)}
-              disabled={deleteMut.isPending}
-              className="rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-60"
-            >
-              {deleteMut.isPending ? "Deleting…" : "Delete"}
-            </button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <CreateCollectionDialog open={formOpen} onClose={() => setFormOpen(false)} />
     </aside>
-  )
-}
-
-interface RailItemProps {
-  item: CollectionTreeItem
-  depth: number
-  isExpanded: boolean
-  onToggleExpand: () => void
-  selectedId: string | null
-  onSelect: (id: string | null) => void
-  onDropDoc: (docId: string) => void
-  onEdit: () => void
-  onDelete: () => void
-  children?: React.ReactNode
-}
-
-function RailItem({
-  item,
-  depth,
-  isExpanded,
-  onToggleExpand,
-  selectedId,
-  onSelect,
-  onDropDoc,
-  onEdit,
-  onDelete,
-  children,
-}: RailItemProps) {
-  const [isDragOver, setIsDragOver] = useState(false)
-  const hasChildren = item.children.length > 0
-  const isActive = selectedId === item.id
-  const paddingLeft = depth * 12 + 4
-
-  return (
-    <>
-      <button
-        onClick={() => onSelect(isActive ? null : item.id)}
-        onDragOver={(e) => {
-          if (e.dataTransfer.types.includes(DOC_DRAG_MIME)) {
-            e.preventDefault()
-            e.dataTransfer.dropEffect = "copy"
-            setIsDragOver(true)
-          }
-        }}
-        onDragLeave={() => setIsDragOver(false)}
-        onDrop={(e) => {
-          const docId = e.dataTransfer.getData(DOC_DRAG_MIME)
-          setIsDragOver(false)
-          if (!docId) return
-          e.preventDefault()
-          onDropDoc(docId)
-        }}
-        style={{ paddingLeft }}
-        className={cn(
-          "group flex items-center gap-1 rounded px-2 py-1 text-left text-sm transition-colors",
-          isActive
-            ? "bg-accent font-medium text-foreground"
-            : isDragOver
-              ? "bg-primary/10 text-foreground ring-1 ring-primary/40"
-              : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
-        )}
-      >
-        <span
-          role="button"
-          tabIndex={hasChildren ? 0 : -1}
-          onClick={(e) => {
-            if (!hasChildren) return
-            e.stopPropagation()
-            onToggleExpand()
-          }}
-          className="shrink-0 text-muted-foreground"
-          style={{ visibility: hasChildren ? "visible" : "hidden" }}
-        >
-          {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-        </span>
-        <span
-          className="shrink-0 h-2.5 w-2.5 rounded-sm"
-          style={{ backgroundColor: item.color }}
-        />
-        <span className="flex-1 min-w-0 truncate">{item.name}</span>
-        {item.scoped_count > 0 && (
-          <span
-            className="ml-auto shrink-0 rounded-full bg-blue-100/60 dark:bg-blue-900/30 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:text-blue-300 group-hover:hidden"
-            title={`${item.scoped_count} document${item.scoped_count === 1 ? "" : "s"} (inclusive of subcollections)`}
-          >
-            {item.scoped_count}
-          </span>
-        )}
-        {/* role=button rather than <button>: this row is itself a button. */}
-        <span className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover:flex">
-          <span
-            role="button"
-            tabIndex={0}
-            aria-label={`Edit ${item.name}`}
-            title="Edit collection"
-            onClick={(e) => {
-              e.stopPropagation()
-              onEdit()
-            }}
-            className="rounded p-0.5 text-muted-foreground hover:bg-background hover:text-foreground"
-          >
-            <Pencil size={11} />
-          </span>
-          <span
-            role="button"
-            tabIndex={0}
-            aria-label={`Delete ${item.name}`}
-            title="Delete collection"
-            onClick={(e) => {
-              e.stopPropagation()
-              onDelete()
-            }}
-            className="rounded p-0.5 text-muted-foreground hover:bg-background hover:text-destructive"
-          >
-            <Trash2 size={11} />
-          </span>
-        </span>
-      </button>
-      {children}
-    </>
   )
 }

--- a/frontend/src/components/library/LibraryCollectionsRail.tsx
+++ b/frontend/src/components/library/LibraryCollectionsRail.tsx
@@ -11,10 +11,8 @@ interface LibraryCollectionsRailProps {
 }
 
 /**
- * Library-side collections rail: the same CollectionTree the Notes sidebar
- * uses, wired for documents. Rows carry inline rename, delete, export and
- * health there, so they carry them here too -- the two rails only differ in
- * what a drop adds and in this header.
+ * The Notes sidebar's CollectionTree, wired for documents. The two rails differ
+ * only in what a drop adds and in this header.
  */
 export function LibraryCollectionsRail({ selectedId, onSelect }: LibraryCollectionsRailProps) {
   const [formOpen, setFormOpen] = useState(false)

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -145,12 +145,7 @@ interface Citation {
   version_mismatch?: boolean  // S142: local vs web version discrepancy
 }
 
-/** Citations the model returned with enough metadata to label a chip.
- *
- * The LLM quotes excerpts but does not always resolve them back to a document
- * and page, and a chip with neither renders as "Doc" or a bare ellipsis. The
- * source chips carry the same grounding fully labelled.
- */
+/** The model often omits document_title and page, which render as a blank chip. */
 function labelledCitations(citations: Citation[] | undefined): Citation[] {
   return (citations ?? []).filter((c) => Boolean(c.document_title?.trim()) || c.page > 0)
 }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -145,6 +145,16 @@ interface Citation {
   version_mismatch?: boolean  // S142: local vs web version discrepancy
 }
 
+/** Citations the model returned with enough metadata to label a chip.
+ *
+ * The LLM quotes excerpts but does not always resolve them back to a document
+ * and page, and a chip with neither renders as "Doc" or a bare ellipsis. The
+ * source chips carry the same grounding fully labelled.
+ */
+function labelledCitations(citations: Citation[] | undefined): Citation[] {
+  return (citations ?? []).filter((c) => Boolean(c.document_title?.trim()) || c.page > 0)
+}
+
 interface WebSource {
   url: string
   title: string
@@ -1347,11 +1357,16 @@ export default function Chat() {
                       </div>
                     )}
 
-                    {/* Citations and confidence — shown after streaming completes */}
-                    {!msg.isStreaming && msg.citations && msg.citations.length > 0 && (
+                    {/* Citations and confidence — shown after streaming completes.
+                        Citations the model quoted without a title or page cannot be
+                        labelled (they render as "Doc" or a bare ellipsis) and the
+                        source chips below already carry the same grounding with
+                        real titles and pages, so they are dropped rather than shown
+                        as blanks. */}
+                    {!msg.isStreaming && labelledCitations(msg.citations).length > 0 && (
                       <div className="mt-3 space-y-2">
                         <div className="flex flex-wrap gap-1.5">
-                          {msg.citations.map((c, i) => (
+                          {labelledCitations(msg.citations).map((c, i) => (
                             <span
                               key={i}
                               className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
@@ -1368,11 +1383,16 @@ export default function Chat() {
                             </span>
                           ))}
                         </div>
-                        {msg.confidence && (
-                          <Badge variant={CONFIDENCE_BADGE[msg.confidence]}>
-                            {msg.confidence} confidence
-                          </Badge>
-                        )}
+                      </div>
+                    )}
+
+                    {/* TransparencyPanel renders the same value with an
+                        explanation, so only stand in when it is absent. */}
+                    {!msg.isStreaming && msg.confidence && !msg.transparency && (
+                      <div className="mt-3">
+                        <Badge variant={CONFIDENCE_BADGE[msg.confidence]}>
+                          {msg.confidence} confidence
+                        </Badge>
                       </div>
                     )}
 

--- a/frontend/src/pages/Notes.tsx
+++ b/frontend/src/pages/Notes.tsx
@@ -1206,14 +1206,6 @@ export default function NotesPage() {
             </button>
           </div>
           <CollectionTree contains="note" />
-
-          <button
-            onClick={() => setShowCreateCollection(true)}
-            className="mt-1 flex w-full items-center gap-1 rounded px-3 py-1.5 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground"
-          >
-            <Plus size={11} />
-            New Collection
-          </button>
         </div>
 
         {/* Tags section */}

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -147,8 +147,7 @@ export const useAppStore = create<AppState>()(
       name: "luminary-app-store",
       storage: createJSONStorage(() => localStorage),
       version: 1,
-      // v0 persisted libraryFiltersOpen; hydrating it would keep the rails
-      // hidden for anyone who had ever collapsed them.
+      // v0 persisted libraryFiltersOpen; hydrating it re-hides the rails.
       migrate: (persisted) => {
         if (persisted && typeof persisted === "object") {
           delete (persisted as Record<string, unknown>).libraryFiltersOpen

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -93,7 +93,9 @@ export const useAppStore = create<AppState>()(
       llmMode: "private",
       currentProvider: "openai",
       libraryView: "grid",
-      libraryFiltersOpen: false,
+      // Open on every app start so the Collections and Tags rails are visible
+      // rather than hidden behind a toggle. Deliberately not persisted.
+      libraryFiltersOpen: true,
       notesView: "grid",
       // Only "false" disables; absent key (first run) defaults to enabled.
       reviewRemindersEnabled: localStorage.getItem("luminary:reviewReminders") !== "false",
@@ -145,12 +147,20 @@ export const useAppStore = create<AppState>()(
     {
       name: "luminary-app-store",
       storage: createJSONStorage(() => localStorage),
+      version: 1,
+      // v0 persisted libraryFiltersOpen. Hydrating that value would keep the
+      // rails hidden for anyone who had ever collapsed them, so drop the key.
+      migrate: (persisted) => {
+        if (persisted && typeof persisted === "object") {
+          delete (persisted as Record<string, unknown>).libraryFiltersOpen
+        }
+        return persisted as AppState
+      },
       partialize: (state) => ({
         chatMessages: state.chatMessages,
         chatScope: state.chatScope,
         chatSelectedDocId: state.chatSelectedDocId,
         libraryView: state.libraryView,
-        libraryFiltersOpen: state.libraryFiltersOpen,
         notesView: state.notesView,
         reviewRemindersEnabled: state.reviewRemindersEnabled,
         studySessionId: state.studySessionId,

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -93,8 +93,7 @@ export const useAppStore = create<AppState>()(
       llmMode: "private",
       currentProvider: "openai",
       libraryView: "grid",
-      // Open on every app start so the Collections and Tags rails are visible
-      // rather than hidden behind a toggle. Deliberately not persisted.
+      // Open every app start so the rails are visible. Deliberately not persisted.
       libraryFiltersOpen: true,
       notesView: "grid",
       // Only "false" disables; absent key (first run) defaults to enabled.
@@ -148,8 +147,8 @@ export const useAppStore = create<AppState>()(
       name: "luminary-app-store",
       storage: createJSONStorage(() => localStorage),
       version: 1,
-      // v0 persisted libraryFiltersOpen. Hydrating that value would keep the
-      // rails hidden for anyone who had ever collapsed them, so drop the key.
+      // v0 persisted libraryFiltersOpen; hydrating it would keep the rails
+      // hidden for anyone who had ever collapsed them.
       migrate: (persisted) => {
         if (persisted && typeof persisted === "object") {
           delete (persisted as Record<string, unknown>).libraryFiltersOpen


### PR DESCRIPTION
Twelve fixes found while exercising the app before the demo. Branched off `master` at 0.2.7 (post-PR #30).

Each item below was reproduced against real data before being changed, and the UI changes were verified in a headless browser rather than by types alone.

## Ingestion

**PDF words were shredded into single characters** — `The C on ce ptu al F oun da ti ons`. Not a font problem: the text was mangled at parse time, so chunks, search and citations all carried the damage. PyMuPDF opens a new span at every style change, and a PDF alternating Type3 font subsets per glyph splits one word across 25–52 spans; joining those on a space inserts one at every glyph boundary. Word gaps are now inferred from geometry (0.2em, clear of both intra-word kerning and a space glyph).

Validated against PyMuPDF's own `get_text()` as ground truth on three real PDFs: exact-line agreement **0% → 100%** on the affected document, 83% → 99% and 97% → 100% on two papers. The few remaining diffs are lines where this output is better than `get_text()`'s.

## Collections

- **Management existed only in Notes.** The Library rail now creates, edits and deletes, and the document card's picker offers "New collection…" which creates and adds in one step. That picker previously dead-ended on "No collections yet".
- **`?contains` pruned the tree, not just the count.** A collection holding only notes was invisible in the Library, so a document could not be dropped into it or renamed from there. An earlier carve-out kept *empty* collections visible so create-then-add would work — the same bug one step earlier, patched rather than fixed. Scoping now applies to the count alone; a row holding none of the rail's kind is de-emphasised, never hidden.
- **One rail component.** The Library rail is the same `CollectionTree` Notes uses, parameterised by member type, drag MIME and selection. It gains inline rename, export and health, and the two rails cannot drift apart again.
- **Row kind is legible**: a sky `Nd` and amber `Nn` pill, each rendered only when non-zero, so presence signals document-based, note-based or both. Previously every row showed a `0n`.
- **Badges counted deleted members.** A collection showing two notes reported `5n`: `collection_members` keys on `(member_id, member_type)`, so nothing keyed by `note_id` or `document_id` cascaded to it. Six orphans existed across the library. Both delete paths now clear memberships, and `member_counts` joins each membership to its target so a stale row can never inflate a badge again.
- **The picker could only add.** Membership state was a `Set` that started empty and recorded only clicks since mount, so a document already in a collection showed no tick — while the card rendered that same membership as a chip below. Membership now reads from `doc.collections` with an optimistic overlay, and a click toggles.
- **The popover was clipped by the card** (`overflow-hidden`), leaving the tail of the list unreachable by scrolling. It is portalled to `body`, viewport-bounded, with a filter once the list passes seven entries.
- **The rails were hidden behind the Filters toggle** by default, and that flag was persisted — so changing the default alone would have changed nothing for existing users. It is no longer persisted, with a store version bump dropping the stale key.

## Flashcards

**Generation deduped per deck.** Note cards land in a tag-named deck and document cards in `default`, so a collection session interleaved two sets that had never been compared. Measured on a real collection: a candidate about dense retrieval scored **0.939** against an existing note card — well past the 0.85 threshold — yet went unflagged. The scope is now the deck plus the document and everything sharing a collection with it.

## Evals

**Faithfulness was judged against a retired gate.** The dashboard used 0.65 while the backend had re-baselined to a 0.30 collapse floor, so a healthy 0.55 run rendered amber. The test meant to prevent that drift asserted against copied literals and kept passing on the stale number; it now parses `THRESHOLDS` out of `evals/run_eval.py` and compares every key — verified by reintroducing the drift and watching it fail.

Also: the eval subprocess logged RAGAS/tqdm progress at WARNING on `rc=0`, making every clean run look like it had errored. Now DEBUG when the run exits 0.

## Chat

The answer footer rendered confidence **twice** (a Badge plus TransparencyPanel's own pill), beside a citation chip showing as a bare ellipsis — the model quotes excerpts without always resolving them to a document and page, and `document_title=None` with `page=0` renders as `Doc` or an empty label. Unlabelable chips are dropped; the source chips below carry the same grounding fully labelled.

## Verification

- Backend **2151 passed, 1 skipped, 102 deselected**
- Frontend **453 passed** (36 files); `tsc`, `vite build` clean
- Browser-verified in light and dark: rail visible on load, popover unclipped (`clipping ancestors: NONE`, extends 300px past the card, within viewport), all 12 collections reachable, add/remove round trip returning the library to its prior state
- New tests: 8 for PDF span joining, 4 for flashcard dedup scope, 2 for membership cascade, plus rewritten threshold-drift and `?contains` contract tests

## Notes for the reviewer

- `documents.py` and several frontend files carry pre-existing `ruff format` drift and eslint `no-restricted-syntax` errors (raw `fetch`). Confirmed against a clean tree and left alone.
- One behaviour change worth a second opinion: adding a document to a collection now closes the picker, so adding to several collections takes several trips. Chosen because the missing completion signal was the reported problem.
- Diagnosed but deliberately not changed: relearn cards sort ahead of newly generated ones (`shapeQueue` favours high stability), so a fresh generation still shows familiar cards first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)