### PR TITLE
fix(notes): stop the split-view preview from unmounting the app

### DIFF
--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -6,6 +6,7 @@ import remarkMath from "remark-math"
 import rehypeHighlight from "rehype-highlight"
 import rehypeKatex from "rehype-katex"
 import rehypeRaw from "rehype-raw"
+import type { PluggableList } from "unified"
 import "katex/dist/katex.min.css"
 import { API_BASE } from "@/lib/config"
 import { findExcalidrawDiagrams, type ExcalidrawNoteDiagramRef } from "@/lib/noteDiagrams"
@@ -191,10 +192,13 @@ function MarkdownBody({ children, className, validNoteIds, imageSize = "medium",
   // Only inline substitutions — line numbering must survive for scroll sync.
   const processed = preprocessLinks(children)
   const [sizeMenu, setSizeMenu] = useState<{ src: string; x: number; y: number } | null>(null)
-  const rehypePlugins = useMemo(
+  // Options go in a tuple, never applied here: unified calls every entry in this
+  // list as an attacher, so passing an already-applied transformer invokes it
+  // with no tree and throws out of <Markdown>, unmounting the app.
+  const rehypePlugins: PluggableList = useMemo(
     () =>
       trackSourceLines
-        ? [rehypeHighlight, rehypeKatex, rehypeRaw, rehypeSourceLine(sourceLineOffset)]
+        ? [rehypeHighlight, rehypeKatex, rehypeRaw, [rehypeSourceLine, sourceLineOffset]]
         : [rehypeHighlight, rehypeKatex, rehypeRaw],
     [trackSourceLines, sourceLineOffset],
   )

--- a/frontend/src/lib/rehypeSourceLine.wiring.test.tsx
+++ b/frontend/src/lib/rehypeSourceLine.wiring.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { renderToStaticMarkup } from "react-dom/server"
+import ReactMarkdown from "react-markdown"
+import type { PluggableList } from "unified"
+import { SOURCE_LINE_ATTR, rehypeSourceLine } from "./rehypeSourceLine"
+
+/**
+ * Guards how the plugin is *wired*, not what it does. Calling
+ * `rehypeSourceLine(offset)` and putting the result in a plugin list type-checks
+ * and passes a direct unit test, but unified calls every entry as an attacher —
+ * so the already-applied transformer runs with no tree and throws out of
+ * <Markdown>, unmounting the whole app. Only a render catches it.
+ */
+function render(rehypePlugins: PluggableList) {
+  return renderToStaticMarkup(<ReactMarkdown rehypePlugins={rehypePlugins}>{"# One\n\ntwo\n"}</ReactMarkdown>)
+}
+
+describe("rehypeSourceLine wiring", () => {
+  it("renders and stamps source lines when passed as [plugin, options]", () => {
+    const html = render([[rehypeSourceLine, 0]])
+    expect(html).toContain(`${SOURCE_LINE_ATTR}="1"`)
+    expect(html).toContain(`${SOURCE_LINE_ATTR}="3"`)
+  })
+
+  it("applies the line offset", () => {
+    expect(render([[rehypeSourceLine, 10]])).toContain(`${SOURCE_LINE_ATTR}="11"`)
+  })
+
+  it("renders with no options", () => {
+    expect(render([rehypeSourceLine])).toContain(`${SOURCE_LINE_ATTR}="1"`)
+  })
+})


### PR DESCRIPTION
## The bug

Opening a note's **preview / split view** rendered a blank page — no nav rail, no editor, URL intact. The React root was gone. Live on `master` since #35.


## Root cause

`MarkdownRenderer` passed `rehypeSourceLine(sourceLineOffset)` into `rehypePlugins`. unified calls **every entry in that list as an attacher**, so the already-applied transformer ran at freeze time with no tree:

```
TypeError: Cannot read properties of undefined (reading 'children')
    at rehypeSourceLine.ts
    at apply.freeze (react-markdown)
    at Markdown
```

Nothing above `<Markdown>` is an error boundary, so the whole tree unmounted (`#root` children → 0). Only preview/split was affected: it is the sole caller that sets `trackSourceLines`.

## The fix

Options belong in a tuple, never applied at the call site:

```diff
-? [rehypeHighlight, rehypeKatex, rehypeRaw, rehypeSourceLine(sourceLineOffset)]
+? [rehypeHighlight, rehypeKatex, rehypeRaw, [rehypeSourceLine, sourceLineOffset]]
```

The preview now renders and stamps `data-src-line` on all top-level blocks — 57 ascending line anchors on the test note — so the line-anchor scroll sync added in `bb10e66` works for the first time.

## Why the existing test missed it

`rehypeSourceLine.test.ts` calls `rehypeSourceLine(offset)(tree)`, which is the correct two-step order, so it passed while production crashed. The added `rehypeSourceLine.wiring.test.tsx` renders through `ReactMarkdown` + `renderToStaticMarkup`; reverting the wiring under it reproduces the exact production `TypeError`.

## Verification

- Real Chromium against the running app: split view renders in both light and dark, `#root` stays mounted, zero page errors. Reading view stamps nothing by design and no longer errors.
- Frontend suite: 476 passed (39 files). `tsc --noEmit` and `npm run build` clean.

Found by the mount-integrity check in `make verify-router` while verifying #36 — a route render crash leaves the URL and tab title correct, so URL-only assertions pass straight through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
