### PR TITLE
fix(parser): the plain-text fallback stops inventing section headings

### DIFF
--- a/backend/app/services/parser.py
+++ b/backend/app/services/parser.py
@@ -693,18 +693,26 @@ class DocumentParser:
         if result is not None:
             return result
 
-        # Fallback: paragraph-split (for unstructured text files)
+        # Fallback: paragraph-split (for unstructured text files).
+        # The heading stays empty (I-30): a paragraph split out of unstructured
+        # text has no label the source authored, and "Section 3" is a fabricated
+        # one. An empty heading is the signal that the source gave none, so
+        # `sectionTitle()` can derive a navigable label for the contents panel
+        # while nothing else presents it as the author's words. This went
+        # unnoticed while retrieval carried no headings at all; now that a
+        # citation names its section, an invented one would be printed under
+        # "Source" beside a real quote.
         text = read_source_text(file_path)
         paragraphs = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
         sections = [
             Section(
-                heading=f"Section {i + 1}",
+                heading="",
                 level=1,
                 text=para,
                 page_start=0,
                 page_end=0,
             )
-            for i, para in enumerate(paragraphs)
+            for para in paragraphs
         ]
         word_count = len(text.split())
         title = file_path.stem

--- a/backend/tests/test_universal_parser.py
+++ b/backend/tests/test_universal_parser.py
@@ -388,3 +388,24 @@ def test_markdown_heading_depth_survives_segmentation(tmp_path):
     assert by_heading["Outer section"] == 2
     assert by_heading["Inner label"] == 3
     assert by_heading["Second outer"] == 2
+
+
+def test_plain_text_fallback_invents_no_heading(tmp_path):
+    """I-30: a heading is a label the source authored.
+
+    The paragraph-split fallback used to name every paragraph "Section N".
+    Nothing surfaced it while retrieval carried no headings, but a citation
+    now names its section, so an invented label would be printed under
+    "Source" beside a real quote. An empty heading is the signal that the
+    source gave none; `sectionTitle()` derives a navigable label for the
+    contents panel from it without claiming the author wrote it.
+    """
+    from app.services.parser import DocumentParser
+
+    f = tmp_path / "unstructured.txt"
+    f.write_text("First paragraph of prose.\n\nSecond paragraph of prose.\n")
+    parsed = DocumentParser().parse(f, "txt")
+
+    assert parsed.sections, "the fallback produced no sections"
+    for s in parsed.sections:
+        assert s.heading == "", f"invented heading {s.heading!r}"


### PR DESCRIPTION
**I-30 violation**, surfaced by 0.7.2 rather than caused by it.

`parser.py`'s paragraph-split fallback named every paragraph `Section 1`, `Section 2`, … — a label nobody authored. It was harmless for as long as retrieval carried no headings at all. Then 0.7.2 made a citation **name its section**, so an invented label is now printed under "Source" beside a verbatim quote, with the same visual weight as the real thing.

Found by ingesting a one-line `.txt` into the shipped 0.7.2 app and reading the search response back:

```
"section_heading": "Section 1"   <- on a file with no headings at all
```

Measured on a real library: **3 of 595** sections carry an invented name, and a fresh `.txt` ingest reproduces it.

An empty heading is the signal that the source gave none. `sectionTitle()` still derives a navigable label for the contents panel, which needs an entry to navigate with — nothing else presents it as the author's words.

Test fires against the old behaviour: `AssertionError: invented heading 'Section 1'`.

`make ci` green: 3094 backend, 678 frontend, 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)