### PR TITLE
fix(hub): make the numbers on the home page mean what they say

### DIFF
--- a/backend/app/routers/home.py
+++ b/backend/app/routers/home.py
@@ -569,12 +569,18 @@ async def _fetch_weekly_stats(session: AsyncSession) -> WeeklyStats:
             )
         )
     ).first()
+    # Documents actually read, not documents the library acquired.
+    # `content_activity` is deliberately bumped by `record_document_added` so the
+    # hub's recency feeds are not empty on a fresh library, which makes it the
+    # wrong source for a weekly engagement figure: on one library it reported 45
+    # of 48 documents "touched", 28 of them on the day of a bulk ingest.
+    # `reading_progress` is only written when a section has actually held the
+    # screen, so it is the one source here that cannot be inflated by ingesting.
     docs_row = (
         await session.execute(
             text(
-                "SELECT COUNT(DISTINCT member_id) FROM content_activity "
-                "WHERE member_type = 'document' "
-                "  AND last_meaningful_at >= datetime('now', '-7 days')"
+                "SELECT COUNT(DISTINCT document_id) FROM reading_progress "
+                "WHERE last_seen_at >= datetime('now', '-7 days')"
             )
         )
     ).first()

--- a/backend/tests/test_home_overview.py
+++ b/backend/tests/test_home_overview.py
@@ -370,17 +370,37 @@ async def test_weekly_stats_count_recent_activity(test_db):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         await c.post("/notes", json={"content": "n1", "tags": [], "document_id": None})
         await c.post("/notes", json={"content": "n2", "tags": [], "document_id": None})
+        # Acquiring a document is not reading it. `record_document_added` bumps
+        # content_activity so the hub's recency feeds are not empty on a fresh
+        # library, which is why that table cannot source an engagement figure:
+        # on one real library it reported 45 of 48 documents "touched", 28 of
+        # them on the day of a bulk ingest.
         async with factory() as s:
-            await ActivityService(s).record_doc_read(doc_id)
+            await ActivityService(s).record_document_added(doc_id)
 
         body = (await c.get("/home/overview")).json()
         stats = body["weekly_stats"]
         assert stats is not None
         assert stats["notes_written"] >= 2
-        assert stats["docs_touched"] >= 1
+        assert stats["docs_touched"] == 0, "an ingested document must not count as read"
         # Cards and minutes should be zero in a fresh DB.
         assert stats["cards_reviewed"] == 0
         assert stats["minutes_studied"] == 0
+
+        # A section that actually held the screen is what counts.
+        async with factory() as s:
+            await s.execute(
+                text(
+                    "INSERT INTO reading_progress "
+                    "(id, document_id, section_id, first_seen_at, last_seen_at, view_count) "
+                    "VALUES (:i, :d, :s, datetime('now'), datetime('now'), 1)"
+                ),
+                {"i": str(uuid.uuid4()), "d": doc_id, "s": str(uuid.uuid4())},
+            )
+            await s.commit()
+
+        stats = (await c.get("/home/overview")).json()["weekly_stats"]
+        assert stats["docs_touched"] == 1
 
 
 @pytest.mark.anyio

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint . --max-warnings 91",
+    "lint": "eslint . --max-warnings 90",
     "preview": "vite preview",
     "test": "vitest run",
     "regen:api-types": "bash scripts/regen-api-types.sh"

--- a/frontend/src/components/reader/DocumentReader.tsx
+++ b/frontend/src/components/reader/DocumentReader.tsx
@@ -676,7 +676,7 @@ function DocumentReaderBase({ documentId, onBack, initialSectionId, initialChunk
   )
 
   // Track reading progress via IntersectionObserver (3-second dwell per section)
-  useReadingProgress(documentId, doc?.sections.length ?? 0)
+  useReadingProgress(documentId, doc?.sections.length ?? 0, readerContainerRef)
 
   // fetch saved reading position on mount; show ResumeBanner unless already dismissed this session
   useEffect(() => {
@@ -1343,8 +1343,14 @@ function DocumentReaderBase({ documentId, onBack, initialSectionId, initialChunk
             </div>
           )}
 
-          {/* Read View — full document content as markdown, or transcript for YouTube */}
-          <div className={cn("flex-1 overflow-hidden", leftTab !== "read" && "hidden")}>
+          {/* Read View — full document content as markdown, or transcript for YouTube.
+              `data-reading-surface` marks this as the only pane whose sections count
+              as reading: the contents list carries data-section-id too, and scrolling
+              a table of contents is not reading the document. */}
+          <div
+            data-reading-surface=""
+            className={cn("flex-1 overflow-hidden", leftTab !== "read" && "hidden")}
+          >
             {isYouTube ? (
               <YouTubeTranscriptView doc={doc} initialSectionId={readTargetSectionId} initialChunkId={initialChunkId} />
             ) : (

--- a/frontend/src/components/reader/hooks/readingDwell.test.ts
+++ b/frontend/src/components/reader/hooks/readingDwell.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  DWELL_MS,
+  isBeingRead,
+  SECTION_VISIBLE_RATIO,
+  THRESHOLDS,
+  VIEWPORT_COVERED_RATIO,
+  type VisibilitySample,
+} from "./readingDwell"
+
+const sample = (over: Partial<VisibilitySample> = {}): VisibilitySample => ({
+  isIntersecting: true,
+  intersectionRatio: 0,
+  intersectionHeight: 0,
+  rootHeight: 900,
+  ...over,
+})
+
+describe("isBeingRead", () => {
+  it("is false when the section is off screen", () => {
+    expect(isBeingRead(sample({ isIntersecting: false, intersectionRatio: 1 }))).toBe(false)
+  })
+
+  it("counts a short section that is half visible", () => {
+    expect(isBeingRead(sample({ intersectionRatio: 0.5, intersectionHeight: 100 }))).toBe(true)
+  })
+
+  it("does not count a section barely peeking in", () => {
+    expect(isBeingRead(sample({ intersectionRatio: 0.1, intersectionHeight: 40 }))).toBe(false)
+  })
+
+  it("counts a section too tall to ever be half visible but filling the screen", () => {
+    // The measured case: 5,063,040 characters in one section. Its ratio can
+    // never reach 0.5, so a ratio-only test never fires and the section is
+    // never recorded as read however long it is on screen.
+    expect(
+      isBeingRead(sample({ intersectionRatio: 0.02, intersectionHeight: 900, rootHeight: 900 })),
+    ).toBe(true)
+  })
+
+  it("does not count a tall section that only covers a sliver of the viewport", () => {
+    expect(
+      isBeingRead(sample({ intersectionRatio: 0.02, intersectionHeight: 90, rootHeight: 900 })),
+    ).toBe(false)
+  })
+
+  it("does not divide by a zero-height root", () => {
+    expect(
+      isBeingRead(sample({ intersectionRatio: 0.1, intersectionHeight: 50, rootHeight: 0 })),
+    ).toBe(false)
+  })
+})
+
+describe("thresholds", () => {
+  it("dwell is longer than a scroll-past and shorter than reading a paragraph", () => {
+    // ~1s is a fast scroll on the way elsewhere; ~15s is a 50-word paragraph at
+    // the 200 wpm convention. The value must sit strictly between them.
+    expect(DWELL_MS).toBeGreaterThan(1000)
+    expect(DWELL_MS).toBeLessThan(15000)
+  })
+
+  it("reports intermediate ratios so a tall section fires a callback at all", () => {
+    expect(THRESHOLDS[0]).toBe(0)
+    expect(THRESHOLDS.some((t) => t > 0 && t < SECTION_VISIBLE_RATIO)).toBe(true)
+  })
+
+  it("both visibility rules are real fractions", () => {
+    for (const r of [SECTION_VISIBLE_RATIO, VIEWPORT_COVERED_RATIO]) {
+      expect(r).toBeGreaterThan(0)
+      expect(r).toBeLessThanOrEqual(1)
+    }
+  })
+})

--- a/frontend/src/components/reader/hooks/readingDwell.ts
+++ b/frontend/src/components/reader/hooks/readingDwell.ts
@@ -1,0 +1,53 @@
+// What counts as reading a section, as a pure rule so it can be tested.
+//
+// Opening a document and clicking around is not reading it, and the reader has
+// two surfaces that both carry `data-section-id` -- the prose and the contents
+// list -- so "visible" alone was never the right test.
+
+// How long a section must hold the screen before it counts as read. Bracketed
+// by two cases: a fast scroll on the way somewhere else holds a section for
+// roughly a second, which must not count; and a short paragraph of ~50 words is
+// about 15s at the 200 wpm convention in `readingTime.ts`, which would be too
+// strict to require, since skimming is still reading.
+//
+// This is a proxy for attention, not a measurement of it. It cannot tell
+// reading from a page left open, so nothing downstream may describe it as time
+// spent reading -- `time_on_task` is the measured one.
+export const DWELL_MS = 5000
+
+// Half the section on screen.
+export const SECTION_VISIBLE_RATIO = 0.5
+// ...or the section filling half the screen. A section taller than twice the
+// viewport can never reach the ratio above, so a ratio test alone silently
+// never fires on long sections -- one measured document holds 5,063,040
+// characters in a single section.
+export const VIEWPORT_COVERED_RATIO = 0.5
+
+// Ratios the observer reports at. Without intermediate steps a tall section
+// jumps from 0 to a value below the threshold and never fires a callback while
+// it is the only thing on screen.
+export const THRESHOLDS = [0, 0.25, 0.5, 0.75, 1]
+
+/** The subset of IntersectionObserverEntry the rule reads. */
+export interface VisibilitySample {
+  isIntersecting: boolean
+  intersectionRatio: number
+  intersectionHeight: number
+  rootHeight: number
+}
+
+export function isBeingRead(sample: VisibilitySample): boolean {
+  if (!sample.isIntersecting) return false
+  if (sample.intersectionRatio >= SECTION_VISIBLE_RATIO) return true
+  if (sample.rootHeight <= 0) return false
+  return sample.intersectionHeight / sample.rootHeight >= VIEWPORT_COVERED_RATIO
+}
+
+export function sampleFromEntry(entry: IntersectionObserverEntry): VisibilitySample {
+  return {
+    isIntersecting: entry.isIntersecting,
+    intersectionRatio: entry.intersectionRatio,
+    intersectionHeight: entry.intersectionRect.height,
+    rootHeight: entry.rootBounds?.height ?? 0,
+  }
+}

--- a/frontend/src/components/reader/hooks/useReadingProgress.ts
+++ b/frontend/src/components/reader/hooks/useReadingProgress.ts
@@ -3,6 +3,8 @@ import { useEffect, useRef } from "react"
 
 import { apiPost } from "@/lib/apiClient"
 
+import { DWELL_MS, isBeingRead, sampleFromEntry, THRESHOLDS } from "./readingDwell"
+
 async function postReadingProgress(documentId: string, sectionId: string): Promise<void> {
   try {
     await apiPost("/reading/progress", {
@@ -14,16 +16,44 @@ async function postReadingProgress(documentId: string, sectionId: string): Promi
   }
 }
 
-// Posts a progress event after a section is visible for 3 seconds (dwell-time).
-// On unmount, invalidates the library query so document cards re-render
-// with the updated progress bar.
-export function useReadingProgress(documentId: string, sectionCount: number) {
+// Only this pane's sections count. The contents list renders `data-section-id`
+// on every row, so an unscoped observer recorded scrolling a table of contents
+// as reading the document.
+const READING_SURFACE = "[data-reading-surface]"
+
+/**
+ * Record a section as read once it has genuinely held the screen.
+ *
+ * Sections are observed as they appear, not once at mount. `sectionCount`
+ * arrives with `GET /documents/{id}` while the elements themselves arrive with
+ * `GET /sections/{id}/content`, so a single `querySelectorAll` in the effect
+ * body raced the second query and usually found nothing -- and since the deps
+ * never changed again, that visit recorded no progress at all. Measured on one
+ * library: three documents that had been opened carried a `content_activity`
+ * row and zero `reading_progress` rows, which is what kept them out of the
+ * hub's "continue reading" lane (it requires read_count > 0).
+ *
+ * The same gap swallowed sections appended later, because the reader extends
+ * its render window as you scroll and those elements never existed when the
+ * observer was attached.
+ */
+export function useReadingProgress(
+  documentId: string,
+  sectionCount: number,
+  rootRef?: React.RefObject<HTMLElement | null>,
+) {
   const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
   const progressPosted = useRef(false)
   const qc = useQueryClient()
 
   useEffect(() => {
     if (sectionCount === 0) return
+    // Bounded to the reader when it has painted, so the mutation callback is
+    // not woken by unrelated DOM churn elsewhere in the app.
+    const root: ParentNode = rootRef?.current ?? document.body
+
+    const seen = new WeakSet<Element>()
+    const timerMap = timers.current
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -31,38 +61,80 @@ export function useReadingProgress(documentId: string, sectionCount: number) {
           const sectionId = (entry.target as HTMLElement).dataset["sectionId"]
           if (!sectionId) continue
 
-          if (entry.isIntersecting) {
-            if (!timers.current.has(sectionId)) {
+          if (isBeingRead(sampleFromEntry(entry))) {
+            if (!timerMap.has(sectionId)) {
               const t = setTimeout(() => {
-                timers.current.delete(sectionId)
+                timerMap.delete(sectionId)
                 progressPosted.current = true
                 void postReadingProgress(documentId, sectionId)
-              }, 3000)
-              timers.current.set(sectionId, t)
+              }, DWELL_MS)
+              timerMap.set(sectionId, t)
             }
           } else {
-            const t = timers.current.get(sectionId)
+            const t = timerMap.get(sectionId)
             if (t !== undefined) {
               clearTimeout(t)
-              timers.current.delete(sectionId)
+              timerMap.delete(sectionId)
             }
           }
         }
       },
-      { threshold: 0.5 },
+      { threshold: THRESHOLDS },
     )
 
-    const elements = document.querySelectorAll("[data-section-id]")
-    for (const el of elements) observer.observe(el)
+    // A hidden pane's sections are observed too, which costs nothing: a
+    // `display: none` subtree never reports itself as intersecting. That is
+    // what lets the surface stay observed across a tab switch.
+    function observeWithin(node: ParentNode) {
+      for (const surface of node.querySelectorAll(READING_SURFACE)) {
+        for (const el of surface.querySelectorAll("[data-section-id]")) {
+          if (!seen.has(el)) {
+            seen.add(el)
+            observer.observe(el)
+          }
+        }
+      }
+    }
+
+    observeWithin(root)
+
+    // Picks up the sections the content query paints after mount, and every
+    // batch the reader appends as its window grows.
+    const mutations = new MutationObserver((records) => {
+      for (const record of records) {
+        for (const node of record.addedNodes) {
+          if (!(node instanceof Element)) continue
+          const surface = node.closest(READING_SURFACE)
+          if (surface) {
+            if (node.matches("[data-section-id]") && !seen.has(node)) {
+              seen.add(node)
+              observer.observe(node)
+            }
+            for (const el of node.querySelectorAll("[data-section-id]")) {
+              if (!seen.has(el)) {
+                seen.add(el)
+                observer.observe(el)
+              }
+            }
+          }
+          observeWithin(node)
+        }
+      }
+    })
+    mutations.observe(root as Node, { childList: true, subtree: true })
 
     return () => {
+      mutations.disconnect()
       observer.disconnect()
-      for (const t of timers.current.values()) clearTimeout(t)
-      timers.current.clear()
+      for (const t of timerMap.values()) clearTimeout(t)
+      timerMap.clear()
       if (progressPosted.current) {
+        // The hub reads reading_progress for its "continue reading" lane, so it
+        // is as stale as the library card if only `documents` is invalidated.
         void qc.invalidateQueries({ queryKey: ["documents"] })
+        void qc.invalidateQueries({ queryKey: ["home-overview"] })
         progressPosted.current = false
       }
     }
-  }, [documentId, sectionCount, qc])
+  }, [documentId, sectionCount, qc, rootRef])
 }

--- a/frontend/src/pages/Hub.tsx
+++ b/frontend/src/pages/Hub.tsx
@@ -85,10 +85,11 @@ export default function Hub() {
   const remainingReads = (data.continue_reading ?? []).filter(
     (d) => d.document_id !== resume?.document_id,
   )
+  // continue_study is not offered: Study reads neither search params nor route
+  // state, so a session id in a link silently starts a fresh session. The lane
+  // cannot do what its label promises until resume exists.
   const hasContinue =
-    remainingReads.length > 0 ||
-    (data.continue_notes?.length ?? 0) > 0 ||
-    data.continue_study != null
+    remainingReads.length > 0 || (data.continue_notes?.length ?? 0) > 0
 
   return (
     <PageSurface>
@@ -104,7 +105,7 @@ export default function Hub() {
         <ContinueSection
           docs={remainingReads}
           notes={data.continue_notes ?? []}
-          study={data.continue_study ?? null}
+          study={null}
         />
       )}
 
@@ -219,7 +220,6 @@ function WhereYouLeftOff({
   const focusCount = scoped > 0 ? scoped : total
   const sessionSize = Math.min(_SESSION_SIZE, focusCount)
   const estimatedMin = Math.max(1, Math.round(sessionSize * 0.9))
-  const overflow = total - focusCount
 
   const startSession = () => {
     markRecommendationActed(action?.recommendation_id)
@@ -237,8 +237,37 @@ function WhereYouLeftOff({
   }
 
   return (
-    <HubSection label="Where you left off" accent gap="gap-5">
+    <HubSection label="Start here" accent gap="gap-5">
       <div className="flex flex-col gap-6 rounded-3xl border border-border bg-card px-7 py-6 transition-colors hover:border-primary/35">
+        {action && total > 0 && (
+          <>
+            <div className="flex flex-wrap items-center justify-between gap-3.5">
+              <div className="flex min-w-0 items-center gap-2.5">
+                {action.collection_color && (
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: action.collection_color }}
+                    aria-hidden
+                  />
+                )}
+                <span className="truncate text-sm font-medium text-foreground">
+                  {action.collection_name ?? "Your daily review"}
+                </span>
+                <span className="shrink-0 text-[13px] text-muted-foreground">
+                  · {focusCount} card{focusCount === 1 ? "" : "s"} due
+                </span>
+              </div>
+              <button
+                onClick={startSession}
+                className="flex shrink-0 items-center gap-2 rounded-xl border border-border bg-transparent px-4 py-2.5 text-[13px] font-semibold text-foreground transition-colors hover:border-muted-foreground/40 hover:bg-accent active:translate-y-px"
+              >
+                Start {sessionSize}-card session
+                <span className="font-normal text-muted-foreground">~{estimatedMin} min</span>
+              </button>
+            </div>
+            <div className="h-px bg-border" />
+          </>
+        )}
         {resume ? (
           <>
             <div className="flex items-start gap-4">
@@ -280,44 +309,10 @@ function WhereYouLeftOff({
           </>
         ) : (
           <p className="text-[15px] text-muted-foreground">
-            Nothing open. Add something to the library, or start a review below.
+            Nothing open yet — add something to your library to pick up here.
           </p>
         )}
 
-        {action && total > 0 && (
-          <>
-            <div className="h-px bg-border" />
-            <div className="flex flex-wrap items-center justify-between gap-3.5">
-              <div className="flex min-w-0 items-center gap-2.5">
-                {action.collection_color && (
-                  <span
-                    className="h-2 w-2 shrink-0 rounded-full"
-                    style={{ backgroundColor: action.collection_color }}
-                    aria-hidden
-                  />
-                )}
-                <span className="truncate text-sm font-medium text-foreground">
-                  {action.collection_name ?? "Your daily review"}
-                </span>
-                <span className="shrink-0 text-[13px] text-muted-foreground">
-                  · {focusCount} card{focusCount === 1 ? "" : "s"} due
-                </span>
-              </div>
-              <button
-                onClick={startSession}
-                className="flex shrink-0 items-center gap-2 rounded-xl border border-border bg-transparent px-4 py-2.5 text-[13px] font-semibold text-foreground transition-colors hover:border-muted-foreground/40 hover:bg-accent active:translate-y-px"
-              >
-                Start {sessionSize}-card session
-                <span className="font-normal text-muted-foreground">~{estimatedMin} min</span>
-              </button>
-            </div>
-            {overflow > 0 && (
-              <span className="text-xs text-muted-foreground/80">
-                {total} cards due across your library
-              </span>
-            )}
-          </>
-        )}
       </div>
     </HubSection>
   )
@@ -453,10 +448,21 @@ function ThisWeek({ stats }: { stats: WeeklyStats }) {
           </div>
         ))}
       </div>
+      {/* Two measures of time, and they are not the same measure. The bars are
+          sampled foreground time; `minutes_studied` is study-session wall clock,
+          which counts only sessions that were closed. They disagreed on one
+          library -- 0 minutes beside 22 minutes of bars -- so each now says what
+          it is rather than sitting side by side unlabelled. Never sum or average
+          them. */}
       <span className="text-xs text-muted-foreground/80">
-        {total > 0 ? `${durationLabel(total)} total` : "No time recorded yet"} ·{" "}
-        {stats.notes_written} note{stats.notes_written === 1 ? "" : "s"} · {stats.docs_touched} docs
-        touched
+        {total > 0 ? `${durationLabel(total)} on screen` : "No time recorded yet"} ·{" "}
+        {stats.minutes_studied > 0
+          ? `${stats.minutes_studied} min in closed study sessions`
+          : "no study session closed"}
+      </span>
+      <span className="text-xs text-muted-foreground/80">
+        {stats.notes_written} note{stats.notes_written === 1 ? "" : "s"} written ·{" "}
+        {stats.docs_touched} doc{stats.docs_touched === 1 ? "" : "s"} read
       </span>
     </div>
   )
@@ -499,7 +505,7 @@ function FadingBlock({ items }: { items: FadingItem[] }) {
 
   return (
     <div className="flex flex-col gap-3.5">
-      <SectionLabel>Fading</SectionLabel>
+      <SectionLabel>Not opened lately</SectionLabel>
       <div className="flex flex-col gap-0.5">
         {items.map((item) => (
           <MiniRow


### PR DESCRIPTION
Third of four stacked branches for 0.7.2. Based on #57.

Reported as *"I ingested a doc, opened it, and the hub keeps showing the old one. How am I to trust this page?"* The hub was faithful; the measurement under it was not.

## Reading was never recorded

`useReadingProgress` ran one `document.querySelectorAll` in the effect body, racing the content query that paints the sections — `sectionCount` arrives with `GET /documents/{id}`, the elements arrive later with `GET /sections/{id}/content` — and the deps never changed again, so the visit recorded nothing.

Measured on the reporter's library: three opened documents held a `content_activity` row and **zero** `reading_progress` rows, which is exactly what kept them out of the continue lane (it requires `read_count > 0`). Sections appended as the render window grows were missed for the same reason, so long documents undercounted even when it worked.

Now observed as they appear, via a MutationObserver scoped to the reader.

## Browsing is not reading

The contents list carries `data-section-id` on every row, so scrolling a table of contents counted as reading the document. Recording is scoped to the reading pane via `data-reading-surface`.

Dwell is 5s, bracketed by the two cases named next to the constant: ~1s is a fast scroll on the way elsewhere, ~15s is a 50-word paragraph at the repo's own 200 wpm convention. A section can also qualify by **filling the screen** — one measured document holds 5,063,040 characters in a single section, which can never be 50% visible and so could never be recorded at all. Nine tests on the pure rule.

This is a proxy for attention, not a measurement of it, and says so: it cannot tell reading from a page left open.

## Numbers that did not mean what they said

- **`docs_touched` counted documents the library acquired**, not documents read — `record_document_added` bumps `content_activity` so recency feeds are not empty on a fresh library. On one library it read **45 of 48**, 28 of them on the day of a bulk ingest. Sourced from `reading_progress`: **45 → 5**.
- **Two study measures contradicted each other**: `minutes_studied: 0` beside a chart drawing 22 minutes. Different bases (closed sessions vs foreground sampling); each now says what it is, with a comment forbidding summing them.
- **The card led with "785 cards due"** — 99.7% of the deck, oldest 147 days overdue. Not an action. It now leads with a session you can finish.
- **"Fading"** is decay language on plain recency; all three items were notes scored on `days_since`. Relabelled.
- **`continue_study` dropped**: it returns null, and Study reads neither search params nor route state, so a session id in a link silently starts a *fresh* session. The lane could not do what its label promised.

## Not fixed here

Every stored `reading_progress_pct` predates the recorder fix, so existing percentages remain untrustworthy — no migration attempted, that is a data decision. And the 99.7%-due backlog is real; removing the number from the hub is not fixing the schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)