### PR TITLE
fix(teachback): never report an unparseable evaluation as a zero

### DIFF
--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -96,6 +96,7 @@ from app.schemas.study import (
 from app.services import study_assembler
 from app.services.fsrs_service import get_fsrs_service
 from app.services.llm import get_llm_service
+from app.services.llm_json import parse_llm_json_object
 from app.services.mastery_service import get_mastery_service
 from app.services.misconceptions import (
     PASSING_TEACHBACK_SCORE,
@@ -1275,10 +1276,12 @@ async def teachback(
         answer=card.answer,
         explanation=req.user_explanation,
     )
-    raw = await llm.generate(prompt=prompt, system=_TEACHBACK_SYSTEM)
-
-    # Parse LLM JSON response
-    parsed = _parse_teachback_response(raw)
+    parsed = await _evaluate_teachback_llm(prompt)
+    if parsed is None:
+        raise HTTPException(
+            status_code=503,
+            detail="The model returned an unreadable evaluation. Please try again.",
+        )
     score = parsed.get("score", 0)
     correct_points: list[str] = parsed.get("correct_points", [])
     missing_points: list[str] = parsed.get("missing_points", [])
@@ -1451,8 +1454,10 @@ async def _evaluate_teachback_bg(
         answer=card_answer,
         explanation=user_explanation,
     )
-    raw = await llm.generate(prompt=prompt, system=_TEACHBACK_SYSTEM)
-    parsed = _parse_teachback_response(raw)
+    parsed = await _evaluate_teachback_llm(prompt)
+    if parsed is None:
+        await _mark_teachback_error(tb_id)
+        return
     score = parsed.get("score", 0)
     correct_points: list[str] = parsed.get("correct_points", [])
     missing_points: list[str] = parsed.get("missing_points", [])
@@ -2177,17 +2182,10 @@ async def get_start_concepts(
 
 
 def _parse_rubric(raw: str) -> dict | None:
-    """Strip markdown fences and parse rubric JSON from LLM response. Returns None on failure."""
-    cleaned = raw.strip()
-    if cleaned.startswith("```"):
-        lines = cleaned.splitlines()
-        cleaned = "\n".join(lines[1:-1]) if len(lines) > 2 else cleaned
-    try:
-        parsed = json.loads(cleaned)
-    except (json.JSONDecodeError, ValueError):
+    """Parse rubric JSON from an LLM response. Returns None on failure."""
+    parsed = parse_llm_json_object(raw)
+    if parsed is None:
         logger.warning("Failed to parse rubric JSON: %r", raw[:200])
-        return None
-    if not isinstance(parsed, dict):
         return None
     if not {"accuracy", "completeness", "clarity"}.issubset(parsed.keys()):
         logger.warning("Rubric JSON missing required keys: %s", set(parsed.keys()))
@@ -2195,18 +2193,49 @@ def _parse_rubric(raw: str) -> dict | None:
     return parsed
 
 
-def _parse_teachback_response(raw: str) -> dict:
-    """Strip markdown fences and parse JSON from LLM teachback response."""
-    cleaned = raw.strip()
-    if cleaned.startswith("```"):
-        lines = cleaned.splitlines()
-        cleaned = "\n".join(lines[1:-1]) if len(lines) > 2 else cleaned
+async def _mark_teachback_error(tb_id: str) -> None:
+    """Flag a teachback row as failed so the UI offers a retry."""
     try:
-        result = json.loads(cleaned)
-        return result if isinstance(result, dict) else {}
-    except (json.JSONDecodeError, ValueError):
+        async with get_session_factory()() as session:
+            result = await session.execute(
+                select(TeachbackResultModel).where(TeachbackResultModel.id == tb_id)
+            )
+            row = result.scalar_one_or_none()
+            if row:
+                row.status = "error"
+                await session.commit()
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to mark teachback %s as error", tb_id)
+
+
+async def _evaluate_teachback_llm(prompt: str) -> dict | None:
+    """Run the teachback evaluation, retrying once on an unparseable reply.
+
+    Local models drop a malformed object often enough that a single bad
+    completion should not cost the learner their score.
+    """
+    llm = get_llm_service()
+    for attempt in (1, 2):
+        raw = await llm.generate(prompt=prompt, system=_TEACHBACK_SYSTEM)
+        parsed = _parse_teachback_response(raw)
+        if parsed is not None:
+            return parsed
+        logger.warning("Teachback evaluation unparseable (attempt %d/2)", attempt)
+    return None
+
+
+def _parse_teachback_response(raw: str) -> dict | None:
+    """Parse the teachback rubric from an LLM completion. None when unparseable.
+
+    Never substitute a zero for a failed parse: the learner reads that as "you
+    got nothing right", it drags the session average down, and _score_to_rating
+    feeds it to FSRS as a failed card.
+    """
+    parsed = parse_llm_json_object(raw)
+    if parsed is None or "score" not in parsed:
         logger.warning("Failed to parse teachback JSON", extra={"raw": raw[:200]})
-        return {"score": 0, "correct_points": [], "missing_points": [], "misconceptions": []}
+        return None
+    return parsed
 
 
 async def _llm_correction_card_payload(

--- a/backend/tests/test_learning.py
+++ b/backend/tests/test_learning.py
@@ -100,11 +100,14 @@ def test_parse_teachback_response_strips_markdown_fences():
     assert result["score"] == 80
 
 
-def test_parse_teachback_response_returns_empty_on_bad_json():
-    """_parse_teachback_response returns zero-score empty dict on unparseable input."""
-    result = _parse_teachback_response("not valid JSON at all")
-    assert result.get("score", 0) == 0
-    assert result.get("correct_points", []) == []
+def test_parse_teachback_response_returns_none_on_bad_json():
+    """Unparseable input yields None, never a zero score.
+
+    A fabricated 0 is indistinguishable from a genuinely poor explanation: the
+    learner sees "you got nothing right", it drags the session average down,
+    and _score_to_rating hands it to FSRS as a lapse.
+    """
+    assert _parse_teachback_response("not valid JSON at all") is None
 
 
 # GET /study/gaps/{document_id} tests

--- a/backend/tests/test_teachback_rubric.py
+++ b/backend/tests/test_teachback_rubric.py
@@ -18,7 +18,7 @@ from app.database import make_engine
 from app.db_init import create_all_tables
 from app.main import app
 from app.models import FlashcardModel, TeachbackResultModel
-from app.routers.study import _parse_rubric
+from app.routers.study import _parse_rubric, _parse_teachback_response
 
 # Pure function tests for _parse_rubric
 
@@ -223,3 +223,30 @@ async def test_teachback_malformed_rubric_no_500(test_db):
     # Legacy fields still present
     assert "score" in body
     assert isinstance(body["score"], int)
+
+
+@pytest.mark.parametrize(
+    ("label", "raw", "expected"),
+    [
+        ("clean", '{"score": 45, "correct_points": []}', 45),
+        ("fenced", '```json\n{"score": 70, "correct_points": []}\n```', 70),
+        ("prose preamble", 'Here is my evaluation:\n{"score": 80}', 80),
+        ("trailing prose", '{"score": 55}\nHope this helps!', 55),
+        ("illegal escape", '{"score": 60, "evidence": "uses \\$ sign"}', 60),
+    ],
+)
+def test_parse_teachback_recovers_real_model_output(label, raw, expected):
+    """Each of these scored 0 before: the parser fenced-stripped then json.loads'd."""
+    parsed = _parse_teachback_response(raw)
+    assert parsed is not None, label
+    assert parsed["score"] == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ['{"score": 40, "correct_points": ["a', '{"correct_points": []}', "The student did well."],
+)
+def test_parse_teachback_returns_none_when_unreadable(raw):
+    """Never a fabricated 0: the learner reads it as "you got nothing right",
+    it drags the session average down, and it reaches FSRS as a failed card."""
+    assert _parse_teachback_response(raw) is None


### PR DESCRIPTION
Found while preparing the demo: a correct explanation of local-first benefits scored **0/100**, while the rubric rendered beside it gave real clarity feedback.

## Cause

Teach-back makes two independent LLM calls — one for the score, one for the rubric. The rubric parsed; the score call did not. `_parse_teachback_response` returned a hardcoded `{"score": 0}` on any JSON error, so a parse failure was indistinguishable from a genuinely worthless answer.

Re-running the exact reported explanation against the same card scored **45**, confirming the 0 was a parse artefact rather than a judgement.

The parser stripped markdown fences and then did a strict `json.loads`, so any of these was fatal:

| model output | before | after |
|---|---|---|
| prose preamble (`Here is my evaluation:\n{...}`) | 0 | parses |
| trailing prose (`{...}\nHope this helps!`) | 0 | parses |
| one illegal escape (`"uses \$ sign"`) | 0 | parses |
| truncated / no score key / not JSON | 0 | `None` |

## Impact beyond the wrong number

`score < 60` drives misconception creation, and `_score_to_rating(score)` feeds FSRS. On the reported session the bogus 0 put the card into `learning` with `lapses=1` — a fabricated failure written into the learner record.

## Fix

- Use the shared tolerant `parse_llm_json_object` (already used by the image and reference enrichers) instead of the bespoke strict parse.
- On unreadable output, retry the evaluation once — local models drop a malformed object often enough that one bad completion should not cost a score.
- If it still cannot be read, fail honestly rather than inventing a number: `503` on the sync path, `status="error"` on the async one. The UI already renders both as a retryable error (`error-${tempId}` / `isLatestError`).

## Tests

Two legacy tests asserted the old behaviour and were updated — one literally documented it (`returns zero-score empty dict on unparseable input`). New coverage pins both directions: five real model-output shapes that previously scored 0 now parse, and three genuinely unreadable ones return `None`.

Backend suite: **2159 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)