### PR TITLE
release: 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-09
+
 ### Added
 - **The reader adapts to what you are reading.** A novel, a paper, a technical
   book and a transcript rendered through identical code, so no layout suited any
@@ -51,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A local model chosen in Settings was ignored when a cloud provider became
   unreachable, silently switching models while offline.
 - Opening a large document sent megabytes of duplicated section text.
+- `make eval` always reported zero: it pointed at a port nothing listens on,
+  and on failing to reach a backend it deleted entries from the committed
+  golden manifest rather than saying it could not connect.
 
 ### Note
 Documents ingested before this release keep their old structure until they are

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "luminary-backend"
-version = "0.5.0"
+version = "0.6.0"
 description = "Luminary — local-first personal knowledge and learning assistant"
 requires-python = ">=3.13"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1669,7 +1669,7 @@ wheels = [
 
 [[package]]
 name = "luminary-backend"
-version = "0.5.0"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminary-desktop"
-version = "0.5.0"
+version = "0.6.0"
 description = "Luminary"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminary",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "sh.luminary.app",
   "build": {
     "frontendDist": "boot"


### PR DESCRIPTION
Cuts 0.6.0 on top of the Universal Reader rework (#46).

**Minor, not a patch.** It adds user-facing capability — seven reading profiles and a reader preferences panel — and carries two additive Alembic revisions (`sections.body`, `documents.structure_type`). It also has a migration-shaped caveat readers need to see: documents ingested before this release keep their old structure until re-added, and the reader marks the ones affected.

- `scripts/version.sh 0.6.0` — all four version files agree.
- `CHANGELOG.md` — `[Unreleased]` moved under `[0.6.0]`.
- `make ci` — green.

Headline numbers, all measured rather than estimated:

| | before | after |
|---|---|---|
| technical PDF, paragraphs starting mid-sentence | 77% | 7% |
| technical PDF, running headers/footers in prose | 999 | 0 |
| 135-chapter EPUB, sections | 11 | 144 |
| 135-chapter EPUB, time to readable | 17 min | 86 s |
| prose, characters per line | ~95 | 64 |
| document detail payload, 210-section book | 1,627 KB | 292 KB |

Retrieval evals unchanged or better: book HR@5 0.575 (was 0.55), paper 0.775, d2l 0.84, conversation 1.0.

Tag with `make release` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)