### PR TITLE
chore(frontend): browser routing verification for the react-router v7 bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ docs/KNOWLEDGE_UNIVERSE.md
 DATA/legal/
 DATA/plays/
 DATA/study/
+
+# router verification artifacts (make verify-router)
+frontend/.router-verify/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev ci backend frontend build start stop lint test test-full test-concurrent test-perf test-e2e test-book-e2e test-book-content test-books-all test-v2 eval eval-d2l eval-d2l-rerank eval-d2l-gen eval-topics golden-d2l logs smoke luminary clean regen-api-types install release docker-build docker-run
+.PHONY: dev ci backend frontend build start stop lint test test-full test-concurrent test-perf test-e2e test-book-e2e test-book-content test-books-all test-v2 eval eval-d2l eval-d2l-rerank eval-d2l-gen eval-topics golden-d2l logs smoke luminary clean regen-api-types verify-router install release docker-build docker-run
 
 LUMINARY_PORT ?= 7820
 
@@ -208,3 +208,12 @@ endif
 
 regen-api-types:
 	cd frontend && npm run regen:api-types
+
+# Client-side routing smoke test in a real browser. Needs the app already
+# running (make luminary) -- it drives the live UI, so it is not part of `make
+# ci`. playwright-core is installed --no-save: a dev-only tool, deliberately
+# kept out of package.json so CI never pulls a browser.
+verify-router:
+	@cd frontend && (node -e "require.resolve('playwright-core')" 2>/dev/null \
+		|| (echo "Installing playwright-core (not saved to package.json)..." && npm install --no-save playwright-core))
+	cd frontend && LUMINARY_URL=$${LUMINARY_URL:-http://localhost:5173} LUMINARY_API=$${LUMINARY_API:-http://localhost:$(LUMINARY_PORT)} node scripts/verify-router.mjs

--- a/docs/router-verification.md
+++ b/docs/router-verification.md
@@ -1,0 +1,56 @@
+# Router verification
+
+Client-side routing is the one layer the automated gates cannot see. `tsc
+--noEmit` and the vitest suite both pass against a broken router, because the
+component/hook API (`Link`, `NavLink`, `Navigate`, `useLocation`,
+`useNavigate`, `useParams`, `useSearchParams`) type-checks identically across
+react-router majors — what changes underneath is runtime behaviour: the history
+stack, `location.state` propagation, and whether a `replace` keeps state.
+
+`make verify-router` drives the live UI in a real Chromium and asserts that
+behaviour. **Re-run it after any react-router upgrade.**
+
+## Running it
+
+```sh
+make luminary        # in one shell; the script drives the running app
+make verify-router   # in another
+```
+
+Overrides: `LUMINARY_URL` (default `http://localhost:5173`), `LUMINARY_API`
+(default `http://localhost:7820`). Exits non-zero if any check fails.
+Screenshots and `results.json` land in `frontend/.router-verify/` (gitignored).
+
+`playwright-core` is installed with `--no-save` on first run, so it never
+enters `package.json` and CI never pulls a browser. The script needs a running
+app, so it is deliberately not part of `make ci`.
+
+## What it asserts
+
+| Area | Check |
+| --- | --- |
+| Tab rail | Every `nav a` destination navigates, sets `aria-current="page"`, and renders content |
+| History | Back ×3 and Forward ×2 replay the exact expected stack, and the view re-renders |
+| Deep links | A pasted document URL opens the reader; a pasted note URL loads the note; both survive a hard refresh |
+| Unknown routes | Self-heal to `/` via the catch-all redirect |
+| `location.state` | A hub card's `state: { from }` reaches `useBackNavigation()` as a labelled back button, and `navigate(-1)` returns to the origin |
+| `setSearchParams` | The library's `?doc=` cleanup strips the param, preserves `state.from` through the `replace`, and adds no history entry |
+| Mount integrity | The app root stays mounted across route and view-mode changes |
+| Console | No react-router warnings |
+
+Checks that depend on library content (a document, a note, an in-progress hub
+card) report `SKIP` with the reason on an empty install rather than failing.
+
+## Why the mount-integrity check exists
+
+A render crash inside a route unmounts the entire React root: the URL stays
+correct, the tab title stays correct, and the page is blank. Any assertion that
+only compares URLs — or counts `body.innerText` characters, which the app shell
+alone satisfies — passes straight through it. Assert on content owned by the
+route (for CodeMirror surfaces, `.cm-content`) and on `#root` having children.
+
+## Scope
+
+The script exercises the dev server. Deep-link URL handling under `make start`
+is served by `serve_spa` in `backend/app/main.py` — a static-file fallback that
+no frontend dependency bump can affect.

--- a/frontend/scripts/verify-router.mjs
+++ b/frontend/scripts/verify-router.mjs
@@ -1,0 +1,270 @@
+/**
+ * Client-side routing smoke test against a running app, in a real browser.
+ *
+ * Routing is the one layer `tsc --noEmit` and the unit suite cannot cover: the
+ * component/hook API type-checks identically across react-router majors, so a
+ * behavioural regression (history stack, location.state, param cleanup) only
+ * shows up at runtime. Re-run this after any react-router bump.
+ *
+ *   make luminary          # app must already be serving
+ *   make verify-router
+ *
+ * Env: LUMINARY_URL (default http://localhost:5173), LUMINARY_API
+ * (default http://localhost:7820). Exits non-zero if any check fails.
+ */
+import { chromium } from "playwright-core"
+import fs from "node:fs"
+import path from "node:path"
+
+const APP = process.env.LUMINARY_URL ?? "http://localhost:5173"
+const API = process.env.LUMINARY_API ?? "http://localhost:7820"
+const OUT = path.resolve(import.meta.dirname, "../.router-verify")
+
+const results = []
+const consoleMsgs = []
+let shotIndex = 0
+
+function check(name, pass, detail) {
+  results.push({ name, status: pass ? "pass" : "fail", detail })
+  console.log(`${pass ? "PASS" : "FAIL"}  ${name}${detail ? " — " + detail : ""}`)
+}
+function skip(name, why) {
+  results.push({ name, status: "skip", detail: why })
+  console.log(`SKIP  ${name} — ${why}`)
+}
+
+async function launch() {
+  // Prefer Playwright's own Chromium; fall back to a locally installed browser
+  // so this runs on a machine that never ran `playwright install`.
+  const attempts = [undefined, "chrome", "msedge", "chromium"]
+  let lastErr
+  for (const channel of attempts) {
+    try {
+      return await chromium.launch(channel ? { channel } : {})
+    } catch (err) {
+      lastErr = err
+    }
+  }
+  throw new Error(
+    `No Chromium-family browser could be launched. Install one with ` +
+      `\`npx playwright install chromium\`.\nLast error: ${lastErr?.message}`
+  )
+}
+
+async function json(url) {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`${res.status} ${url}`)
+  return res.json()
+}
+
+const browser = await launch()
+const page = await browser.newPage({ viewport: { width: 1440, height: 900 } })
+page.on("console", (m) => {
+  if (m.type() === "warning" || m.type() === "error")
+    consoleMsgs.push({ type: m.type(), text: m.text().slice(0, 500), at: page.url() })
+})
+page.on("pageerror", (e) => consoleMsgs.push({ type: "pageerror", text: String(e).slice(0, 500), at: page.url() }))
+
+const here = () => {
+  const u = new URL(page.url())
+  return u.pathname + u.search
+}
+async function settle(ms = 1200) {
+  await page.waitForLoadState("networkidle").catch(() => {})
+  await page.waitForTimeout(ms)
+}
+async function shot(label) {
+  await page.screenshot({ path: `${OUT}/${String(++shotIndex).padStart(2, "0")}-${label}.png` })
+}
+const backButton = () => page.locator("button", { hasText: /^Back to / }).first()
+async function backLabel() {
+  const b = backButton()
+  return (await b.count()) ? (await b.innerText()).trim() : null
+}
+const chars = async () => (await page.locator("body").innerText()).trim().length
+
+fs.rmSync(OUT, { recursive: true, force: true })
+fs.mkdirSync(OUT, { recursive: true })
+
+// -- 1. every tab-rail destination -------------------------------------------
+await page.goto(`${APP}/`, { waitUntil: "networkidle" })
+await settle()
+const rail = await page
+  .locator("nav a")
+  .evaluateAll((els) => els.map((e) => ({ href: new URL(e.href).pathname, label: (e.getAttribute("title") ?? e.innerText).trim().split("\n")[0] })))
+check("app shell renders a tab rail", rail.length > 0, `${rail.length} destinations`)
+await shot("home")
+
+for (const { href, label } of rail) {
+  const link = page.locator(`nav a[href="${href}"]`).first()
+  await link.click()
+  await settle(900)
+  const current = await link.evaluate((e) => e.getAttribute("aria-current"))
+  const size = await chars()
+  check(`rail → ${href} (${label})`, here() === href && current === "page" && size > 50, `url=${here()} aria-current=${current} chars=${size}`)
+  await shot(`rail${href.replace(/\//g, "_")}`)
+}
+
+// -- 2. history stack --------------------------------------------------------
+const trail = rail.map((r) => r.href).filter((h) => h !== "/").slice(0, 5)
+if (trail.length < 4) {
+  skip("browser Back/Forward", `needs 4+ rail destinations, found ${trail.length}`)
+} else {
+  await page.goto(`${APP}/`, { waitUntil: "networkidle" })
+  await settle(700)
+  for (const t of trail) {
+    await page.locator(`nav a[href="${t}"]`).first().click()
+    await settle(700)
+  }
+  const back = []
+  for (let i = 0; i < 3; i++) {
+    await page.goBack()
+    await settle(600)
+    back.push(here())
+  }
+  const expectBack = trail.slice(0, -1).reverse().slice(0, 3)
+  check("browser Back x3 replays the history stack", JSON.stringify(back) === JSON.stringify(expectBack), `${back.join(" → ")} (expected ${expectBack.join(" → ")})`)
+
+  const fwd = []
+  for (let i = 0; i < 2; i++) {
+    await page.goForward()
+    await settle(600)
+    fwd.push(here())
+  }
+  const expectFwd = expectBack.slice(0, -1).reverse()
+  check("browser Forward x2 replays the history stack", JSON.stringify(fwd) === JSON.stringify(expectFwd), `${fwd.join(" → ")} (expected ${expectFwd.join(" → ")})`)
+  check("view re-renders after history navigation", (await chars()) > 100, `chars=${await chars()}`)
+  await shot("after-history")
+}
+
+// -- 3. deep links -----------------------------------------------------------
+const doc = (await json(`${API}/documents?page=1&page_size=1`).catch(() => ({ items: [] }))).items?.[0]
+if (!doc) {
+  skip("document deep link", "library is empty")
+} else {
+  // /library/doc/:id is an alias that Navigate-replaces to /library?doc=, which
+  // the library page then strips — so landing on a bare /library is correct.
+  // The reader affordances, not the URL, are the proof it resolved.
+  const readerOpen = async () =>
+    (await page.locator("button", { hasText: /^Back to library$/ }).count()) > 0 &&
+    (await page.getByText("Sections", { exact: true }).count()) > 0
+  for (const label of ["pasted URL", "hard reload"]) {
+    await page.goto(`${APP}/library/doc/${doc.id}`, { waitUntil: "networkidle" })
+    await settle(1800)
+    check(`deep-link /library/doc/:id opens the reader (${label})`, await readerOpen(), `url=${here()}`)
+  }
+  await shot("deeplink-doc")
+}
+
+const notes = await json(`${API}/notes`).catch(() => [])
+const note = Array.isArray(notes) ? notes[0] : notes?.items?.[0]
+if (!note) {
+  skip("note deep link", "no notes exist")
+} else {
+  const target = `/notes/${note.id}`
+  // The note body lives in a CodeMirror instance, which body.innerText does not
+  // report — assert on the editor content, or an empty editor reads as a pass.
+  const editorChars = async () => ((await page.locator(".cm-content").first().innerText().catch(() => "")) ?? "").trim().length
+  for (const label of ["pasted URL", "hard refresh"]) {
+    if (label === "pasted URL") await page.goto(APP + target, { waitUntil: "networkidle" })
+    else await page.reload({ waitUntil: "networkidle" })
+    await settle(1500)
+    check(`deep-link /notes/:noteId loads the note (${label})`, here() === target && (await editorChars()) > 0, `url=${here()} editorChars=${await editorChars()}`)
+  }
+  await shot("deeplink-note")
+
+  // A render crash inside a route unmounts the whole root and leaves a blank
+  // page with the URL intact, so URL-only assertions miss it entirely.
+  const mounted = async () => (await page.evaluate(() => document.getElementById("root")?.children.length ?? 0)) > 0
+  const preview = page.locator('button[title="Show preview pane"]')
+  if (!(await preview.count())) {
+    skip("preview pane keeps the app mounted", "no preview toggle on this note")
+  } else {
+    await preview.click()
+    await settle(2000)
+    check("toggling the preview pane keeps the app mounted", (await mounted()) && (await editorChars()) > 0, `rootChildren=${await page.evaluate(() => document.getElementById("root")?.children.length ?? 0)} editorChars=${await editorChars()}`)
+    await shot("note-preview-pane")
+  }
+}
+
+await page.goto(`${APP}/no-such-route-exists`, { waitUntil: "networkidle" })
+await settle(1200)
+check("unknown route self-heals to /", here() === "/", `landed ${here()}`)
+
+// -- 4. location.state.from round trip ---------------------------------------
+// Hub cards navigate with { state: { from: "/" } }; useBackNavigation turns that
+// into a labelled back affordance. Both are invisible to the type checker.
+// Some hub cards open a launcher dialog instead of navigating, so try the
+// candidates in turn rather than assuming the first one routes.
+const candidates = page.locator("main button", { hasText: /in Study|card session|review now/i })
+const candidateCount = Math.min(await candidates.count(), 4)
+let routed = null
+for (let i = 0; i < candidateCount; i++) {
+  await page.goto(`${APP}/`, { waitUntil: "networkidle" })
+  await settle(1800)
+  const card = candidates.nth(i)
+  if (!(await card.count())) continue
+  const text = (await card.innerText()).trim().replace(/\n/g, " ").slice(0, 50)
+  await card.click()
+  await settle(1500)
+  if (here() !== "/" && (await backLabel())) {
+    routed = { text, url: here(), label: await backLabel() }
+    break
+  }
+}
+if (!routed) {
+  skip("Hub card → state.from back button", `no navigating study card among ${candidateCount} candidate(s)`)
+} else {
+  check("Hub card → destination renders a state.from back button", routed.label === "Back to Home", `clicked "${routed.text}" → url=${routed.url} label="${routed.label}"`)
+  await shot("state-from-back-label")
+  if (routed.label === "Back to Home") {
+    await backButton().click()
+    await settle(1200)
+    check("back button (navigate(-1)) returns to the origin", here() === "/", `landed ${here()}`)
+  }
+}
+
+// -- 5. setSearchParams(replace, state) preserves state ----------------------
+// The library strips ?doc/?section_id/?page after opening a document. The state
+// must ride through that replace, or the back affordance dies on deep links.
+await page.goto(`${APP}/`, { waitUntil: "networkidle" })
+await settle(1800)
+const progressCard = await page.evaluate(() => {
+  const b = [...document.querySelectorAll("main li > button, main button")].find(
+    (el) => /\d+%/.test(el.innerText ?? "") && (el.innerText ?? "").trim().length > 5
+  )
+  if (!b) return null
+  b.click()
+  return b.innerText.trim().replace(/\n/g, " ").slice(0, 50)
+})
+if (!progressCard) {
+  skip("?doc= cleanup preserves location.state", "no in-progress document card on the hub")
+} else {
+  await settle(1800)
+  const cleaned = here()
+  const label = await backLabel()
+  check("?doc= is stripped by setSearchParams(replace: true)", cleaned.startsWith("/library") && !cleaned.includes("doc="), `clicked "${progressCard}" → ${cleaned}`)
+  check("location.state.from survives the param cleanup", label === "Back to Home", `label="${label}"`)
+  await shot("param-cleanup")
+  await page.goBack()
+  await settle(1200)
+  check("replace: true left no extra history entry", here() === "/", `one Back landed on ${here()}`)
+}
+
+// -- 6. router diagnostics ---------------------------------------------------
+const routerMsgs = consoleMsgs.filter((m) => /router|<Link>|useNavigate|future flag|v7_|relative splat|startTransition|hydrat/i.test(m.text))
+check("no react-router warnings in the console", routerMsgs.length === 0, `${routerMsgs.length} router-related message(s)`)
+
+fs.writeFileSync(`${OUT}/results.json`, JSON.stringify({ app: APP, ran_at: new Date().toISOString(), results, consoleMsgs }, null, 2))
+await browser.close()
+
+const failed = results.filter((r) => r.status === "fail")
+const passed = results.filter((r) => r.status === "pass")
+const skipped = results.filter((r) => r.status === "skip")
+console.log(`\n${passed.length} passed, ${failed.length} failed, ${skipped.length} skipped`)
+if (consoleMsgs.length) {
+  console.log(`\nconsole warnings/errors (${consoleMsgs.length}, router-related: ${routerMsgs.length}):`)
+  for (const m of consoleMsgs.slice(0, 20)) console.log(`  [${m.type}] ${m.text}  @${m.at}`)
+}
+console.log(`\nScreenshots and results.json: ${OUT}`)
+process.exit(failed.length ? 1 : 0)


### PR DESCRIPTION
Closes #36.

## Why

`tsc --noEmit` and the vitest suite both pass against a broken router. The component/hook API (`Link`, `NavLink`, `Navigate`, `useLocation`, `useNavigate`, `useParams`, `useSearchParams`) type-checks identically across react-router majors — what changes underneath is runtime behaviour: the history stack, `location.state` propagation, and whether a `replace` preserves state. #36 was opened because that layer went unverified on the 6.30.3 → 7.18.2 bump.

## What this adds

`make verify-router` drives the running app in a real Chromium and asserts it:

```
make luminary        # app must already be serving
make verify-router
```

| Area | Check |
| --- | --- |
| Tab rail | Every `nav a` destination navigates, sets `aria-current="page"`, renders content |
| History | Back ×3 / Forward ×2 replay the exact expected stack; view re-renders |
| Deep links | Pasted document URL opens the reader; pasted note URL loads the note; both across a hard refresh |
| Unknown routes | Self-heal to `/` |
| `location.state` | A hub card's `state: { from }` reaches `useBackNavigation()` as a labelled back button; `navigate(-1)` returns to the origin |
| `setSearchParams` | The library's `?doc=` cleanup strips the param, preserves `state.from` through the `replace`, and adds no history entry |
| Mount integrity | `#root` stays mounted across route and view changes |
| Console | No react-router warnings |

Checks that depend on library content report `SKIP` with a reason on an empty install rather than failing. `docs/router-verification.md` covers usage and rationale.

## Result on 7.18.2

**25 checks pass, zero router warnings.** No behavioural regression from the v7 major — every #36 checklist item is now covered by an automated assertion rather than a manual pass.

## Deliberate constraints

- `playwright-core` installs `--no-save`, so it never enters `package.json` and CI never pulls a browser.
- The script needs a live app, so it is **not** wired into `make ci`.
- Artifacts (screenshots + `results.json`) go to gitignored `frontend/.router-verify/`.
- The dev server is what gets exercised. Deep-link handling under `make start` is `serve_spa` in `backend/app/main.py`, a static-file fallback no frontend dependency bump can affect.

## Note on the mount-integrity check

That check is what caught the notes split-view crash fixed in #37 — a route render crash leaves the URL and tab title correct and the page blank, so URL-only assertions pass straight through it. **Until #37 merges, this script reports 25 pass / 1 fail on `master`, and the failure is real.** Merge #37 first for a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)