### PR TITLE
test: stop ingestion's library-summary refresh outliving its event loop

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -103,6 +103,7 @@ markers = [
     "unstable: known-broken or environment-flaky; excluded from CI, runnable locally via `uv run pytest -m unstable`",
     "flaky: mark test as flaky for rerunning or skipping",
     "anyio: inert; the anyio plugin is disabled and pytest-asyncio drives async tests",
+    "real_library_summary: opt out of the autouse neutralisation of SummarizationService.refresh_library_summary; for tests whose subject IS that method",
 ]
 
 [dependency-groups]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -240,5 +240,43 @@ def _no_real_library_summary_generation():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _no_real_library_summary_refresh(request):
+    """The same leak, reached from ingestion rather than from chat.
+
+    `enrichment_enqueue_node` fires `_run_pregenerate` as a background task, and
+    `pregenerate` ends by calling `refresh_library_summary`, which streams a
+    library summary and touches the database. A test that runs real ingestion --
+    `test_e2e_upload` does, and needs to -- therefore spawns a DB-touching task
+    that outlives its event loop.
+
+    Observed as a 120s session timeout attributed to `test_e2e_upload`, whose
+    captured stderr carries the real story: `stream_library_summary failed ...
+    no such table: summaries`, the in-memory database of an earlier test already
+    disposed, with aiosqlite's `_connection_worker_thread` still blocked. That
+    thread is why `_drain_leaked_tasks` cannot save it -- a task parked in a
+    thread executor cannot be cancelled, only detached.
+
+    Neutralised rather than suppressed: ingestion still runs for real and still
+    schedules the task, so anything asserting that it was scheduled still holds.
+    Only the part that reaches the database after the loop is gone is removed.
+
+    A test whose subject *is* this method opts out with
+    `@pytest.mark.real_library_summary`, which is what keeps the neutralisation
+    from hiding the behaviour it is meant to keep out of other tests' loops.
+    """
+    if "real_library_summary" in {m.name for m in request.node.iter_markers()}:
+        yield
+        return
+
+    async def _noop(self) -> None:
+        return
+
+    with patch(
+        "app.services.summarizer.SummarizationService.refresh_library_summary", _noop
+    ):
+        yield
+
+
 # Deterministic service stubs live in tests/stubs.py (Belief #25)
 # Test files import directly: from stubs import MockLLMService

--- a/backend/tests/test_library_summary.py
+++ b/backend/tests/test_library_summary.py
@@ -198,6 +198,7 @@ async def test_library_summary_error_when_fewer_than_2_docs(test_db):
     mock_llm.generate.assert_not_called()
 
 
+@pytest.mark.real_library_summary
 @pytest.mark.asyncio
 async def test_library_summary_stays_readable_while_it_refreshes(test_db):
     """A new ingest refreshes the library summary without ever leaving it missing.


### PR DESCRIPTION
Fourth of four stacked branches for 0.7.2. Pre-existing flake, not introduced by the others — surfaced when it failed the release gate.

`make ci` timed out at 120s and blamed `test_e2e_upload`. Its captured stderr named the real cause:

```
app.services.summarizer WARNING : stream_library_summary failed
  sqlite3.OperationalError: no such table: summaries
```

A fire-and-forget library-summary task from an *earlier* test, still running against an in-memory database already disposed, parked in aiosqlite's `_connection_worker_thread` — where cancellation cannot land, so `_drain_leaked_tasks` could only detach it.

**The gap was a second entry point.** `_no_real_library_summary_generation` patches `summary._generate_library_summary_task`, the chat-graph path. But `enrichment_enqueue_node` spawns `_run_pregenerate`, which ends at `SummarizationService.refresh_library_summary` → `stream_library_summary` → the database. Any test running real ingestion spawned a DB-touching task nothing neutralised.

Per-site neutralisation with an opt-out, which is what the two earlier failed attempts at this concluded is the durable fix. Ingestion still runs for real and still schedules the task, so anything asserting it was scheduled still holds; `@pytest.mark.real_library_summary` exempts the one test whose subject *is* that method. Explicitly **not** a timing policy — those wedge GitHub runners and pollute shared Kuzu state.

## On the evidence

Not my other changes: the retrieval change was present in a run that passed 3093 tests with zero timeouts, and the only delta before the failure was a test file that runs *after* `test_e2e_upload` alphabetically.

The flake is intermittent (a re-run of the identical tree passed), so a green run is weak evidence on its own. The positive check is that `test_e2e_upload` and `test_library_summary` run together no longer reach the database from a dead loop, and the opt-out test still exercises the real method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)