### PR TITLE
ci: allow refactor/, fix/ and ci/ branch prefixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Check Branch Name
         run: |
           BRANCH_NAME=$(echo ${{ github.ref }} | sed 's/refs\/heads\///')
-          if [[ ! $BRANCH_NAME =~ ^(feature\/|bugfix\/|hotfix\/|chore\/|docs\/|feat\/).+ ]]; then
-            echo "Error: Branch name '$BRANCH_NAME' does not follow the convention (feature/..., bugfix/..., hotfix/..., chore/..., docs/..., feat/...)!"
+          if [[ ! $BRANCH_NAME =~ ^(feature\/|bugfix\/|hotfix\/|chore\/|docs\/|feat\/|fix\/|refactor\/|ci\/).+ ]]; then
+            echo "Error: Branch name '$BRANCH_NAME' does not follow the convention (feature/..., bugfix/..., hotfix/..., chore/..., docs/..., feat/..., fix/..., refactor/..., ci/...)!"
             exit 1
           fi
 


### PR DESCRIPTION
The branch-name guard in `ci.yml` accepted `feature/`, `bugfix/`, `hotfix/`, `chore/`, `docs/` and `feat/` only. A push to `refactor/code-quality-security-perf` failed CI in **7 seconds** at the name check, before any build or test ran.

Three prefixes already in use in this repository are rejected the same way:

| prefix | example branch | passes today |
|---|---|---|
| `refactor/` | `refactor/code-quality-security-perf` | no |
| `fix/` | `fix/staple-app-before-dmg` | no |
| `ci/` | `ci/split-build-from-notarization` | no |

All three are conventional-commit types, consistent with the `chore` and `docs` entries already on the list. Pull requests were never affected — the `ci` job runs regardless on `pull_request` events (`ci.yml:30`) — so this only ever bit direct pushes.

Merging this to `master` does not retroactively fix `refactor/code-quality-security-perf`: the guard runs the workflow file from the pushed branch, so that branch needs this commit merged or cherry-picked into it before its own pushes go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)