### PR TITLE
fix(images): recover vector-drawn figures from PDFs and degrade honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **PDFs whose figures are drawn rather than embedded now have a visual layer.**
+  A paper typeset from LaTeX draws its figures with path operators, so
+  `page.get_images()` returns nothing and the document previously extracted zero
+  images no matter how many figures it contained. When a page yields no raster
+  image, its drawing primitives are now clustered into figure regions on a coarse
+  occupancy grid and rasterized at 150 DPI. Primitives spanning the page (a
+  background wash, a page border) are excluded from clustering first — they would
+  otherwise bridge every figure into one whole-page region that the size guard
+  then discards, losing the real figures with it. Blank renders are dropped before
+  they cost a vision call. Off by `PDF_VECTOR_FIGURES=false`; capped at 4 figures
+  per page and 300 per document.
+- **Image extraction degrades honestly instead of failing the job.** A PDF that
+  cannot be opened (encrypted, truncated) left the document stuck mid-enrichment.
+  Extraction is now best-effort and runs off the event loop via `asyncio.to_thread`
+  — rasterizing a large PDF is seconds of CPU that the single-worker server used
+  to spend blocking every concurrent request. The reason a document has no figures
+  ("extraction failed …", "No images found") is recorded on the enrichment job
+  rather than presenting as a silently empty gallery.
+- **A truncated vision response no longer becomes the image's description.** A
+  local vision model that runs out of tokens mid-JSON used to have its half-written
+  object stored verbatim as the description text. `salvage_llm_json_object()`
+  now recovers the keys the model completed; when nothing is recoverable the
+  description is left null so the next `image_analyze` job retries the image
+  instead of indexing an unusable body. Repeated labels are deduplicated so one
+  looping block name cannot crowd out every other label.
+- **`POST /documents/{id}/images/reextract`** re-runs extraction on an
+  already-ingested document, so a library picks up extraction improvements without
+  re-uploading. Deduplicates on content hash; returns the in-flight job if one is
+  already queued.
+
 - **The Map's Tags view no longer stalls for ~7s** (and neither does anything
   else that happens to run alongside a graph query). Kuzu is synchronous, and
   the `/graph` handlers awaited it directly on the event loop; with a single
@@ -17,6 +47,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ~7.1s; `/tags/graph` alongside `/graph` drops from 8.58s to 0.034s. `/graph`
   itself is still slow (~8s for 4.3k nodes) — it just no longer blocks the app.
   I-2 extended to cover Kuzu, not just LanceDB.
+
+### Security
+- **Frontend dependency advisories: 38 → 6.** `npm audit fix` cleared the
+  in-range ones — `postcss`, `vite`, `immutable`, `js-yaml` (high), plus
+  `dompurify`, `esbuild`, `mermaid` and `@babel/core`. `react-router-dom` moved
+  6 → 7.18.2, closing both open-redirect advisories (protocol-relative `//` and
+  backslash in `<Link>`/`useNavigate`); the app uses only the component and hook
+  API, which is unchanged across that major.
+
+  The 6 that remain have no non-destructive fix and are accepted knowingly:
+  - `lodash-es` (×3) and `nanoid`, reached only through
+    `@excalidraw/excalidraw` → `mermaid-to-excalidraw`. Excalidraw 0.18.1 is the
+    latest release; npm's only offered "fix" is a **downgrade** to 0.17.6.
+  - `brace-expansion` DoS under `openapi-typescript` (7.13.0, also latest; the
+    offered fix is a downgrade to 6.x). Dev-only — it runs on our own schema
+    during `make regen-api-types` and ships nothing.
+  - `react-router` RSC-mode CSRF, which arrived *with* 7.18.2 and has no fixed
+    release. It applies only to React Server Components mode; this is a static
+    SPA with `BrowserRouter` and no server runtime. Downgrading to dodge it
+    would reinstate the two open-redirects that do apply.
 
 ### Changed
 - **Chat contradiction lookup filters in Cypher instead of Python.** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The notes preview now tracks the editor properly, at any zoom level.** Scroll
+  sync mapped one pane onto the other with a single global ratio
+  (`scrollTop / scrollMax`). That ratio is only correct at the very top and the
+  very bottom: the editor is monospace with one row per source line, while the
+  preview is serif prose whose block heights vary with headings, list spacing,
+  images and KaTeX — three tight source lines can render as one wrapped
+  paragraph while a five-item list expands into something far taller. Pixels per
+  source line therefore differ by region, and the preview drifted further behind
+  the more the two diverged. Browser zoom made it worse because it rewraps the
+  two panes by different amounts, and because integer `scrollHeight`/
+  `clientHeight` arithmetic rounds at fractional zoom.
+
+  Sync is now line-anchored. A rehype plugin stamps each rendered block with the
+  markdown line it came from, and a position converts between panes by
+  interpolating between the anchors bracketing it, so every region uses its own
+  measured pixels-per-line instead of a document-wide average. Offsets come from
+  `getBoundingClientRect`, which is sub-pixel and therefore zoom-correct. A
+  `ResizeObserver` re-syncs on zoom, window resize and splitter drags — none of
+  which change the note text, so the existing content-change effect never saw
+  them. Anchors are cached against a cheap signature rather than re-measured on
+  every scroll event. Notes split around diagrams keep one continuous line axis.
+  Previews without anchors (the blog dialogs, which wrap theirs in extra chrome)
+  fall back to the previous proportional behaviour.
 - **PDFs whose figures are drawn rather than embedded now have a visual layer.**
   A paper typeset from LaTeX draws its figures with path operators, so
   `page.get_images()` returns nothing and the document previously extracted zero

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ All settings are environment variables in `backend/.env` (gitignored).
 | `LITELLM_DEFAULT_MODEL` | `ollama/llama3.2` | LLM for chat, summaries, flashcards |
 | `OLLAMA_URL` | `http://127.0.0.1:11434` | Ollama server address |
 | `VISION_MODEL` | `ollama/qwen2.5vl:7b` | Model for image/figure analysis (optional, full mode only) |
+| `PDF_VECTOR_FIGURES` | `true` | Rasterize vector-drawn PDF figures (LaTeX papers embed no images) |
 | `LUMINARY_MODE` | `full` | `full` = every feature (what `make luminary` runs); `public` = curated learner surfaces, SPA + API on one port |
 | `GLINER_ENABLED` | `true` | Entity extraction (disable on <8 GB RAM) |
 | `DATA_DIR` | `.luminary` | Where databases and embeddings live |

--- a/README.md
+++ b/README.md
@@ -209,6 +209,18 @@ The library database schema is versioned with Alembic, and the server applies an
 
 Export options: Markdown vault (Obsidian-compatible), Anki deck (`.apkg`), flashcard CSV.
 
+### Re-extracting figures from an existing document
+
+Extraction improvements only apply to documents ingested after them. To re-run
+figure extraction on a document already in your library, without re-uploading it:
+
+```bash
+curl -X POST http://localhost:7820/documents/<document_id>/images/reextract
+```
+
+Extraction deduplicates on content hash, so this only adds figures the previous
+run missed. `GET /documents/<document_id>/enrichment` shows the job's progress.
+
 ---
 
 ## Make commands

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,6 +34,11 @@ ENRICHMENT_VISION_CONCURRENCY=@@VISION_CONCURRENCY@@
 #   ollama pull <model>
 # VISION_MODEL=ollama/qwen2.5vl:7b
 
+# Rasterize vector-drawn PDF figures when a page embeds no raster image.
+# Papers whose figures are drawn with path operators extract zero images
+# without it. Each recovered figure costs one vision call.
+# PDF_VECTOR_FIGURES=true
+
 # Disable on memory-constrained machines to avoid OOM during ingestion.
 GLINER_ENABLED=true
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -108,6 +108,11 @@ class Settings(BaseSettings):
     # pair with OLLAMA_NUM_PARALLEL so a single Ollama batches the calls. The install
     # profile sets this: public=1, standard=2, performance=4.
     ENRICHMENT_VISION_CONCURRENCY: int = 1
+    # Rasterize vector-drawn PDF figures when a page has no embedded raster image.
+    # LaTeX-authored papers draw figures with path operators, so without this they
+    # extract zero images. Costs a vision LLM call per recovered figure — turn off
+    # on a machine where enrichment throughput matters more than figure coverage.
+    PDF_VECTOR_FIGURES: bool = True
     GLINER_ENABLED: bool = True  # Set to false on memory-constrained machines (avoids OOM)
     # 2D.2: seed document auto-tags with entities from the graph extraction.
     # On by default -- no extra LLM calls; uses entities already populated by

--- a/backend/app/routers/images.py
+++ b/backend/app/routers/images.py
@@ -1,9 +1,10 @@
 """Images API router — .
 
 Endpoints:
-  GET /documents/{id}/images       -- paginated image list for a document
-  GET /images/{id}/raw             -- serve raw PNG file
-  GET /documents/{id}/enrichment   -- enrichment job list for a document
+  GET  /documents/{id}/images            -- paginated image list for a document
+  GET  /images/{id}/raw                  -- serve raw PNG file
+  POST /documents/{id}/images/reextract  -- re-run image extraction for a document
+  GET  /documents/{id}/enrichment        -- enrichment job list for a document
 """
 
 import json
@@ -44,6 +45,11 @@ class ImageListResponse(BaseModel):
     total: int
     page: int
     page_size: int
+
+
+class ReextractResponse(BaseModel):
+    job_id: str
+    queued: bool
 
 
 class EnrichmentJobItem(BaseModel):
@@ -205,6 +211,44 @@ async def serve_local_article_image(doc_id: str, filename: str) -> FileResponse:
     else:
         media_type = f"image/{ext}" if ext in ["png", "jpg", "jpeg", "gif", "webp"] else "image/png"
     return FileResponse(str(abs_path), media_type=media_type)
+
+
+@router.post("/documents/{document_id}/images/reextract", response_model=ReextractResponse)
+async def reextract_document_images(document_id: str) -> ReextractResponse:
+    """Queue a fresh image_extract job for a document.
+
+    Extraction dedupes on content hash, so this only adds figures the previous run
+    missed — the way an already-ingested document picks up an extraction improvement
+    without being re-uploaded. Returns the existing job when one is already queued.
+    """
+    async with get_session_factory()() as session:
+        await get_or_404(session, DocumentModel, document_id, name="Document")
+
+        existing = (
+            await session.execute(
+                select(EnrichmentJobModel)
+                .where(
+                    EnrichmentJobModel.document_id == document_id,
+                    EnrichmentJobModel.job_type == "image_extract",
+                    EnrichmentJobModel.status.in_(["pending", "running"]),
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            return ReextractResponse(job_id=existing.id, queued=False)
+
+        job = EnrichmentJobModel(
+            id=str(uuid.uuid4()),
+            document_id=document_id,
+            job_type="image_extract",
+            status="pending",
+        )
+        session.add(job)
+        await session.commit()
+
+    logger.info("reextract_document_images: queued job=%s doc=%s", job.id, document_id)
+    return ReextractResponse(job_id=job.id, queued=True)
 
 
 @router.get("/documents/{document_id}/enrichment", response_model=list[EnrichmentJobItem])

--- a/backend/app/services/image_enricher.py
+++ b/backend/app/services/image_enricher.py
@@ -33,7 +33,7 @@ from app.services import (
     vector_store as _vector_store_module,  # indirect: get_lancedb_service is patched
 )
 from app.services.llm import LLMUnavailableError, get_llm_service
-from app.services.llm_json import parse_llm_json_object
+from app.services.llm_json import parse_llm_json_object, salvage_llm_json_object
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +181,14 @@ def _merge_labels(parsed: dict) -> str:
     description = str(parsed.get("description") or "")
     labels = parsed.get("labels")
     if isinstance(labels, list):
-        clean = [str(label).strip() for label in labels if str(label).strip()]
+        # Order-preserving dedup: a model that loops on a repetitive diagram emits
+        # the same block name dozens of times and would crowd out the rest.
+        seen: dict[str, None] = {}
+        for label in labels:
+            text = str(label).strip()
+            if text:
+                seen.setdefault(text, None)
+        clean = list(seen)
         if clean:
             description = (
                 f"{description} Visible labels: {', '.join(clean[:_MAX_LABELS])}.".strip()
@@ -268,6 +275,21 @@ async def _call_vision_llm(image_path: Path, settings: object, context: str = ""
     parsed = parse_llm_json_object(raw)
     if parsed is not None:
         return parsed
+
+    # A local vision model that loops on a dense diagram hits the token limit
+    # mid-object. Keep the labels and type it did commit to rather than storing
+    # the half-written JSON blob verbatim as the image's description.
+    salvaged = salvage_llm_json_object(raw)
+    if salvaged is not None:
+        logger.warning(
+            "_call_vision_llm: response truncated; salvaged keys=%s", sorted(salvaged)
+        )
+        return salvaged
+
+    if raw.lstrip().startswith(("{", "[", "```")):
+        logger.warning("_call_vision_llm: unparseable JSON response, no description recovered")
+        return {}
+
     logger.warning("_call_vision_llm: JSON parse failed, using raw text as description")
     return {
         "image_type": "other",
@@ -339,6 +361,16 @@ class ImageEnricherService:
                         )
                         image_type = parsed.get("image_type") or "other"
                         description = _merge_labels(parsed) or ""
+                        if not description.strip():
+                            # Leaving description null keeps the image in the
+                            # un-described set, so the next image_analyze job
+                            # retries it instead of indexing an empty body.
+                            logger.warning(
+                                "image_enricher: no usable description for image_id=%s, "
+                                "leaving it for retry",
+                                img.id,
+                            )
+                            continue
 
                     # Embed description before any DB writes so a CPU/OOM failure
                     # does not leave the SQLite row updated without an FTS5 entry.

--- a/backend/app/services/image_enricher.py
+++ b/backend/app/services/image_enricher.py
@@ -181,8 +181,8 @@ def _merge_labels(parsed: dict) -> str:
     description = str(parsed.get("description") or "")
     labels = parsed.get("labels")
     if isinstance(labels, list):
-        # Order-preserving dedup: a model that loops on a repetitive diagram emits
-        # the same block name dozens of times and would crowd out the rest.
+        # Order-preserving dedup: a model looping on a repetitive diagram repeats
+        # one block name until it crowds every other label out of _MAX_LABELS.
         seen: dict[str, None] = {}
         for label in labels:
             text = str(label).strip()
@@ -276,14 +276,11 @@ async def _call_vision_llm(image_path: Path, settings: object, context: str = ""
     if parsed is not None:
         return parsed
 
-    # A local vision model that loops on a dense diagram hits the token limit
-    # mid-object. Keep the labels and type it did commit to rather than storing
-    # the half-written JSON blob verbatim as the image's description.
+    # Truncated mid-object: keep what the model committed to. The fallthrough
+    # below would otherwise store the half-written JSON as the description.
     salvaged = salvage_llm_json_object(raw)
     if salvaged is not None:
-        logger.warning(
-            "_call_vision_llm: response truncated; salvaged keys=%s", sorted(salvaged)
-        )
+        logger.warning("_call_vision_llm: response truncated; salvaged keys=%s", sorted(salvaged))
         return salvaged
 
     if raw.lstrip().startswith(("{", "[", "```")):

--- a/backend/app/services/image_extractor.py
+++ b/backend/app/services/image_extractor.py
@@ -1,7 +1,7 @@
 """PDF and EPUB image extraction service.
 
-Pure extraction logic — no DB writes.
-Called by image_extract_handler (enrichment job handler).
+The extract_images_* functions are pure — they read a file and write PNGs, never
+the DB. Only image_extract_handler (the enrichment job handler) touches SQLite.
 """
 
 import asyncio
@@ -29,13 +29,7 @@ _MIN_WIDTH = 150
 _MIN_HEIGHT = 100
 _MAX_DIM = 4000
 
-# Vector-figure fallback. A LaTeX-authored paper draws its figures with path
-# operators rather than embedding raster XObjects, so page.get_images() returns
-# nothing and the document ends up with no visual layer at all. When a page has
-# no extractable raster image we cluster its drawing primitives into figure
-# regions and rasterize those instead.
-#
-# Units are PDF points (1/72 inch) unless noted.
+# Vector-figure fallback tuning, in PDF points (1/72 inch) unless noted.
 _CLUSTER_CELL_PT = 6.0  # occupancy-grid resolution
 _CLUSTER_GAP_PT = 9.0  # primitives within this distance belong to one figure
 _CLIP_PAD_PT = 12.0  # captured around the cluster so edge labels survive
@@ -48,8 +42,7 @@ _VECTOR_RENDER_DPI = 150
 # line-art figures measure well below it, so real diagrams survive.
 _BLANK_DOMINANT_FRACTION = 0.99
 _MAX_VECTOR_FIGURES_PER_PAGE = 4
-# Runaway guard only: a 500-page textbook of plots legitimately reaches into the
-# hundreds, and every figure costs a vision LLM call downstream.
+# Runaway guard only; every recovered figure costs a vision LLM call downstream.
 _MAX_VECTOR_FIGURES_PER_DOC = 300
 
 
@@ -81,9 +74,7 @@ def _cluster_drawings(page) -> list:
 
     Primitive bounding boxes are painted onto a coarse occupancy grid, inflated by
     _CLUSTER_GAP_PT so the hundreds of short strokes making up one plot join into a
-    single blob, then connected components are read back as rectangles. This handles
-    both extremes seen in the wild: one large path covering a whole diagram, and a
-    thousand hairlines making up an attention heatmap.
+    single blob, then connected components are read back as rectangles.
 
     Returns fitz.Rect regions, largest first, already filtered to plausible figures.
     """
@@ -91,6 +82,7 @@ def _cluster_drawings(page) -> list:
     if page_rect.width <= 0 or page_rect.height <= 0:
         return []
 
+    page_area = page_rect.width * page_rect.height
     rects = []
     for drawing in page.get_drawings():
         raw_rect = drawing.get("rect")
@@ -98,6 +90,11 @@ def _cluster_drawings(page) -> list:
             continue
         rect = fitz.Rect(raw_rect) & page_rect
         if rect.is_empty or rect.width <= 0 or rect.height <= 0:
+            continue
+        # A background wash or page border spans the grid and would bridge every
+        # figure on the page into one component, which the same fraction check
+        # then discards -- losing the real figures with it.
+        if rect.get_area() > _MAX_FIGURE_PAGE_FRACTION * page_area:
             continue
         rects.append(rect)
     if not rects:
@@ -117,7 +114,6 @@ def _cluster_drawings(page) -> list:
                 occupied[row_base + cell_x] = 1
 
     visited = bytearray(cols * rows)
-    page_area = page_rect.width * page_rect.height
     figures: list = []
     for seed in range(cols * rows):
         if not occupied[seed] or visited[seed]:
@@ -240,10 +236,13 @@ def _extract_vector_figures_page(
     out_dir: Path,
     doc_id: str,
     seen_hashes: set[str],
+    limit: int,
 ) -> list[ExtractedImage]:
-    """Rasterize the vector-drawn figures on one page."""
+    """Rasterize up to `limit` of the vector-drawn figures on one page."""
     results: list[ExtractedImage] = []
     for fig_idx, bbox in enumerate(_cluster_drawings(page)):
+        if len(results) >= limit:
+            break
         # Drawing bounds exclude text, so axis labels and captions sitting just
         # outside the strokes are only captured by padding the clip.
         clip = fitz.Rect(
@@ -343,10 +342,15 @@ def extract_images_pdf(
                 results.append(stored)
                 page_results += 1
 
-        if page_results or not vector_fallback or vector_count >= _MAX_VECTOR_FIGURES_PER_DOC:
+        if page_results or not vector_fallback:
+            continue
+        budget = min(_MAX_VECTOR_FIGURES_PER_PAGE, _MAX_VECTOR_FIGURES_PER_DOC - vector_count)
+        if budget <= 0:
             continue
         try:
-            figures = _extract_vector_figures_page(page, page_idx, out_dir, doc_id, seen_hashes)
+            figures = _extract_vector_figures_page(
+                page, page_idx, out_dir, doc_id, seen_hashes, budget
+            )
         except Exception as exc:
             logger.warning(
                 "Vector figure detection failed doc=%s page=%d: %s", doc_id, page_idx, exc
@@ -467,7 +471,8 @@ async def _record_job_note(job_id: str, note: str) -> None:
     """Attach a diagnostic note to the job row.
 
     The worker overwrites status but not error_message, so a degraded-but-finished
-    job keeps its explanation while still reporting 'done'.
+    job keeps its explanation while still reporting 'done'. A note on a 'done' job
+    is therefore an explanation, not a failure -- readers must check status too.
     """
     try:
         async with _database_module.get_session_factory()() as session:
@@ -478,7 +483,7 @@ async def _record_job_note(job_id: str, note: str) -> None:
             )
             await session.commit()
     except Exception as exc:
-        logger.debug("image_extract_handler: could not record job note job=%s: %s", job_id, exc)
+        logger.warning("image_extract_handler: could not record job note job=%s: %s", job_id, exc)
 
 
 async def image_extract_handler(document_id: str, job_id: str) -> None:
@@ -522,14 +527,10 @@ async def image_extract_handler(document_id: str, job_id: str) -> None:
         logger.info("image_extract_handler: format %s has no image extraction", fmt)
         return
 
-    # Extraction is best-effort: a PDF we cannot open (encrypted, truncated) leaves
-    # the rest of the document perfectly usable, so it degrades to "no images" and
-    # lets the remaining enrichment run instead of failing the job. The cause is
-    # recorded so the enrichment endpoint can explain the missing figures rather
-    # than the library just showing none.
-    #
-    # Off-loop: parsing and rasterizing a large PDF is seconds of CPU, and the
-    # worker enriches several documents concurrently on the single server loop.
+    # Best-effort: an unreadable PDF still leaves the rest of the document usable,
+    # so degrade to "no images" with a recorded cause rather than failing the job.
+    # Off-loop because rasterizing a large PDF is seconds of CPU on the single
+    # server loop the worker shares with every live request.
     note: str | None = None
     try:
         if fmt == "pdf":

--- a/backend/app/services/image_extractor.py
+++ b/backend/app/services/image_extractor.py
@@ -4,9 +4,11 @@ Pure extraction logic — no DB writes.
 Called by image_extract_handler (enrichment job handler).
 """
 
+import asyncio
 import hashlib
 import logging
 import uuid
+from collections import deque
 from io import BytesIO
 from pathlib import Path
 
@@ -26,6 +28,29 @@ logger = logging.getLogger(__name__)
 _MIN_WIDTH = 150
 _MIN_HEIGHT = 100
 _MAX_DIM = 4000
+
+# Vector-figure fallback. A LaTeX-authored paper draws its figures with path
+# operators rather than embedding raster XObjects, so page.get_images() returns
+# nothing and the document ends up with no visual layer at all. When a page has
+# no extractable raster image we cluster its drawing primitives into figure
+# regions and rasterize those instead.
+#
+# Units are PDF points (1/72 inch) unless noted.
+_CLUSTER_CELL_PT = 6.0  # occupancy-grid resolution
+_CLUSTER_GAP_PT = 9.0  # primitives within this distance belong to one figure
+_CLIP_PAD_PT = 12.0  # captured around the cluster so edge labels survive
+_MIN_FIGURE_PT = 60.0  # smaller regions are rules, bullets and highlight boxes
+_MIN_FIGURE_PRIMITIVES = 3
+# A region covering nearly the whole page is a page frame or background wash.
+_MAX_FIGURE_PAGE_FRACTION = 0.85
+_VECTOR_RENDER_DPI = 150
+# One color covering this much of a render means an empty framed box. Sparse
+# line-art figures measure well below it, so real diagrams survive.
+_BLANK_DOMINANT_FRACTION = 0.99
+_MAX_VECTOR_FIGURES_PER_PAGE = 4
+# Runaway guard only: a 500-page textbook of plots legitimately reaches into the
+# hundreds, and every figure costs a vision LLM call downstream.
+_MAX_VECTOR_FIGURES_PER_DOC = 300
 
 
 class ExtractedImage:
@@ -51,10 +76,219 @@ class ExtractedImage:
         self.rel_path = rel_path
 
 
+def _cluster_drawings(page) -> list:
+    """Group a page's vector drawing primitives into candidate figure regions.
+
+    Primitive bounding boxes are painted onto a coarse occupancy grid, inflated by
+    _CLUSTER_GAP_PT so the hundreds of short strokes making up one plot join into a
+    single blob, then connected components are read back as rectangles. This handles
+    both extremes seen in the wild: one large path covering a whole diagram, and a
+    thousand hairlines making up an attention heatmap.
+
+    Returns fitz.Rect regions, largest first, already filtered to plausible figures.
+    """
+    page_rect = page.rect
+    if page_rect.width <= 0 or page_rect.height <= 0:
+        return []
+
+    rects = []
+    for drawing in page.get_drawings():
+        raw_rect = drawing.get("rect")
+        if raw_rect is None:
+            continue
+        rect = fitz.Rect(raw_rect) & page_rect
+        if rect.is_empty or rect.width <= 0 or rect.height <= 0:
+            continue
+        rects.append(rect)
+    if not rects:
+        return []
+
+    cols = int(page_rect.width / _CLUSTER_CELL_PT) + 1
+    rows = int(page_rect.height / _CLUSTER_CELL_PT) + 1
+    occupied = bytearray(cols * rows)
+    for rect in rects:
+        x0 = max(0, int((rect.x0 - page_rect.x0 - _CLUSTER_GAP_PT) / _CLUSTER_CELL_PT))
+        x1 = min(cols - 1, int((rect.x1 - page_rect.x0 + _CLUSTER_GAP_PT) / _CLUSTER_CELL_PT))
+        y0 = max(0, int((rect.y0 - page_rect.y0 - _CLUSTER_GAP_PT) / _CLUSTER_CELL_PT))
+        y1 = min(rows - 1, int((rect.y1 - page_rect.y0 + _CLUSTER_GAP_PT) / _CLUSTER_CELL_PT))
+        for cell_y in range(y0, y1 + 1):
+            row_base = cell_y * cols
+            for cell_x in range(x0, x1 + 1):
+                occupied[row_base + cell_x] = 1
+
+    visited = bytearray(cols * rows)
+    page_area = page_rect.width * page_rect.height
+    figures: list = []
+    for seed in range(cols * rows):
+        if not occupied[seed] or visited[seed]:
+            continue
+        visited[seed] = 1
+        queue = deque([seed])
+        min_x = max_x = seed % cols
+        min_y = max_y = seed // cols
+        while queue:
+            cell = queue.popleft()
+            cell_y, cell_x = divmod(cell, cols)
+            min_x, max_x = min(min_x, cell_x), max(max_x, cell_x)
+            min_y, max_y = min(min_y, cell_y), max(max_y, cell_y)
+            for delta_y, delta_x in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                next_y, next_x = cell_y + delta_y, cell_x + delta_x
+                if 0 <= next_y < rows and 0 <= next_x < cols:
+                    neighbour = next_y * cols + next_x
+                    if occupied[neighbour] and not visited[neighbour]:
+                        visited[neighbour] = 1
+                        queue.append(neighbour)
+
+        bbox = fitz.Rect(
+            page_rect.x0 + min_x * _CLUSTER_CELL_PT,
+            page_rect.y0 + min_y * _CLUSTER_CELL_PT,
+            page_rect.x0 + (max_x + 1) * _CLUSTER_CELL_PT,
+            page_rect.y0 + (max_y + 1) * _CLUSTER_CELL_PT,
+        ) & page_rect
+        if bbox.width < _MIN_FIGURE_PT or bbox.height < _MIN_FIGURE_PT:
+            continue
+        if bbox.get_area() > _MAX_FIGURE_PAGE_FRACTION * page_area:
+            continue
+        primitives = sum(
+            1
+            for rect in rects
+            if bbox.contains(fitz.Point((rect.x0 + rect.x1) / 2, (rect.y0 + rect.y1) / 2))
+        )
+        if primitives < _MIN_FIGURE_PRIMITIVES:
+            continue
+        figures.append(bbox)
+
+    figures.sort(key=lambda r: r.get_area(), reverse=True)
+    return figures[:_MAX_VECTOR_FIGURES_PER_PAGE]
+
+
+def _is_blank_render(img_pil: PILImage.Image) -> bool:
+    """True when a rasterized clip carries no ink worth analyzing.
+
+    Guard for the vector path only: clustering can fence off an empty framed box,
+    and a blank PNG would otherwise cost a vision LLM call. Mirrors the near-blank
+    rule the enricher applies to already-stored images, so nothing reaches the DB
+    that would be classified 'decorative' a step later.
+    """
+    try:
+        colors = img_pil.convert("RGB").getcolors(maxcolors=1 << 16)
+    except Exception:
+        return False
+    if colors is None:
+        return False
+    total = sum(count for count, _ in colors)
+    if total == 0:
+        return True
+    return max(count for count, _ in colors) / total > _BLANK_DOMINANT_FRACTION
+
+
+def _store_png(
+    img_pil: PILImage.Image,
+    content_hash: str,
+    seen_hashes: set[str],
+    out_dir: Path,
+    doc_id: str,
+    page_idx: int,
+    index: int,
+    filename: str,
+) -> ExtractedImage | None:
+    """Apply the shared size/dedup rules and write the PNG. None when rejected."""
+    if content_hash in seen_hashes:
+        return None
+
+    try:
+        w, h = img_pil.size
+    except Exception:
+        return None
+
+    if w < _MIN_WIDTH or h < _MIN_HEIGHT:
+        return None
+
+    if w > _MAX_DIM or h > _MAX_DIM:
+        logger.warning(
+            "Skipping oversized image doc=%s page=%d index=%d size=%dx%d",
+            doc_id,
+            page_idx,
+            index,
+            w,
+            h,
+        )
+        return None
+
+    abs_path = out_dir / filename
+    try:
+        img_pil.save(str(abs_path), format="PNG")
+    except Exception as exc:
+        logger.warning("Could not save PNG doc=%s page=%d: %s", doc_id, page_idx, exc)
+        return None
+
+    seen_hashes.add(content_hash)
+    return ExtractedImage(
+        page=page_idx,
+        index=index,
+        width=w,
+        height=h,
+        content_hash=content_hash,
+        abs_path=abs_path,
+        rel_path=f"images/{doc_id}/{filename}",
+    )
+
+
+def _extract_vector_figures_page(
+    page,
+    page_idx: int,
+    out_dir: Path,
+    doc_id: str,
+    seen_hashes: set[str],
+) -> list[ExtractedImage]:
+    """Rasterize the vector-drawn figures on one page."""
+    results: list[ExtractedImage] = []
+    for fig_idx, bbox in enumerate(_cluster_drawings(page)):
+        # Drawing bounds exclude text, so axis labels and captions sitting just
+        # outside the strokes are only captured by padding the clip.
+        clip = fitz.Rect(
+            bbox.x0 - _CLIP_PAD_PT,
+            bbox.y0 - _CLIP_PAD_PT,
+            bbox.x1 + _CLIP_PAD_PT,
+            bbox.y1 + _CLIP_PAD_PT,
+        ) & page.rect
+        try:
+            raw_bytes = page.get_pixmap(clip=clip, dpi=_VECTOR_RENDER_DPI).tobytes("png")
+            img_pil = PILImage.open(BytesIO(raw_bytes))
+            img_pil.load()
+        except Exception as exc:
+            logger.warning(
+                "Vector figure render failed doc=%s page=%d index=%d: %s",
+                doc_id,
+                page_idx,
+                fig_idx,
+                exc,
+            )
+            continue
+
+        if _is_blank_render(img_pil):
+            continue
+
+        stored = _store_png(
+            img_pil,
+            hashlib.sha256(raw_bytes).hexdigest(),
+            seen_hashes,
+            out_dir,
+            doc_id,
+            page_idx,
+            fig_idx,
+            f"{page_idx}_v{fig_idx}.png",
+        )
+        if stored is not None:
+            results.append(stored)
+    return results
+
+
 def extract_images_pdf(
     file_path: Path,
     images_dir: Path,
     doc_id: str,
+    vector_fallback: bool = True,
 ) -> list[ExtractedImage]:
     """Extract images from a PDF file.
 
@@ -63,16 +297,22 @@ def extract_images_pdf(
     Skips images outside the 150x100 to 4000x4000 bounds.
     Deduplicates via SHA-256 hash within this document.
     Returns list of ExtractedImage value objects (does NOT write to DB).
+
+    When a page yields no raster image and vector_fallback is on, its vector
+    drawings are clustered into figure regions and rasterized instead — without
+    this, a LaTeX-authored paper extracts zero images however many figures it has.
     """
     out_dir = images_dir / doc_id
     out_dir.mkdir(parents=True, exist_ok=True)
     results: list[ExtractedImage] = []
     seen_hashes: set[str] = set()
+    vector_count = 0
 
     doc = fitz.open(str(file_path))
     for page_idx in range(len(doc)):
         page = doc[page_idx]
         image_list = page.get_images(full=True)
+        page_results = 0
         for img_idx, img_info in enumerate(image_list):
             xref = img_info[0]
             try:
@@ -84,58 +324,45 @@ def extract_images_pdf(
                 continue
 
             raw_bytes = img_data["image"]
-            content_hash = hashlib.sha256(raw_bytes).hexdigest()
-            if content_hash in seen_hashes:
-                continue
-
             try:
                 img_pil = PILImage.open(BytesIO(raw_bytes))
-                w, h = img_pil.size
             except Exception:
                 continue
 
-            if w < _MIN_WIDTH or h < _MIN_HEIGHT:
-                continue
-
-            if w > _MAX_DIM or h > _MAX_DIM:
-                logger.warning(
-                    "Skipping oversized image doc=%s page=%d index=%d size=%dx%d",
-                    doc_id,
-                    page_idx,
-                    img_idx,
-                    w,
-                    h,
-                )
-                continue
-
-            rel_path = f"images/{doc_id}/{page_idx}_{img_idx}.png"
-            abs_path = out_dir / f"{page_idx}_{img_idx}.png"
-            try:
-                img_pil.save(str(abs_path), format="PNG")
-            except Exception as exc:
-                logger.warning("Could not save PNG doc=%s page=%d: %s", doc_id, page_idx, exc)
-                continue
-
-            seen_hashes.add(content_hash)
-            results.append(
-                ExtractedImage(
-                    page=page_idx,
-                    index=img_idx,
-                    width=w,
-                    height=h,
-                    content_hash=content_hash,
-                    abs_path=abs_path,
-                    rel_path=rel_path,
-                )
+            stored = _store_png(
+                img_pil,
+                hashlib.sha256(raw_bytes).hexdigest(),
+                seen_hashes,
+                out_dir,
+                doc_id,
+                page_idx,
+                img_idx,
+                f"{page_idx}_{img_idx}.png",
             )
+            if stored is not None:
+                results.append(stored)
+                page_results += 1
+
+        if page_results or not vector_fallback or vector_count >= _MAX_VECTOR_FIGURES_PER_DOC:
+            continue
+        try:
+            figures = _extract_vector_figures_page(page, page_idx, out_dir, doc_id, seen_hashes)
+        except Exception as exc:
+            logger.warning(
+                "Vector figure detection failed doc=%s page=%d: %s", doc_id, page_idx, exc
+            )
+            continue
+        vector_count += len(figures)
+        results.extend(figures)
 
     page_count = len(doc)
     doc.close()
     logger.info(
-        "PDF image extraction complete doc=%s pages=%d images=%d",
+        "PDF image extraction complete doc=%s pages=%d images=%d (vector figures=%d)",
         doc_id,
         page_count,
         len(results),
+        vector_count,
     )
     return results
 
@@ -165,50 +392,24 @@ def extract_images_epub(
     img_idx = 0
     for item in book.get_items_of_type(ebooklib.ITEM_IMAGE):
         raw_bytes = item.get_content()
-        content_hash = hashlib.sha256(raw_bytes).hexdigest()
-        if content_hash in seen_hashes:
-            continue
-
         try:
             img_pil = PILImage.open(BytesIO(raw_bytes))
-            w, h = img_pil.size
         except Exception:
             continue
 
-        if w < _MIN_WIDTH or h < _MIN_HEIGHT:
-            continue
-
-        if w > _MAX_DIM or h > _MAX_DIM:
-            logger.warning(
-                "Skipping oversized EPUB image doc=%s index=%d size=%dx%d",
-                doc_id,
-                img_idx,
-                w,
-                h,
-            )
-            continue
-
-        rel_path = f"images/{doc_id}/epub_{img_idx}.png"
-        abs_path = out_dir / f"epub_{img_idx}.png"
-        try:
-            img_pil.save(str(abs_path), format="PNG")
-        except Exception as exc:
-            logger.warning("Could not save EPUB PNG doc=%s: %s", doc_id, exc)
-            continue
-
-        seen_hashes.add(content_hash)
-        results.append(
-            ExtractedImage(
-                page=0,  # EPUB has no page numbers
-                index=img_idx,
-                width=w,
-                height=h,
-                content_hash=content_hash,
-                abs_path=abs_path,
-                rel_path=rel_path,
-            )
+        stored = _store_png(
+            img_pil,
+            hashlib.sha256(raw_bytes).hexdigest(),
+            seen_hashes,
+            out_dir,
+            doc_id,
+            0,  # EPUB has no page numbers
+            img_idx,
+            f"epub_{img_idx}.png",
         )
-        img_idx += 1
+        if stored is not None:
+            results.append(stored)
+            img_idx += 1
 
     logger.info("EPUB image extraction complete doc=%s images=%d", doc_id, len(results))
     return results
@@ -262,6 +463,24 @@ def extract_images_md(
     return results
 
 
+async def _record_job_note(job_id: str, note: str) -> None:
+    """Attach a diagnostic note to the job row.
+
+    The worker overwrites status but not error_message, so a degraded-but-finished
+    job keeps its explanation while still reporting 'done'.
+    """
+    try:
+        async with _database_module.get_session_factory()() as session:
+            await session.execute(
+                _update(EnrichmentJobModel)
+                .where(EnrichmentJobModel.id == job_id)
+                .values(error_message=note)
+            )
+            await session.commit()
+    except Exception as exc:
+        logger.debug("image_extract_handler: could not record job note job=%s: %s", job_id, exc)
+
+
 async def image_extract_handler(document_id: str, job_id: str) -> None:
     """Enrichment handler for job_type='image_extract'.
 
@@ -299,15 +518,56 @@ async def image_extract_handler(document_id: str, job_id: str) -> None:
     fmt = doc.format.lower()
     file_path = Path(doc.file_path)
 
-    if fmt == "pdf":
-        extracted = extract_images_pdf(file_path, images_dir, document_id)
-    elif fmt == "epub":
-        extracted = extract_images_epub(file_path, images_dir, document_id)
-    elif fmt in ("md", "markdown"):
-        extracted = extract_images_md(images_dir, document_id)
-    else:
+    if fmt not in ("pdf", "epub", "md", "markdown"):
         logger.info("image_extract_handler: format %s has no image extraction", fmt)
         return
+
+    # Extraction is best-effort: a PDF we cannot open (encrypted, truncated) leaves
+    # the rest of the document perfectly usable, so it degrades to "no images" and
+    # lets the remaining enrichment run instead of failing the job. The cause is
+    # recorded so the enrichment endpoint can explain the missing figures rather
+    # than the library just showing none.
+    #
+    # Off-loop: parsing and rasterizing a large PDF is seconds of CPU, and the
+    # worker enriches several documents concurrently on the single server loop.
+    note: str | None = None
+    try:
+        if fmt == "pdf":
+            extracted = await asyncio.to_thread(
+                extract_images_pdf,
+                file_path,
+                images_dir,
+                document_id,
+                settings.PDF_VECTOR_FIGURES,
+            )
+        elif fmt == "epub":
+            extracted = await asyncio.to_thread(
+                extract_images_epub, file_path, images_dir, document_id
+            )
+        else:
+            extracted = extract_images_md(images_dir, document_id)
+    except Exception as exc:
+        extracted = []
+        note = (
+            f"Image extraction failed ({type(exc).__name__}: {exc}); "
+            "document indexed without images."
+        )
+        logger.warning(
+            "image_extract_handler: extraction failed doc=%s format=%s -- %s",
+            document_id,
+            fmt,
+            exc,
+            exc_info=exc,
+        )
+
+    if note is None and not extracted and not existing_hashes:
+        note = "No images found in this document."
+        logger.warning(
+            "image_extract_handler: no images extracted doc=%s format=%s", document_id, fmt
+        )
+
+    if note is not None:
+        await _record_job_note(job_id, note)
 
     def _find_nearest_chunk(page: int) -> str | None:
         best_id: str | None = None

--- a/backend/app/services/llm_json.py
+++ b/backend/app/services/llm_json.py
@@ -74,6 +74,57 @@ def parse_llm_json_object(raw: str) -> dict | None:
     return None
 
 
+def salvage_llm_json_object(raw: str) -> dict | None:
+    """Recover the complete key/value pairs of a truncated JSON object.
+
+    The object counterpart of the array salvage: decoding stops at the first pair
+    that was cut off mid-generation, keeping everything the model had already
+    committed to. Kept out of parse_llm_json_object because a partial object is a
+    lossy result its callers should opt into knowingly.
+
+    Returns None when not even one pair is recoverable.
+    """
+    text = _repair_escapes(_strip_fences(raw))
+    start = text.find("{")
+    if start == -1:
+        return None
+
+    decoder = json.JSONDecoder()
+    i = start + 1
+    n = len(text)
+    out: dict = {}
+    while i < n:
+        while i < n and text[i] in " \t\r\n,":
+            i += 1
+        if i >= n or text[i] == "}":
+            break
+        try:
+            key, i = decoder.raw_decode(text, i)
+        except ValueError:
+            break
+        while i < n and text[i] in " \t\r\n":
+            i += 1
+        if i >= n or text[i] != ":":
+            break
+        i += 1
+        # raw_decode does not skip leading whitespace of its own.
+        while i < n and text[i] in " \t\r\n":
+            i += 1
+        try:
+            value, i = decoder.raw_decode(text, i)
+        except ValueError:
+            # The cut landed inside the value. An array still has complete
+            # elements worth keeping -- that is where a label list gets lost.
+            if i < n and text[i] == "[":
+                salvaged = _salvage_elements(text[i:])
+                if salvaged and isinstance(key, str):
+                    out[key] = salvaged
+            break
+        if isinstance(key, str):
+            out[key] = value
+    return out or None
+
+
 def parse_llm_json_array(raw: str) -> list:
     """Extract a JSON array from an LLM completion, tolerating markdown
     fences, surrounding prose, illegal escape sequences, and truncation.

--- a/backend/app/services/llm_json.py
+++ b/backend/app/services/llm_json.py
@@ -1,4 +1,4 @@
-"""Tolerant parsing of JSON arrays out of LLM completions.
+"""Tolerant parsing of JSON objects and arrays out of LLM completions.
 
 Local models routinely wrap JSON in markdown fences or prose, emit string
 content containing backslash sequences that are not legal JSON escapes, or
@@ -28,6 +28,14 @@ def _strip_fences(text: str) -> str:
     return cleaned
 
 
+def _skip(text: str, i: int, chars: str = " \t\r\n") -> int:
+    """Advance past `chars`. raw_decode does not skip leading whitespace itself."""
+    n = len(text)
+    while i < n and text[i] in chars:
+        i += 1
+    return i
+
+
 def _salvage_elements(text: str) -> list:
     """Decode complete top-level elements from a (possibly truncated) array,
     stopping at the first element that cannot be decoded."""
@@ -39,8 +47,7 @@ def _salvage_elements(text: str) -> list:
     items: list = []
     n = len(text)
     while i < n:
-        while i < n and text[i] in " \t\r\n,":
-            i += 1
+        i = _skip(text, i, " \t\r\n,")
         if i >= n or text[i] == "]":
             break
         try:
@@ -55,9 +62,8 @@ def parse_llm_json_object(raw: str) -> dict | None:
     """Extract a JSON object from an LLM completion, tolerating markdown
     fences, surrounding prose, and illegal escape sequences.
 
-    Returns None when no object is recoverable (truncated objects are not
-    salvaged: unlike array elements, a partial object has no complete
-    sub-units to keep).
+    All-or-nothing: a truncated object returns None here. Callers willing to
+    accept a partial result opt into salvage_llm_json_object instead.
     """
     cleaned = _strip_fences(raw)
     start = cleaned.find("{")
@@ -94,22 +100,17 @@ def salvage_llm_json_object(raw: str) -> dict | None:
     n = len(text)
     out: dict = {}
     while i < n:
-        while i < n and text[i] in " \t\r\n,":
-            i += 1
+        i = _skip(text, i, " \t\r\n,")
         if i >= n or text[i] == "}":
             break
         try:
             key, i = decoder.raw_decode(text, i)
         except ValueError:
             break
-        while i < n and text[i] in " \t\r\n":
-            i += 1
+        i = _skip(text, i)
         if i >= n or text[i] != ":":
             break
-        i += 1
-        # raw_decode does not skip leading whitespace of its own.
-        while i < n and text[i] in " \t\r\n":
-            i += 1
+        i = _skip(text, i + 1)
         try:
             value, i = decoder.raw_decode(text, i)
         except ValueError:

--- a/backend/tests/test_image_enricher.py
+++ b/backend/tests/test_image_enricher.py
@@ -830,6 +830,116 @@ def test_merge_labels_ignores_missing_or_invalid() -> None:
     assert _merge_labels({"description": "A chart.", "labels": []}) == "A chart."
 
 
+def test_merge_labels_dedupes_repeated_labels() -> None:
+    from app.services.image_enricher import _merge_labels
+
+    parsed = {
+        "description": "An encoder stack.",
+        "labels": ["Add & Norm", "Feed Forward", "Add & Norm", "Feed Forward", "Add & Norm"],
+    }
+    assert _merge_labels(parsed) == (
+        "An encoder stack. Visible labels: Add & Norm, Feed Forward."
+    )
+
+
+@pytest.mark.asyncio
+async def test_truncated_vision_response_is_salvaged(tmp_path: Path) -> None:
+    """A response cut off mid-JSON keeps the type and labels it committed to.
+
+    Storing the half-written blob verbatim is what previously left a paper's
+    flagship diagram typed 'other' with unusable JSON as its description.
+    """
+    from app.services.image_enricher import _call_vision_llm
+
+    img_path = tmp_path / "figure.png"
+    _make_varied_png(img_path)
+
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = (
+        '```json\n{"image_type": "architecture_diagram", '
+        '"labels": ["Softmax", "Linear", "Add & Norm"], "descrip'
+    )
+
+    with patch("app.services.llm.litellm.acompletion", new_callable=AsyncMock) as mock_llm:
+        mock_llm.return_value = mock_response
+        settings = MagicMock()
+        settings.VISION_MODEL = "ollama/llava:7b"
+        settings.OLLAMA_URL = "http://localhost:11434"
+        settings.LITELLM_DEFAULT_MODEL = "ollama/gemma4"
+
+        parsed = await _call_vision_llm(img_path, settings, "")
+
+    assert parsed["image_type"] == "architecture_diagram"
+    assert parsed["labels"] == ["Softmax", "Linear", "Add & Norm"]
+    assert "description" not in parsed
+
+
+@pytest.mark.asyncio
+async def test_unsalvageable_json_response_is_not_stored_as_description(tmp_path: Path) -> None:
+    """Nothing recoverable means no description -- not a JSON blob as the body."""
+    from app.services.image_enricher import _call_vision_llm
+
+    img_path = tmp_path / "figure.png"
+    _make_varied_png(img_path)
+
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = '```json\n{"image_ty'
+
+    with patch("app.services.llm.litellm.acompletion", new_callable=AsyncMock) as mock_llm:
+        mock_llm.return_value = mock_response
+        settings = MagicMock()
+        settings.VISION_MODEL = "ollama/llava:7b"
+        settings.OLLAMA_URL = "http://localhost:11434"
+        settings.LITELLM_DEFAULT_MODEL = "ollama/gemma4"
+
+        parsed = await _call_vision_llm(img_path, settings, "")
+
+    assert parsed == {}
+
+
+@pytest.mark.asyncio
+async def test_undescribable_image_left_null_for_retry(
+    doc_and_image, session_factory, tmp_path: Path
+) -> None:
+    """An image with no usable description stays un-described so it is retried."""
+    doc_id, image_id, img_path, data_dir = doc_and_image
+
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = '```json\n{"image_ty'
+
+    mock_lancedb = MagicMock()
+    mock_embedder = MagicMock()
+    mock_embedder.encode.return_value = [[0.1] * 384]
+
+    with (
+        patch("app.services.llm.litellm.acompletion", new_callable=AsyncMock) as mock_llm,
+        patch("app.database.get_session_factory", return_value=session_factory),
+        patch("app.config.get_settings") as mock_settings,
+        patch("app.services.vector_store.get_lancedb_service", return_value=mock_lancedb),
+        patch("app.services.embedder.get_embedding_service", return_value=mock_embedder),
+    ):
+        mock_llm.return_value = mock_response
+        settings = MagicMock()
+        settings.DATA_DIR = str(data_dir)
+        settings.VISION_MODEL = "ollama/llava:7b"
+        settings.OLLAMA_URL = "http://localhost:11434"
+        settings.LITELLM_DEFAULT_MODEL = "ollama/gemma4"
+        mock_settings.return_value = settings
+
+        count = await ImageEnricherService().enrich(doc_id)
+
+    assert count == 0
+    mock_lancedb.upsert_image_vector.assert_not_called()
+
+    from sqlalchemy import select  # noqa: PLC0415
+
+    async with session_factory() as session:
+        row = (
+            await session.execute(select(ImageModel).where(ImageModel.id == image_id))
+        ).scalar_one()
+        assert row.description is None, "Null description keeps the image in the retry set"
+
+
 @pytest.mark.asyncio
 async def test_vision_call_includes_context_when_given(tmp_path: Path) -> None:
     from app.services.image_enricher import _call_vision_llm

--- a/backend/tests/test_image_extractor.py
+++ b/backend/tests/test_image_extractor.py
@@ -117,7 +117,9 @@ def test_min_size_constants():
     assert _MAX_DIM == 4000
 
 
-def _pdf_with_vector_figure(path: Path, *, with_raster: bool = False) -> Path:
+def _pdf_with_vector_figure(
+    path: Path, *, with_raster: bool = False, with_background: bool = False
+) -> Path:
     """Write a one-page PDF whose only figure is drawn with vector strokes.
 
     This is the LaTeX/TikZ shape: the figure exists but page.get_images() sees
@@ -125,6 +127,8 @@ def _pdf_with_vector_figure(path: Path, *, with_raster: bool = False) -> Path:
     """
     doc = fitz.open()
     page = doc.new_page()
+    if with_background:
+        page.draw_rect(page.rect, color=(0.95, 0.95, 0.95), fill=(0.95, 0.95, 0.95))
     page.insert_text(fitz.Point(72, 60), "Figure 1: a vector-drawn diagram")
     for row in range(12):
         for col in range(12):
@@ -147,6 +151,21 @@ def test_vector_figure_extracted_when_page_has_no_raster(tmp_path):
     assert len(results) == 1, "The vector figure should have been recovered"
     assert results[0].abs_path.exists()
     assert "_v" in results[0].abs_path.name, "Vector figures use the _v filename marker"
+
+
+def test_page_spanning_primitive_does_not_swallow_the_figure(tmp_path):
+    """A background wash must not bridge every cluster into one rejected region.
+
+    The wash spans the occupancy grid, so without excluding it up front the
+    figure merges into a whole-page component that the page-fraction guard then
+    discards -- taking the real figure with it.
+    """
+    pdf = _pdf_with_vector_figure(tmp_path / "washed.pdf", with_background=True)
+
+    results = extract_images_pdf(pdf, tmp_path / "out", "wash-doc")
+
+    assert len(results) == 1, "The figure must survive a full-page background"
+    assert "_v" in results[0].abs_path.name
 
 
 def test_vector_fallback_can_be_disabled(tmp_path):

--- a/backend/tests/test_image_extractor.py
+++ b/backend/tests/test_image_extractor.py
@@ -5,9 +5,22 @@ from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import fitz
+import pytest
+import pytest_asyncio
 from PIL import Image as PILImage
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
 
-from app.services.image_extractor import _MAX_DIM, _MIN_HEIGHT, _MIN_WIDTH, extract_images_pdf
+from app.models import Base, DocumentModel, EnrichmentJobModel
+from app.services.image_extractor import (
+    _MAX_DIM,
+    _MIN_HEIGHT,
+    _MIN_WIDTH,
+    extract_images_pdf,
+    image_extract_handler,
+)
 
 
 def _make_png_bytes(w: int, h: int, color: tuple[int, int, int] = (200, 200, 200)) -> bytes:
@@ -33,6 +46,7 @@ def _mock_fitz_doc(images_per_page: list[list[bytes]]):
             page_image_list.append((xref, 0, 0, 0, 8, "", "", ""))
         mock_page = MagicMock()
         mock_page.get_images.return_value = page_image_list
+        mock_page.get_drawings.return_value = []
         pages.append(mock_page)
 
     mock_doc = MagicMock()
@@ -101,3 +115,194 @@ def test_min_size_constants():
     assert _MIN_WIDTH == 150
     assert _MIN_HEIGHT == 100
     assert _MAX_DIM == 4000
+
+
+def _pdf_with_vector_figure(path: Path, *, with_raster: bool = False) -> Path:
+    """Write a one-page PDF whose only figure is drawn with vector strokes.
+
+    This is the LaTeX/TikZ shape: the figure exists but page.get_images() sees
+    nothing because no raster XObject was ever embedded.
+    """
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text(fitz.Point(72, 60), "Figure 1: a vector-drawn diagram")
+    for row in range(12):
+        for col in range(12):
+            x = 150 + col * 18
+            y = 200 + row * 18
+            page.draw_line(fitz.Point(x, y), fitz.Point(x + 14, y + 14), color=(0, 0, 0), width=1)
+    if with_raster:
+        page.insert_image(fitz.Rect(150, 500, 450, 700), stream=_make_png_bytes(300, 200))
+    doc.save(str(path))
+    doc.close()
+    return path
+
+
+def test_vector_figure_extracted_when_page_has_no_raster(tmp_path):
+    """A vector-drawn figure must be rasterized when get_images() finds nothing."""
+    pdf = _pdf_with_vector_figure(tmp_path / "vector.pdf")
+
+    results = extract_images_pdf(pdf, tmp_path / "out", "vec-doc")
+
+    assert len(results) == 1, "The vector figure should have been recovered"
+    assert results[0].abs_path.exists()
+    assert "_v" in results[0].abs_path.name, "Vector figures use the _v filename marker"
+
+
+def test_vector_fallback_can_be_disabled(tmp_path):
+    """vector_fallback=False restores raster-only behaviour."""
+    pdf = _pdf_with_vector_figure(tmp_path / "vector.pdf")
+
+    results = extract_images_pdf(pdf, tmp_path / "out", "vec-doc", vector_fallback=False)
+
+    assert results == []
+
+
+def test_vector_fallback_skipped_when_page_has_raster(tmp_path):
+    """A page that already yielded a raster image is not rasterized again."""
+    pdf = _pdf_with_vector_figure(tmp_path / "mixed.pdf", with_raster=True)
+
+    results = extract_images_pdf(pdf, tmp_path / "out", "mixed-doc")
+
+    assert len(results) == 1
+    assert "_v" not in results[0].abs_path.name
+
+
+def test_rules_and_underlines_are_not_figures(tmp_path):
+    """Header rules and text underlines must not be mistaken for figures."""
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text(fitz.Point(72, 100), "A page of prose with a header rule")
+    page.draw_line(fitz.Point(72, 80), fitz.Point(520, 80), width=0.8)
+    page.draw_line(fitz.Point(72, 300), fitz.Point(180, 300), width=0.8)
+    page.draw_line(fitz.Point(72, 500), fitz.Point(240, 500), width=0.8)
+    pdf = tmp_path / "prose.pdf"
+    doc.save(str(pdf))
+    doc.close()
+
+    results = extract_images_pdf(pdf, tmp_path / "out", "prose-doc")
+
+    assert results == [], "Rule lines are not figures"
+
+
+@pytest_asyncio.fixture
+async def handler_db():
+    """In-memory SQLite engine with all tables created."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+async def _seed_doc_and_job(factory, doc_id: str, job_id: str, file_path: Path):
+    async with factory() as session:
+        session.add(
+            DocumentModel(
+                id=doc_id,
+                title="Broken PDF",
+                file_path=str(file_path),
+                format="pdf",
+                content_type="paper",
+                stage="enriching",
+            )
+        )
+        session.add(
+            EnrichmentJobModel(
+                id=job_id,
+                document_id=doc_id,
+                job_type="image_extract",
+                status="running",
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_handler_degrades_when_pdf_cannot_be_opened(handler_db, tmp_path):
+    """An unreadable PDF must leave the document usable, not stuck enriching."""
+    doc_id, job_id = "doc-broken", "job-broken"
+    bad_pdf = tmp_path / "broken.pdf"
+    bad_pdf.write_bytes(b"not really a pdf")
+    await _seed_doc_and_job(handler_db, doc_id, job_id, bad_pdf)
+
+    with (
+        patch("app.database.get_session_factory", return_value=handler_db),
+        patch("app.config.get_settings") as mock_settings,
+    ):
+        settings = MagicMock()
+        settings.DATA_DIR = str(tmp_path)
+        settings.PDF_VECTOR_FIGURES = True
+        mock_settings.return_value = settings
+
+        await image_extract_handler(doc_id, job_id)
+
+    async with handler_db() as session:
+        doc = (
+            await session.execute(select(DocumentModel).where(DocumentModel.id == doc_id))
+        ).scalar_one()
+        job = (
+            await session.execute(
+                select(EnrichmentJobModel).where(EnrichmentJobModel.id == job_id)
+            )
+        ).scalar_one()
+
+    assert doc.stage == "complete", "The handler must finish rather than abort on the error"
+    assert job.error_message and "Image extraction failed" in job.error_message
+
+
+@pytest.mark.asyncio
+async def test_handler_notes_when_a_pdf_yields_no_images(handler_db, tmp_path):
+    """A silently image-free document gets an explanation on its job."""
+    doc_id, job_id = "doc-empty", "job-empty"
+    doc = fitz.open()
+    doc.new_page().insert_text(fitz.Point(72, 100), "Prose only, no figures.")
+    empty_pdf = tmp_path / "prose.pdf"
+    doc.save(str(empty_pdf))
+    doc.close()
+    await _seed_doc_and_job(handler_db, doc_id, job_id, empty_pdf)
+
+    with (
+        patch("app.database.get_session_factory", return_value=handler_db),
+        patch("app.config.get_settings") as mock_settings,
+    ):
+        settings = MagicMock()
+        settings.DATA_DIR = str(tmp_path)
+        settings.PDF_VECTOR_FIGURES = True
+        mock_settings.return_value = settings
+
+        await image_extract_handler(doc_id, job_id)
+
+    async with handler_db() as session:
+        job = (
+            await session.execute(
+                select(EnrichmentJobModel).where(EnrichmentJobModel.id == job_id)
+            )
+        ).scalar_one()
+        stage = (
+            await session.execute(select(DocumentModel.stage).where(DocumentModel.id == doc_id))
+        ).scalar_one()
+
+    assert stage == "complete"
+    assert job.error_message == "No images found in this document."
+
+
+def test_blank_render_is_not_stored(tmp_path):
+    """A region that rasterizes to a flat wash must not cost a vision call.
+
+    Figure backgrounds are often drawn as a filled white rectangle; clustering
+    fences one off like any other primitive, but there is nothing in it to see.
+    """
+    doc = fitz.open()
+    page = doc.new_page()
+    page.draw_rect(fitz.Rect(150, 200, 450, 400), color=(1, 1, 1), fill=(1, 1, 1))
+    page.draw_rect(fitz.Rect(155, 205, 445, 395), color=(1, 1, 1), fill=(1, 1, 1))
+    page.draw_rect(fitz.Rect(160, 210, 440, 390), color=(1, 1, 1), fill=(1, 1, 1))
+    pdf = tmp_path / "blank_box.pdf"
+    doc.save(str(pdf))
+    doc.close()
+
+    results = extract_images_pdf(pdf, tmp_path / "out", "blank-doc")
+
+    assert results == [], "A flat render carries no analyzable content"

--- a/backend/tests/test_images_api.py
+++ b/backend/tests/test_images_api.py
@@ -7,6 +7,7 @@ from io import BytesIO
 import pytest
 from httpx import ASGITransport, AsyncClient
 from PIL import Image as PILImage
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 import app.database as db_module
@@ -325,4 +326,50 @@ async def test_get_enrichment_returns_404_for_unknown_doc(test_db):
     """GET /documents/{unknown}/enrichment returns 404."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get("/documents/nonexistent-id/enrichment")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_reextract_queues_an_image_extract_job(test_db):
+    """POST .../images/reextract lets an already-ingested document pick up
+    extraction improvements without being re-uploaded."""
+    engine, factory, tmp_path = test_db
+    doc_id = str(uuid.uuid4())
+    async with factory() as session:
+        session.add(
+            DocumentModel(
+                id=doc_id,
+                title="Paper",
+                format="pdf",
+                content_type="paper",
+                word_count=100,
+                page_count=15,
+                file_path="/fake.pdf",
+                stage="complete",
+            )
+        )
+        await session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        first = await client.post(f"/documents/{doc_id}/images/reextract")
+        second = await client.post(f"/documents/{doc_id}/images/reextract")
+
+    assert first.status_code == 200
+    assert first.json()["queued"] is True
+    assert second.json() == {"job_id": first.json()["job_id"], "queued": False}
+
+    async with factory() as session:
+        result = await session.execute(
+            select(EnrichmentJobModel).where(EnrichmentJobModel.document_id == doc_id)
+        )
+        jobs = result.scalars().all()
+    assert len(jobs) == 1
+    assert jobs[0].job_type == "image_extract"
+    assert jobs[0].status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_reextract_returns_404_for_unknown_doc(test_db):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/documents/nonexistent-id/images/reextract")
     assert resp.status_code == 404

--- a/backend/tests/test_llm_json.py
+++ b/backend/tests/test_llm_json.py
@@ -1,6 +1,10 @@
 """Tests for tolerant LLM JSON parsing."""
 
-from app.services.llm_json import parse_llm_json_array, parse_llm_json_object
+from app.services.llm_json import (
+    parse_llm_json_array,
+    parse_llm_json_object,
+    salvage_llm_json_object,
+)
 
 
 def test_valid_array_passes_through():
@@ -91,3 +95,30 @@ def test_object_unrecoverable_returns_none():
     assert parse_llm_json_object("no braces here") is None
     assert parse_llm_json_object('{"truncated": "mid str') is None
     assert parse_llm_json_object("[1, 2]") is None
+
+
+def test_salvage_keeps_pairs_completed_before_truncation():
+    """A vision model that loops on a dense diagram runs out of tokens mid-object."""
+    raw = '```json\n{"image_type": "architecture_diagram", "labels": ["Softmax", "Linear"], "des'
+    assert salvage_llm_json_object(raw) == {
+        "image_type": "architecture_diagram",
+        "labels": ["Softmax", "Linear"],
+    }
+
+
+def test_salvage_drops_the_partial_trailing_value():
+    raw = '{"image_type": "flowchart", "description": "a partial senten'
+    assert salvage_llm_json_object(raw) == {"image_type": "flowchart"}
+
+
+def test_salvage_returns_none_when_nothing_completed():
+    assert salvage_llm_json_object('{"image_ty') is None
+    assert salvage_llm_json_object("no braces here") is None
+    assert salvage_llm_json_object("{}") is None
+
+
+def test_salvage_repairs_illegal_escapes():
+    raw = '{"description": "plots \\sigma over time", "labels": ["x'
+    salvaged = salvage_llm_json_object(raw)
+    assert salvaged is not None
+    assert "sigma" in salvaged["description"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^6.30.3",
+        "react-router-dom": "^7.18.2",
         "recharts": "^3.7.0",
         "rehype-highlight": "^7.0.2",
         "rehype-katex": "^7.0.1",
@@ -92,13 +92,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -117,21 +117,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -148,14 +148,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -165,14 +165,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -192,29 +192,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -234,9 +234,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -254,9 +254,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -264,27 +264,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -326,33 +326,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -360,14 +360,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -380,40 +380,54 @@
       "license": "MIT"
     },
     "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
-      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
+      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/gast": "12.0.0",
-        "@chevrotain/types": "12.0.0"
+        "@chevrotain/gast": "11.0.3",
+        "@chevrotain/types": "11.0.3",
+        "lodash-es": "4.17.21"
       }
+    },
+    "node_modules/@chevrotain/cst-dts-gen/node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
     },
     "node_modules/@chevrotain/gast": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
-      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
+      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/types": "12.0.0"
+        "@chevrotain/types": "11.0.3",
+        "lodash-es": "4.17.21"
       }
     },
+    "node_modules/@chevrotain/gast/node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
-      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
+      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/types": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
-      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
+      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/utils": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
-      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
+      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@codemirror/autocomplete": {
@@ -807,9 +821,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -824,9 +838,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -841,9 +855,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -858,9 +872,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -875,9 +889,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -892,9 +906,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -909,9 +923,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -926,9 +940,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -943,9 +957,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -960,9 +974,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -977,9 +991,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -994,9 +1008,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -1011,9 +1025,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -1028,9 +1042,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1045,9 +1059,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1062,9 +1076,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -1079,9 +1093,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -1096,9 +1110,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -1113,9 +1127,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -1130,9 +1144,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1147,9 +1161,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -1164,9 +1178,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -1181,9 +1195,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1198,9 +1212,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1215,9 +1229,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1232,9 +1246,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1464,22 +1478,10 @@
       }
     },
     "node_modules/@excalidraw/excalidraw/node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "license": "MIT"
-    },
-    "node_modules/@excalidraw/excalidraw/node_modules/nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/@excalidraw/excalidraw/node_modules/points-on-curve": {
       "version": "1.0.1",
@@ -1546,102 +1548,6 @@
         "nanoid": "4.0.2"
       }
     },
-    "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
-      }
-    },
-    "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/@chevrotain/gast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
-      }
-    },
-    "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/@chevrotain/types": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/@chevrotain/utils": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/@mermaid-js/parser": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz",
-      "integrity": "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==",
-      "license": "MIT",
-      "dependencies": {
-        "langium": "3.3.1"
-      }
-    },
-    "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/chevrotain": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.0.3",
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/regexp-to-ast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "@chevrotain/utils": "11.0.3",
-        "lodash-es": "4.17.21"
-      }
-    },
-    "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/chevrotain-allstar": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash-es": "^4.17.21"
-      },
-      "peerDependencies": {
-        "chevrotain": "^11.0.0"
-      }
-    },
-    "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/langium": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-3.3.1.tgz",
-      "integrity": "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==",
-      "license": "MIT",
-      "dependencies": {
-        "chevrotain": "~11.0.3",
-        "chevrotain-allstar": "~0.3.0",
-        "vscode-languageserver": "~9.0.1",
-        "vscode-languageserver-textdocument": "~1.0.11",
-        "vscode-uri": "~3.0.8"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
-    },
     "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/nanoid": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
@@ -1659,12 +1565,6 @@
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
-    },
-    "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/vscode-uri": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-      "license": "MIT"
     },
     "node_modules/@excalidraw/random-username": {
       "version": "1.1.0",
@@ -2016,12 +1916,12 @@
       "license": "MIT"
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
-      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz",
+      "integrity": "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==",
       "license": "MIT",
       "dependencies": {
-        "langium": "^4.0.0"
+        "langium": "3.3.1"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -2680,62 +2580,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
-      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-primitive": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
-      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-slot": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
-      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.8.tgz",
@@ -3149,47 +2993,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
-      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
-      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -3308,47 +3111,6 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
       "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
       "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-primitive": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
-      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-slot": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
-      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.1"
-      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -3724,9 +3486,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.14",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.14.tgz",
-      "integrity": "sha512-y+xFx+Zz54Xhr8jUdnLENYnt7Y7GEDL6Q03ga7rTtX8DVwefX9H+hQEPgJp1nda7vdH+wJ9/HBVvyfBuW9x6rA==",
+      "version": "1.34.18",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.18.tgz",
+      "integrity": "sha512-UyKIm0wTPw5BcY7Z2PkbK1Ma260um96LSBWXHrdSMe+ZV0EPMyDfAcUcjjm3qEiGST9OK/1TriekdPCZkn4Q3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3735,7 +3497,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.3.0",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -3746,9 +3508,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3802,15 +3564,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4851,16 +4604,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -5308,9 +5061,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5502,32 +5255,36 @@
       }
     },
     "node_modules/chevrotain": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
-      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
+      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "12.0.0",
-        "@chevrotain/gast": "12.0.0",
-        "@chevrotain/regexp-to-ast": "12.0.0",
-        "@chevrotain/types": "12.0.0",
-        "@chevrotain/utils": "12.0.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
+        "@chevrotain/cst-dts-gen": "11.0.3",
+        "@chevrotain/gast": "11.0.3",
+        "@chevrotain/regexp-to-ast": "11.0.3",
+        "@chevrotain/types": "11.0.3",
+        "@chevrotain/utils": "11.0.3",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/chevrotain-allstar": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
-      "integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
       "license": "MIT",
       "dependencies": {
-        "lodash-es": "^4.18.1"
+        "lodash-es": "^4.17.21"
       },
       "peerDependencies": {
-        "chevrotain": "^12.0.0"
+        "chevrotain": "^11.0.0"
       }
+    },
+    "node_modules/chevrotain/node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -5652,6 +5409,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cose-base": {
       "version": "1.0.3",
@@ -6349,9 +6119,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -6403,9 +6173,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6416,32 +6186,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -7342,9 +7112,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -7590,10 +7360,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7690,21 +7470,19 @@
       "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/langium": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.3.tgz",
-      "integrity": "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-3.3.1.tgz",
+      "integrity": "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/regexp-to-ast": "~12.0.0",
-        "chevrotain": "~12.0.0",
-        "chevrotain-allstar": "~0.4.3",
+        "chevrotain": "~11.0.3",
+        "chevrotain-allstar": "~0.3.0",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.11",
-        "vscode-uri": "~3.1.0"
+        "vscode-uri": "~3.0.8"
       },
       "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/layout-base": {
@@ -8176,32 +7954,47 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
-      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.0",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
-        "katex": "^0.16.25",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
-        "lodash-es": "^4.17.23",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/mermaid/node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/micromark": {
@@ -8869,16 +8662,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -9290,9 +9076,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -9310,7 +9096,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9465,6 +9251,25 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -9659,35 +9464,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {
@@ -10141,6 +9952,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -10981,13 +10798,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -11225,9 +11042,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
       "license": "MIT"
     },
     "node_modules/w3c-keyname": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^6.30.3",
+    "react-router-dom": "^7.18.2",
     "recharts": "^3.7.0",
     "rehype-highlight": "^7.0.2",
     "rehype-katex": "^7.0.1",

--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useId, useState } from "react"
+import { type ReactNode, useEffect, useId, useMemo, useState } from "react"
 import { Pencil } from "lucide-react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
@@ -10,6 +10,7 @@ import "katex/dist/katex.min.css"
 import { API_BASE } from "@/lib/config"
 import { findExcalidrawDiagrams, type ExcalidrawNoteDiagramRef } from "@/lib/noteDiagrams"
 import { resolveLuminaryAssetUrl } from "@/lib/noteAssets"
+import { SOURCE_LINE_ATTR, lineOffsetAt, rehypeSourceLine } from "@/lib/rehypeSourceLine"
 import { cn } from "@/lib/utils"
 
 export type ImageSize = "small" | "medium" | "large"
@@ -30,6 +31,12 @@ interface MarkdownRendererProps {
   /** When set, clicking an image opens a small size picker that writes the
    * |small/medium/large alt pipe back into the source markdown. */
   onSetImageSize?: (src: string, size: ImageSize) => void
+  /** Stamp rendered blocks with their markdown line so a split editor can
+   * scroll-sync against them. Off by default — only the editors need it. */
+  trackSourceLines?: boolean
+  /** Lines of the original document preceding `children`, when this body is one
+   * chunk of a note split around diagrams. */
+  sourceLineOffset?: number
 }
 
 const IMAGE_SIZE_STYLE: Record<ImageSize, { maxWidth: string; maxHeight: string; objectFit: "contain" }> = {
@@ -141,13 +148,18 @@ function ExcalidrawDiagramPreview({
   diagram,
   index,
   onEdit,
+  sourceLine,
 }: {
   diagram: ExcalidrawNoteDiagramRef
   index: number
   onEdit?: (diagram: ExcalidrawNoteDiagramRef) => void
+  sourceLine?: number
 }) {
   return (
-    <figure className="not-prose my-5 overflow-hidden rounded-lg border border-border bg-background shadow-sm">
+    <figure
+      {...(sourceLine != null ? { [SOURCE_LINE_ATTR]: String(sourceLine) } : {})}
+      className="not-prose my-5 overflow-hidden rounded-lg border border-border bg-background shadow-sm"
+    >
       <div className="flex items-center justify-between border-b border-border bg-muted/35 px-3 py-2">
         <figcaption className="text-xs font-medium text-muted-foreground">
           Diagram {index + 1}
@@ -175,9 +187,17 @@ function ExcalidrawDiagramPreview({
   )
 }
 
-function MarkdownBody({ children, className, validNoteIds, imageSize = "medium", serif = false, onNoteLinkClick, onSetImageSize }: MarkdownRendererProps) {
+function MarkdownBody({ children, className, validNoteIds, imageSize = "medium", serif = false, onNoteLinkClick, onSetImageSize, trackSourceLines = false, sourceLineOffset = 0 }: MarkdownRendererProps) {
+  // Only inline substitutions — line numbering must survive for scroll sync.
   const processed = preprocessLinks(children)
   const [sizeMenu, setSizeMenu] = useState<{ src: string; x: number; y: number } | null>(null)
+  const rehypePlugins = useMemo(
+    () =>
+      trackSourceLines
+        ? [rehypeHighlight, rehypeKatex, rehypeRaw, rehypeSourceLine(sourceLineOffset)]
+        : [rehypeHighlight, rehypeKatex, rehypeRaw],
+    [trackSourceLines, sourceLineOffset],
+  )
 
   return (
     <div className={cn(
@@ -195,7 +215,7 @@ function MarkdownBody({ children, className, validNoteIds, imageSize = "medium",
     )}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
-        rehypePlugins={[rehypeHighlight, rehypeKatex, rehypeRaw]}
+        rehypePlugins={rehypePlugins}
         components={{
           pre: ({ children: preChildren }) => {
             const child = Array.isArray(preChildren) ? preChildren[0] : preChildren
@@ -310,12 +330,13 @@ export function MarkdownRenderer({
   onEditExcalidrawDiagram,
   onNoteLinkClick,
   onSetImageSize,
+  trackSourceLines = false,
 }: MarkdownRendererProps) {
   const diagrams = findExcalidrawDiagrams(children)
 
   if (diagrams.length === 0) {
     return (
-      <MarkdownBody className={className} validNoteIds={validNoteIds} imageSize={imageSize} serif={serif} onNoteLinkClick={onNoteLinkClick} onSetImageSize={onSetImageSize}>
+      <MarkdownBody className={className} validNoteIds={validNoteIds} imageSize={imageSize} serif={serif} onNoteLinkClick={onNoteLinkClick} onSetImageSize={onSetImageSize} trackSourceLines={trackSourceLines}>
         {children}
       </MarkdownBody>
     )
@@ -329,7 +350,7 @@ export function MarkdownRenderer({
         return (
           <div key={`${diagram.scenePath}-${diagram.start}`}>
             {before.trim() && (
-              <MarkdownBody validNoteIds={validNoteIds} imageSize={imageSize} serif={serif} onNoteLinkClick={onNoteLinkClick} onSetImageSize={onSetImageSize}>
+              <MarkdownBody validNoteIds={validNoteIds} imageSize={imageSize} serif={serif} onNoteLinkClick={onNoteLinkClick} onSetImageSize={onSetImageSize} trackSourceLines={trackSourceLines} sourceLineOffset={lineOffsetAt(children, previousEnd)}>
                 {before}
               </MarkdownBody>
             )}
@@ -337,12 +358,15 @@ export function MarkdownRenderer({
               diagram={diagram}
               index={index}
               onEdit={onEditExcalidrawDiagram}
+              sourceLine={
+                trackSourceLines ? lineOffsetAt(children, diagram.start) + 1 : undefined
+              }
             />
           </div>
         )
       })}
       {children.substring(diagrams.at(-1)?.end ?? 0).trim() && (
-        <MarkdownBody validNoteIds={validNoteIds} imageSize={imageSize} serif={serif} onNoteLinkClick={onNoteLinkClick} onSetImageSize={onSetImageSize}>
+        <MarkdownBody validNoteIds={validNoteIds} imageSize={imageSize} serif={serif} onNoteLinkClick={onNoteLinkClick} onSetImageSize={onSetImageSize} trackSourceLines={trackSourceLines} sourceLineOffset={lineOffsetAt(children, diagrams.at(-1)?.end ?? 0)}>
           {children.substring(diagrams.at(-1)?.end ?? 0)}
         </MarkdownBody>
       )}

--- a/frontend/src/components/notes/MarkdownCodeEditor.tsx
+++ b/frontend/src/components/notes/MarkdownCodeEditor.tsx
@@ -40,6 +40,26 @@ export interface MarkdownEditorHandle {
   scrollDOM: () => HTMLElement | null
   /** Move the cursor to a 0-based line and scroll it to the top (outline nav). */
   scrollToLine: (line: number) => void
+  /** Total source lines, for the preview's terminal scroll anchor. */
+  lineCount: () => number
+  /** 1-based source line at the top of the viewport, fractional within the line. */
+  topSourceLine: () => number | null
+  /** Scroll (without moving the caret) so `line` sits at the top of the viewport. */
+  scrollToSourceLine: (line: number) => void
+}
+
+/**
+ * Height, in CodeMirror's document coordinate space, of whatever is currently at
+ * the top of the scroller.
+ *
+ * `documentTop` is the document origin in screen coordinates and already accounts
+ * for content padding, so subtracting it from the scroller's screen top converts
+ * between the two spaces without assuming anything about the theme. Both terms
+ * are sub-pixel, which is what keeps the mapping correct under browser zoom —
+ * scrollTop/scrollHeight arithmetic rounds and drifts.
+ */
+function docHeightAtViewportTop(view: EditorView): number {
+  return view.scrollDOM.getBoundingClientRect().top - view.documentTop
 }
 
 export interface MarkdownCodeEditorProps {
@@ -298,6 +318,28 @@ export const MarkdownCodeEditor = forwardRef<MarkdownEditorHandle, MarkdownCodeE
             effects: EditorView.scrollIntoView(docLine.from, { y: "start", yMargin: 8 }),
           })
           v.focus()
+        },
+        lineCount: () => viewRef.current?.state.doc.lines ?? 0,
+        topSourceLine: () => {
+          const v = viewRef.current
+          if (!v) return null
+          const height = Math.max(0, docHeightAtViewportTop(v))
+          const block = v.lineBlockAtHeight(height)
+          const line = v.state.doc.lineAt(block.from).number
+          if (block.height <= 0) return line
+          // A wrapped line is one block, so the fraction locates the visual row
+          // within it -- without this, sync quantises to whole source lines.
+          const within = Math.min(1, Math.max(0, (height - block.top) / block.height))
+          return line + within
+        },
+        scrollToSourceLine: (line) => {
+          const v = viewRef.current
+          if (!v) return
+          const clamped = Math.min(Math.max(line, 1), v.state.doc.lines)
+          const whole = Math.floor(clamped)
+          const block = v.lineBlockAt(v.state.doc.line(whole).from)
+          const target = block.top + (clamped - whole) * block.height
+          v.scrollDOM.scrollTop += target - docHeightAtViewportTop(v)
         },
       }),
       [],

--- a/frontend/src/components/notes/MarkdownSplitEditor.tsx
+++ b/frontend/src/components/notes/MarkdownSplitEditor.tsx
@@ -5,6 +5,13 @@ import {
 } from "@/components/notes/MarkdownCodeEditor"
 import { type NoteLinkCompletionConfig } from "@/components/notes/noteLinkCompletion"
 import { type SlashCommandConfig } from "@/components/notes/slashCommands"
+import {
+  lineToOffset,
+  normalizeAnchors,
+  offsetToLine,
+  type SourceAnchor,
+} from "@/components/notes/scrollSync"
+import { SOURCE_LINE_ATTR } from "@/lib/rehypeSourceLine"
 
 export type MarkdownSplitLayout = "splitter" | "tabs" | "editor"
 
@@ -30,6 +37,11 @@ const DEFAULT_EDITOR_CLASS =
 
 const DEFAULT_PREVIEW_CLASS = "prose-sm flex-1 overflow-auto px-2 py-2"
 
+// Treat a pane as scrolled to its end within this many pixels. Not zero: at
+// fractional zoom levels scrollTop is sub-pixel while scrollHeight/clientHeight
+// are integers, so a pane at its true limit never reports an exact match.
+const AT_END_PX = 4
+
 export function MarkdownSplitEditor({
   content,
   onContentChange,
@@ -51,28 +63,91 @@ export function MarkdownSplitEditor({
   const previewRef = useRef<HTMLDivElement>(null)
   const splitContainerRef = useRef<HTMLDivElement>(null)
   const syncingRef = useRef<"write" | "preview" | null>(null)
+  const anchorsRef = useRef<{ signature: string; anchors: SourceAnchor[] }>({
+    signature: "",
+    anchors: [],
+  })
 
   const [leftPct, setLeftPct] = useState(50)
   const [dragging, setDragging] = useState(false)
   const [activeTab, setActiveTab] = useState<"write" | "preview">("write")
 
+  /**
+   * Measure where each rendered block starts, relative to the preview's scroll
+   * origin. Offsets come from getBoundingClientRect rather than offsetTop so they
+   * stay sub-pixel accurate at any browser zoom, and so they are unaffected by
+   * whatever positioned ancestors the surrounding layout introduces.
+   */
+  function measurePreviewAnchors(previewEl: HTMLElement, totalLines: number): SourceAnchor[] {
+    const origin = previewEl.getBoundingClientRect().top - previewEl.scrollTop
+    const raw: SourceAnchor[] = []
+    for (const el of previewEl.querySelectorAll<HTMLElement>(`[${SOURCE_LINE_ATTR}]`)) {
+      raw.push({
+        line: Number(el.getAttribute(SOURCE_LINE_ATTR)),
+        top: el.getBoundingClientRect().top - origin,
+      })
+    }
+    return normalizeAnchors(raw, totalLines, previewEl.scrollHeight - previewEl.clientHeight)
+  }
+
+  /**
+   * Anchors are reused across scroll events — measuring every block on each one
+   * would mean hundreds of layout reads per frame on a long note. The signature
+   * covers everything that can move a block: an edit, a reflow (zoom, resize,
+   * splitter drag), and content settling after paint such as an image finishing
+   * loading, which changes scrollHeight without resizing the pane itself.
+   */
+  function previewAnchors(previewEl: HTMLElement, totalLines: number): SourceAnchor[] {
+    const signature = `${totalLines}:${previewEl.scrollHeight}:${previewEl.clientHeight}:${previewEl.clientWidth}`
+    if (anchorsRef.current.signature !== signature) {
+      anchorsRef.current = {
+        signature,
+        anchors: measurePreviewAnchors(previewEl, totalLines),
+      }
+    }
+    return anchorsRef.current.anchors
+  }
+
   function syncScroll(source: "write" | "preview") {
     if (syncingRef.current && syncingRef.current !== source) return
-    const writeEl = editorRef.current?.scrollDOM() ?? null
+    const editor = editorRef.current
+    const writeEl = editor?.scrollDOM() ?? null
     const previewEl = previewRef.current
     const src = source === "write" ? writeEl : previewEl
     const dst = source === "write" ? previewEl : writeEl
-    if (!src || !dst) return
-    const srcMax = src.scrollHeight - src.clientHeight
+    if (!src || !dst || !editor || !previewEl) return
     const dstMax = dst.scrollHeight - dst.clientHeight
-    if (srcMax <= 0 || dstMax <= 0) return
+    if (dstMax <= 0) return
+
+    const anchors = previewAnchors(previewEl, editor.lineCount())
     syncingRef.current = source
-    // Proportional mapping is approximate (monospace editor vs serif preview), so
-    // near the end it can leave the last lines cut off. When the source is at or
-    // near its bottom — the type-at-end case — pin the destination to its true
-    // bottom so freshly typed text is always visible in the preview.
-    const nearBottom = srcMax - src.scrollTop <= 24
-    dst.scrollTop = nearBottom ? dstMax : (src.scrollTop / srcMax) * dstMax
+
+    const srcAtEnd = src.scrollHeight - src.clientHeight - src.scrollTop <= AT_END_PX
+
+    if (anchors.length >= 2) {
+      // Line-anchored: convert through the shared source-line axis, so each
+      // region uses its own pixels-per-line rather than a document-wide average.
+      if (source === "write") {
+        // Anchoring aligns the pane *tops*. At the end of the document that is
+        // not enough: if the tail renders taller than it does in the editor, the
+        // line just typed still falls below the preview's fold. Showing the end
+        // of one pane must show the end of the other.
+        const line = srcAtEnd ? null : editor.topSourceLine()
+        previewEl.scrollTop = line == null ? dstMax : lineToOffset(line, anchors)
+      } else {
+        editor.scrollToSourceLine(
+          srcAtEnd ? editor.lineCount() : offsetToLine(previewEl.scrollTop, anchors),
+        )
+      }
+    } else {
+      // No anchors: a preview that is not a tracked MarkdownRenderer (the blog
+      // dialogs wrap theirs in extra chrome). Proportional is all we can do.
+      const srcMax = src.scrollHeight - src.clientHeight
+      if (srcMax > 0) {
+        dst.scrollTop = srcAtEnd ? dstMax : (src.scrollTop / srcMax) * dstMax
+      }
+    }
+
     requestAnimationFrame(() => {
       syncingRef.current = null
     })
@@ -80,9 +155,9 @@ export function MarkdownSplitEditor({
 
   // Typing at the bottom of the editor does not always fire a scroll event (the
   // caret is already visible), and when it does the preview has not yet re-rendered
-  // the new text, so its height is stale. Either way the preview is left behind and
-  // freshly-typed content scrolls out of view. Re-sync after the preview re-renders
-  // on a content change so it follows the editor's scroll position.
+  // the new text, so its anchors are stale. Either way the preview is left behind
+  // and freshly-typed content scrolls out of view. Re-sync after the preview
+  // re-renders on a content change.
   useEffect(() => {
     if (layout !== "splitter") return
     // Second frame catches preview height changes that land after the first
@@ -99,6 +174,29 @@ export function MarkdownSplitEditor({
     // syncScroll reads live DOM through refs; re-run only when content/layout change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [content, layout])
+
+  // Anchor offsets are measurements, so anything that reflows either pane
+  // invalidates them: browser zoom (which rewraps the serif preview and the
+  // monospace editor by different amounts), window resize, and splitter drags.
+  // None of those change `content`, so the effect above never sees them.
+  useEffect(() => {
+    if (layout !== "splitter") return
+    const previewEl = previewRef.current
+    const writeEl = editorRef.current?.scrollDOM() ?? null
+    if (!previewEl) return
+    let frame = 0
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(frame)
+      frame = requestAnimationFrame(() => syncScroll("write"))
+    })
+    observer.observe(previewEl)
+    if (writeEl) observer.observe(writeEl)
+    return () => {
+      cancelAnimationFrame(frame)
+      observer.disconnect()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [layout])
 
   function handleSplitterMouseDown(e: React.MouseEvent) {
     if (layout !== "splitter") return

--- a/frontend/src/components/notes/NoteEditor.tsx
+++ b/frontend/src/components/notes/NoteEditor.tsx
@@ -91,6 +91,7 @@ export function NoteEditor({
             content.trim() ? (
               <MarkdownRenderer
                 serif
+                trackSourceLines
                 onEditExcalidrawDiagram={openDiagramEditor}
                 onSetImageSize={(src, size) =>
                   onContentChange(setImageSizeInMarkdown(content, src, size, API_BASE))

--- a/frontend/src/components/notes/scrollSync.test.ts
+++ b/frontend/src/components/notes/scrollSync.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest"
+import {
+  interpolate,
+  lineToOffset,
+  normalizeAnchors,
+  offsetToLine,
+  type SourceAnchor,
+} from "./scrollSync"
+
+describe("interpolate", () => {
+  const points = [
+    { x: 0, y: 0 },
+    { x: 10, y: 100 },
+    { x: 20, y: 150 },
+  ]
+
+  it("clamps outside the covered range", () => {
+    expect(interpolate(-5, points)).toBe(0)
+    expect(interpolate(99, points)).toBe(150)
+  })
+
+  it("returns exact values at the anchors", () => {
+    expect(interpolate(10, points)).toBe(100)
+  })
+
+  it("interpolates within a segment using that segment's own slope", () => {
+    // The second segment is half as steep as the first; a global ratio would
+    // put x=15 at 112.5 instead of 125.
+    expect(interpolate(5, points)).toBe(50)
+    expect(interpolate(15, points)).toBe(125)
+  })
+
+  it("survives an empty or degenerate input", () => {
+    expect(interpolate(3, [])).toBe(0)
+    expect(interpolate(3, [{ x: 3, y: 7 }])).toBe(7)
+    expect(
+      interpolate(3, [
+        { x: 3, y: 7 },
+        { x: 3, y: 9 },
+      ]),
+    ).toBe(7)
+  })
+})
+
+describe("normalizeAnchors", () => {
+  it("adds the synthetic start and end so the range is total", () => {
+    const anchors = normalizeAnchors([{ line: 4, top: 40 }], 10, 400)
+    expect(anchors[0]).toEqual({ line: 1, top: 0 })
+    expect(anchors[anchors.length - 1]).toEqual({ line: 11, top: 400 })
+  })
+
+  it("drops blocks that would invert the mapping", () => {
+    const raw: SourceAnchor[] = [
+      { line: 1, top: 0 },
+      { line: 5, top: 50 },
+      { line: 3, top: 70 }, // line goes backwards
+      { line: 9, top: 40 }, // offset goes backwards from the last kept anchor
+      { line: 12, top: 120 },
+    ]
+    expect(normalizeAnchors(raw, 12, 200).map((a) => a.line)).toEqual([1, 5, 12, 13])
+  })
+
+  it("ignores non-finite values", () => {
+    const raw = [
+      { line: 1, top: 0 },
+      { line: Number.NaN, top: 10 },
+      { line: 6, top: Number.NaN },
+      { line: 8, top: 80 },
+    ]
+    expect(normalizeAnchors(raw, 8, 160).map((a) => a.line)).toEqual([1, 8, 9])
+  })
+
+  it("returns nothing when the preview exposed no anchors", () => {
+    expect(normalizeAnchors([], 10, 400)).toEqual([])
+  })
+
+  it("does not append an end anchor that would sit above the last block", () => {
+    // A pane scrolled to its limit can report a content end below the final
+    // block's measured top; appending it would invert the mapping.
+    const anchors = normalizeAnchors([{ line: 4, top: 500 }], 10, 100)
+    expect(anchors[anchors.length - 1]).toEqual({ line: 4, top: 500 })
+  })
+})
+
+describe("lineToOffset / offsetToLine", () => {
+  // A tight source block that renders tall (a list becoming spaced paragraphs)
+  // followed by a long paragraph that renders short.
+  const anchors: SourceAnchor[] = [
+    { line: 1, top: 0 },
+    { line: 10, top: 100 },
+    { line: 14, top: 600 },
+    { line: 40, top: 700 },
+  ]
+
+  it("round-trips a line through an offset and back", () => {
+    for (const line of [1, 5, 10, 12, 14, 30, 40]) {
+      expect(offsetToLine(lineToOffset(line, anchors), anchors)).toBeCloseTo(line, 6)
+    }
+  })
+
+  it("tracks the steep region instead of the document average", () => {
+    // Line 12 is halfway through the block that renders tall: 350px in.
+    // The global-ratio mapping this replaces would have produced ~193px.
+    expect(lineToOffset(12, anchors)).toBe(350)
+  })
+
+  it("pins the ends", () => {
+    expect(lineToOffset(0, anchors)).toBe(0)
+    expect(lineToOffset(999, anchors)).toBe(700)
+  })
+
+  it("falls back to offset 0 when there are no anchors", () => {
+    expect(lineToOffset(7, [])).toBe(0)
+    expect(offsetToLine(70, [])).toBe(0)
+  })
+})

--- a/frontend/src/components/notes/scrollSync.ts
+++ b/frontend/src/components/notes/scrollSync.ts
@@ -1,0 +1,99 @@
+/**
+ * Line-anchored scroll mapping between the markdown source pane and its preview.
+ *
+ * A single global ratio (scrollTop / scrollMax) cannot track these two panes: the
+ * editor is monospace with one row per source line, while the preview is serif
+ * prose whose block heights vary with headings, list spacing, images and KaTeX.
+ * The pixels-per-source-line ratio therefore differs by region, and one constant
+ * is only correct at the very top and the very bottom.
+ *
+ * Instead both panes are described as anchors — (source line, pixel offset) pairs
+ * — and a position in one pane is converted by interpolating between the anchors
+ * that bracket it. Because every offset is measured rather than derived from a
+ * ratio, the mapping holds at any browser zoom level.
+ */
+
+export interface SourceAnchor {
+  /** 1-based markdown line the block starts at. */
+  line: number
+  /** Pixel offset of the block from the pane's scroll origin. */
+  top: number
+}
+
+interface Point {
+  x: number
+  y: number
+}
+
+/**
+ * Piecewise-linear interpolation over points sorted ascending by x.
+ * Clamps to the first/last point outside the covered range.
+ */
+export function interpolate(x: number, points: Point[]): number {
+  if (points.length === 0) return 0
+  const first = points[0]
+  const last = points[points.length - 1]
+  if (x <= first.x) return first.y
+  if (x >= last.x) return last.y
+
+  let lo = 0
+  let hi = points.length - 1
+  while (hi - lo > 1) {
+    const mid = (lo + hi) >> 1
+    if (points[mid].x <= x) lo = mid
+    else hi = mid
+  }
+  const a = points[lo]
+  const b = points[hi]
+  const span = b.x - a.x
+  if (span <= 0) return a.y
+  return a.y + ((x - a.x) / span) * (b.y - a.y)
+}
+
+/**
+ * Anchors are read from the DOM in document order, but a block whose line is not
+ * greater than its predecessor's (raw HTML, a plugin that rewrites positions)
+ * would break the monotonic invariant interpolation depends on. Such blocks are
+ * dropped rather than allowed to invert the mapping.
+ *
+ * The synthetic endpoints make the range total: line 1 sits at offset 0, and one
+ * past the last line sits at the end of the scrollable content, so a position
+ * before the first block or after the last still maps somewhere sensible.
+ */
+export function normalizeAnchors(
+  raw: SourceAnchor[],
+  totalLines: number,
+  contentEnd: number,
+): SourceAnchor[] {
+  const anchors: SourceAnchor[] = []
+  for (const anchor of raw) {
+    if (!Number.isFinite(anchor.line) || !Number.isFinite(anchor.top)) continue
+    const prev = anchors[anchors.length - 1]
+    if (prev && (anchor.line <= prev.line || anchor.top < prev.top)) continue
+    anchors.push(anchor)
+  }
+
+  if (anchors.length === 0) return []
+  if (anchors[0].line > 1) anchors.unshift({ line: 1, top: 0 })
+
+  const last = anchors[anchors.length - 1]
+  const endLine = Math.max(totalLines + 1, last.line + 1)
+  if (contentEnd > last.top) anchors.push({ line: endLine, top: contentEnd })
+  return anchors
+}
+
+/** Scroll offset showing `line` (fractional) at the top of the pane. */
+export function lineToOffset(line: number, anchors: SourceAnchor[]): number {
+  return interpolate(
+    line,
+    anchors.map((a) => ({ x: a.line, y: a.top })),
+  )
+}
+
+/** The (fractional) source line sitting at scroll offset `offset`. */
+export function offsetToLine(offset: number, anchors: SourceAnchor[]): number {
+  return interpolate(
+    offset,
+    anchors.map((a) => ({ x: a.top, y: a.line })),
+  )
+}

--- a/frontend/src/lib/rehypeSourceLine.test.ts
+++ b/frontend/src/lib/rehypeSourceLine.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import type { Root } from "hast"
+import { SOURCE_LINE_ATTR, lineOffsetAt, rehypeSourceLine } from "./rehypeSourceLine"
+
+function element(tagName: string, line: number | null) {
+  return {
+    type: "element" as const,
+    tagName,
+    properties: {},
+    children: [],
+    ...(line == null ? {} : { position: { start: { line, column: 1, offset: 0 }, end: { line, column: 1, offset: 0 } } }),
+  }
+}
+
+function stamp(tree: Root, offset = 0) {
+  rehypeSourceLine(offset)(tree)
+  return tree.children.map((n) =>
+    n.type === "element" ? n.properties?.[SOURCE_LINE_ATTR] : undefined,
+  )
+}
+
+describe("rehypeSourceLine", () => {
+  it("stamps top-level blocks with their source line", () => {
+    const tree: Root = {
+      type: "root",
+      children: [element("h1", 1), element("p", 3), element("ul", 5)],
+    }
+    expect(stamp(tree)).toEqual(["1", "3", "5"])
+  })
+
+  it("skips nodes whose position was lost", () => {
+    const tree: Root = {
+      type: "root",
+      children: [element("h1", 1), element("div", null), element("p", 9)],
+    }
+    expect(stamp(tree)).toEqual(["1", undefined, "9"])
+  })
+
+  it("applies the chunk offset so split notes keep one line axis", () => {
+    const tree: Root = { type: "root", children: [element("p", 1), element("p", 4)] }
+    expect(stamp(tree, 20)).toEqual(["21", "24"])
+  })
+
+  it("leaves existing properties intact", () => {
+    const tree: Root = { type: "root", children: [element("p", 2)] }
+    tree.children[0].type === "element" &&
+      (tree.children[0].properties = { className: ["keep"] })
+    rehypeSourceLine()(tree)
+    const node = tree.children[0]
+    expect(node.type === "element" && node.properties).toEqual({
+      className: ["keep"],
+      [SOURCE_LINE_ATTR]: "2",
+    })
+  })
+})
+
+describe("lineOffsetAt", () => {
+  const source = "one\ntwo\nthree\nfour"
+
+  it("counts the lines before a character index", () => {
+    expect(lineOffsetAt(source, 0)).toBe(0)
+    expect(lineOffsetAt(source, 4)).toBe(1)
+    expect(lineOffsetAt(source, 8)).toBe(2)
+  })
+
+  it("clamps past the end of the source", () => {
+    expect(lineOffsetAt(source, 9999)).toBe(3)
+  })
+
+  it("makes a chunk's stamped lines continue the parent document", () => {
+    // The chunk after a diagram starts at index 8, i.e. document line 3. Its own
+    // first block reports line 1, so the offset must lift it back to 3.
+    expect(lineOffsetAt(source, 8) + 1).toBe(3)
+  })
+})

--- a/frontend/src/lib/rehypeSourceLine.ts
+++ b/frontend/src/lib/rehypeSourceLine.ts
@@ -1,0 +1,41 @@
+import type { Root } from "hast"
+
+export const SOURCE_LINE_ATTR = "data-src-line"
+
+/**
+ * Stamp each top-level rendered block with the markdown line it came from, so
+ * scroll sync can map a source position to a pixel offset in the preview.
+ *
+ * Only root-level children are stamped. They correspond one-for-one with the
+ * source blocks a scroll position lands in, and keeping the set small keeps the
+ * per-sync DOM query cheap. Nodes whose position was lost (raw HTML re-parsed by
+ * rehype-raw) are skipped — the sync interpolates across the gap.
+ */
+export function rehypeSourceLine(lineOffset = 0) {
+  return (tree: Root) => {
+    for (const node of tree.children) {
+      if (node.type !== "element") continue
+      const line = node.position?.start.line
+      if (line == null) continue
+      node.properties = {
+        ...node.properties,
+        [SOURCE_LINE_ATTR]: String(line + lineOffset),
+      }
+    }
+  }
+}
+
+/**
+ * Lines preceding `index` in `source`.
+ *
+ * A note containing diagrams is rendered as several markdown chunks split around
+ * them, and each chunk's positions restart at line 1. Without this offset the
+ * stamped lines would repeat and the mapping would fold back on itself.
+ */
+export function lineOffsetAt(source: string, index: number): number {
+  let lines = 0
+  for (let i = 0; i < index && i < source.length; i++) {
+    if (source[i] === "\n") lines++
+  }
+  return lines
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -3103,6 +3103,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/documents/{document_id}/images/reextract": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reextract Document Images
+         * @description Queue a fresh image_extract job for a document.
+         *
+         *     Extraction dedupes on content hash, so this only adds figures the previous run
+         *     missed — the way an already-ingested document picks up an extraction improvement
+         *     without being re-uploaded. Returns the existing job when one is already queued.
+         */
+        post: operations["reextract_document_images_documents__document_id__images_reextract_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/documents/{document_id}/enrichment": {
         parameters: {
             query?: never;
@@ -5368,6 +5392,26 @@ export interface paths {
         };
         /** Health */
         get: operations["health_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/healthz": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Healthz
+         * @description Lightweight liveness probe for containers and monitors (no DB).
+         */
+        get: operations["healthz_healthz_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -8345,6 +8389,13 @@ export interface components {
             /** Detail */
             detail: string;
         };
+        /** ReextractResponse */
+        ReextractResponse: {
+            /** Job Id */
+            job_id: string;
+            /** Queued */
+            queued: boolean;
+        };
         /** RegenStatus */
         RegenStatus: {
             /** Status */
@@ -8435,6 +8486,8 @@ export interface components {
             text: string;
             /** Relevance Score */
             relevance_score: number;
+            /** Global Rank */
+            global_rank: number;
         };
         /** SectionContentItem */
         SectionContentItem: {
@@ -14881,6 +14934,37 @@ export interface operations {
             };
         };
     };
+    reextract_document_images_documents__document_id__images_reextract_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                document_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReextractResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_enrichment_jobs_documents__document_id__enrichment_get: {
         parameters: {
             query?: never;
@@ -18318,6 +18402,26 @@ export interface operations {
         };
     };
     health_health_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    healthz_healthz_get: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
## Root cause

`extract_images_pdf` only enumerated embedded raster XObjects via `page.get_images(full=True)`. A LaTeX-authored paper draws its figures with path operators — TikZ, pgfplots, matplotlib PDF output — so there is no XObject to find and the document ends up with **no visual layer at all**, silently.

Measured on the local corpus (`page.get_images()` vs `page.get_drawings()` per page):

| Document | raster images | vector-only pages | figures previously lost |
|---|---|---|---|
| Attention Is All You Need | 3 | 13 | Figures 3-5 (pages 13-15, ~1000 primitives each) |
| Sutton & Barto, RL | 18 | 340 | 93 |
| Foundations of Data Science | 3 | 477 | 114 |

Nothing about this is offline-specific — offline is simply where it bites, because there is no cloud vision or PDF service to paper over a local extractor that found nothing.

## Plan B

When a page yields no raster image, its drawing primitives are clustered into figure regions (occupancy grid inflated by a gap tolerance, then connected components) and those regions are rasterized at 150 DPI. This handles both shapes seen in the wild: one large path covering a whole diagram, and a thousand hairlines making up an attention heatmap.

Guards, all validated against the corpus: minimum region size, minimum primitive count, maximum page fraction, per-page and per-document caps, and a flat-render check. Result on the prose-heavy PDFs (`Approximations`, `luminary_conceptual_foundations`, DDIA, Iceberg): **zero** false positives — header rules, bullets, underlines and highlight boxes are all rejected.

After: Attention 3 → 6 images, Chess paper 5 → 10.

Kill switch: `PDF_VECTOR_FIGURES` (default on).

## Not erroring out, warning appropriately

- An unreadable PDF (encrypted, truncated) no longer fails the job. Extraction degrades to "no images", records the cause on the job row, and the rest of enrichment runs.
- A document that ends up with no images at all now says so on its job, instead of the library reporting "Images ready" over an empty set. Both notes surface through the existing `GET /documents/{id}/enrichment`.
- Extraction moved off the event loop (`asyncio.to_thread`) — rasterizing a large PDF is seconds of CPU and the worker enriches several documents concurrently on one loop.

## Broken vision output is no longer stored as a description

A local vision model that loops on a dense diagram hits the token limit mid-JSON. The raw half-written blob was being stored verbatim as the image's description and embedded into LanceDB and FTS. Attention's Figure 1 — the Transformer architecture, the paper's flagship figure — was typed `other` with 1855 characters of truncated JSON as its body, which also excluded it from diagram extraction.

`salvage_llm_json_object` recovers the top-level pairs the model did commit to, including complete elements of a truncated trailing array. Verified against the actual stored bad output: that figure recovers as `architecture_diagram` with its transcribed labels (`Output Probabilities, Softmax, Linear, Add & Norm, Feed Forward, Multi-Head Attention, Masked Multi-Head Attention`). An unsalvageable response now leaves the description null so the next `image_analyze` job retries it, rather than indexing junk.

## Applying it to existing documents

`POST /documents/{id}/images/reextract` queues a fresh extraction. Extraction dedupes on content hash, so a re-run only adds what was missed — no re-upload needed.

## Tests

`ruff check` clean, layer linter clean, `tsc --noEmit` clean, full backend suite **2177 passed, 1 skipped**.

New coverage: vector figure recovered when no raster present; fallback skipped when the page already has a raster; fallback disabled by flag; rules and underlines rejected; flat renders rejected; handler degrades and notes on an unreadable PDF; handler notes an image-free document; truncated-object salvage (four cases); truncated vision response salvaged rather than stored raw; undescribable image left null for retry; re-extract endpoint queues and dedupes.

## Follow-ups, not in this PR

- The library row shows "Images ready" whenever enrichment status is `done`, regardless of whether any image exists. The job note explains it via the enrichment endpoint but the list surface still can't see it.
- `content_type='paper'` is not in `TECHNICAL_CONTENT_TYPES`, so the Attention doc carries `is_technical=0` and its entity extraction runs without the technical path. Separate from images; worth a look.

---

# Added after review prep

Three commits were added on top of the original change. Merged `master` (PDF reader last-page fix) in; no conflicts.

## `72e1b38` — quality pass on the extraction commit

**A real defect in the clustering.** `_cluster_drawings` painted *every* drawing primitive onto the occupancy grid, so a single page-spanning primitive — a background wash, a page border — bridged every figure on the page into one whole-page component, which the page-fraction guard then discarded. Those pages yielded **zero** figures instead of their diagrams. Oversize primitives are now excluded before clustering. Confirmed by stubbing the guard out: the new regression test returns 0 figures without it, 1 with it.

Also: `_MAX_VECTOR_FIGURES_PER_DOC` could be exceeded by up to a page's worth (the budget was checked before a page ran, not enforced) — now exact. `_record_job_note` swallowed its own failure at `debug`, which is the one thing that must not be silent given the function exists so a degraded job can explain itself — raised to `warning`.

Three docstrings the original commit had made false were corrected, most notably `parse_llm_json_object` still claiming truncated objects are never salvaged directly above the new `salvage_llm_json_object`. Comment prose trimmed 37 → 27 added lines. Added the missing CHANGELOG entry, `PDF_VECTOR_FIGURES` in `.env.example`, and README docs for the re-extract endpoint (it had no consumer and no mention anywhere).

## `bb10e66` — notes preview scroll sync

Out of scope for the images work, folded in at the author's request.

Scroll sync mapped one pane onto the other with a single global ratio, which is correct only at the exact top and bottom: the editor is monospace with one row per source line, the preview is serif prose whose block heights vary with headings, lists, images and KaTeX. Three tight source lines can render as one wrapped paragraph while a five-item list expands into something far taller, so pixels-per-source-line differs by region. Browser zoom compounded it — it rewraps the panes by different amounts, and integer `scrollHeight`/`clientHeight` arithmetic rounds at fractional zoom.

Now line-anchored: a rehype plugin stamps each rendered block with its markdown line, and positions convert by interpolating between bracketing anchors, so each region uses its own measured pixels-per-line. A `ResizeObserver` handles zoom/resize/splitter-drag, none of which change the note text. Bottom affinity is retained — aligning tops alone still hides the just-typed line when the tail renders taller.

## Dependency advisories

Frontend advisories **38 → 6** via `npm audit fix` plus `react-router-dom` 6 → 7.18.2, which closes both open-redirect advisories. The 6 remaining have no non-destructive fix — every fix npm offers for the `@excalidraw` and `openapi-typescript` chains is a *downgrade* from the latest release. `react-router` 7.18.2 carries an RSC-mode CSRF advisory with no fixed release; it does not apply to a `BrowserRouter` SPA, and downgrading would reinstate the open-redirects.

## Verification

`make ci` green on the merged result: **2177 passed, 1 skipped**, plus layer linter, boundary checker, manifest checks, frontend build and `tsc`. 473 vitest tests including 20 new units for the scroll interpolation and line stamping.

**Not verified:** runtime routing behaviour after the react-router major, and the on-screen scroll behaviour. Both need a browser; Chrome automation was unavailable. Routing is tracked in #36. Reviewers should click through tab navigation, a deep-linked document route and browser back, and type at the bottom of a long note at more than one zoom level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
