### PR TITLE
fix(docker): the public image could not serve its own public surfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,13 @@ COPY backend/pyproject.toml /backend/pyproject.toml
 # (same reason surface-manifest.json is placed at / above).
 COPY --from=frontend-build /frontend/dist /frontend/dist
 
-ENV LUMINARY_MODE=public \
+# The venv's bin on PATH, because `resolve_tool` finds tools with
+# `shutil.which`. `uv run` used to put it there; running the interpreter
+# directly does not, so console scripts installed into the venv (yt-dlp) were
+# present on disk and invisible to the app -- a YouTube ingest failed saying
+# yt-dlp was missing while `/app/.venv/bin/yt-dlp --version` answered fine.
+ENV PATH="/app/.venv/bin:${PATH}" \
+    LUMINARY_MODE=public \
     DATA_DIR=/data \
     PORT=7820
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,4 +95,12 @@ EXPOSE 7820
 # DATA_DIR is a volume mount — create it so it exists even without a volume
 RUN mkdir -p /data
 
-CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "7820"]
+# The venv interpreter directly, never `uv run`. `uv run` resolves the project
+# before executing, and it resolves DEFAULT groups -- so every container start
+# downloaded and installed 46 packages (av, ctranslate2, faster-whisper,
+# yt-dlp, arize-phoenix, ruff, pytest) over the network, into the image that
+# had just been built without them. Three things broke at once: the image's
+# dependency curation was undone at runtime, a local-first app needed the
+# network to boot, and the GPL components the licence carve-out exists to keep
+# out of distribution were installed automatically anyway.
+CMD ["/app/.venv/bin/python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "7820"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,16 +45,17 @@ RUN uv sync --frozen --no-default-groups --no-install-project
 # publishes an image), so opting in installs GPL code from upstream by the
 # user's own action, exactly as `apt install ffmpeg` would.
 #
-# One flag does the whole path deliberately. ffmpeg alone leaves the download
+# One flag does the whole path deliberately. ffmpeg alone leaves the downloader
 # and the transcriber missing, and the user hits a second wall with a worse
 # message -- the failure mode `_media_missing_message` exists to prevent.
+# `media` and not `full`: `full` also carries the tree-sitter grammars, and
+# `code_parsing` is a full-mode surface this image does not serve.
 ARG WITH_MEDIA=0
 RUN if [ "$WITH_MEDIA" = "1" ]; then \
       apt-get update && \
       apt-get install -y --no-install-recommends ffmpeg && \
       rm -rf /var/lib/apt/lists/* && \
-      uv sync --frozen --no-default-groups --group full --group media \
-        --no-install-project; \
+      uv sync --frozen --no-default-groups --group media --no-install-project; \
     fi
 
 # Copy app code and the surface manifest.

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,27 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY backend/pyproject.toml backend/uv.lock ./
 RUN uv sync --frozen --no-default-groups --no-install-project
 
+# Audio/video ingestion (MP4, YouTube), off by default.
+#
+# ffmpeg and faster-whisper's PyAV carry x264/x265, which are GPL-2.0-or-later,
+# and Luminary is Apache-2.0 -- so neither may travel inside anything the
+# project distributes. Nothing here breaks that: this image is built on the
+# user's own machine (`docker-compose.yml` uses `build:`, and no workflow
+# publishes an image), so opting in installs GPL code from upstream by the
+# user's own action, exactly as `apt install ffmpeg` would.
+#
+# One flag does the whole path deliberately. ffmpeg alone leaves the download
+# and the transcriber missing, and the user hits a second wall with a worse
+# message -- the failure mode `_media_missing_message` exists to prevent.
+ARG WITH_MEDIA=0
+RUN if [ "$WITH_MEDIA" = "1" ]; then \
+      apt-get update && \
+      apt-get install -y --no-install-recommends ffmpeg && \
+      rm -rf /var/lib/apt/lists/* && \
+      uv sync --frozen --no-default-groups --group full --group media \
+        --no-install-project; \
+    fi
+
 # Copy app code and the surface manifest.
 # surface_manifest.py resolves Path(__file__).parents[2]/surface-manifest.json;
 # in this image __file__=/app/app/surface_manifest.py so parents[2]=/

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ docker-build:
 	docker build -t luminary:latest .
 
 docker-run:
-	docker compose --profile ai up
+	docker compose --profile ai up --build
 
 stop:
 	@pids=$$(lsof -ti :$(LUMINARY_PORT) 2>/dev/null); \

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ WITH_MEDIA=1 docker compose --profile ai up --build
 ```
 
 That installs ffmpeg from Debian plus the download and transcription packages,
-by your own action, and adds roughly 300 MB to the image. Installing ffmpeg on
+by your own action, and adds about 850 MB to the image. Installing ffmpeg on
 the Mac itself does nothing here -- the backend is a Linux container and cannot
 see the host's PATH.
 </details>

--- a/README.md
+++ b/README.md
@@ -163,6 +163,19 @@ Docker (needs [Docker Desktop](https://www.docker.com/products/docker-desktop/) 
 docker compose --profile ai up --build
 ```
 
+Audio, video and YouTube ingestion are **off** in that image — they need ffmpeg
+and a transcriber, which are GPL and never travel inside anything Luminary
+distributes. The image is built on your machine, so you can opt in. PowerShell
+has no inline `VAR=value` form, so set it first:
+
+```powershell
+$env:WITH_MEDIA=1
+docker compose --profile ai up --build
+```
+
+That adds about 850 MB. Installing ffmpeg on Windows itself does nothing for the
+Docker path — the backend is a Linux container and cannot see your `PATH`.
+
 Native, for a proxy or VPN that blocks Docker. In a normal PowerShell window (no admin):
 
 ```powershell
@@ -172,6 +185,10 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; .\scripts\install.ps1   # one-
 
 Open http://localhost:7820 when the log settles. First start downloads models —
 the launcher prints `Luminary is ready` only when it truly is.
+
+The native install covers everything except audio and video. For those, install
+ffmpeg and leave it on `PATH` (`winget install Gyan.FFmpeg`), then add **Speech
+to text** from Settings — Luminary fetches that one itself.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ build needs 20+. Verified end to end on a clean `ubuntu:24.04` container (arm64)
 Docker (needs [Docker Desktop](https://www.docker.com/products/docker-desktop/) running):
 
 ```powershell
-docker compose --profile ai up
+docker compose --profile ai up --build
 ```
 
 Native, for a proxy or VPN that blocks Docker. In a normal PowerShell window (no admin):
@@ -182,8 +182,10 @@ Intel Macs have no native `lancedb` wheel, so `make install` cannot run there.
 ```bash
 git clone https://github.com/nupsea/luminary.git
 cd luminary
-docker compose --profile ai up   # or: make docker-run
+make docker-run
 ```
+
+*(or directly via compose: `docker compose --profile ai up --build`)*
 
 Then open http://localhost:7820. Apple Silicon Macs use the native path above.
 </details>

--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ make docker-run
 *(or directly via compose: `docker compose --profile ai up --build`)*
 
 Then open http://localhost:7820. Apple Silicon Macs use the native path above.
+
+Audio, video and YouTube ingestion are **off** in this image. They need ffmpeg
+and a transcriber, which are GPL and so are never part of anything Luminary
+distributes. The image is built on your machine, so you can opt in:
+
+```bash
+WITH_MEDIA=1 docker compose --profile ai up --build
+```
+
+That installs ffmpeg from Debian plus the download and transcription packages,
+by your own action, and adds roughly 300 MB to the image. Installing ffmpeg on
+the Mac itself does nothing here -- the backend is a Linux container and cannot
+see the host's PATH.
 </details>
 
 > First launch is slow because it downloads ML models. Every launcher polls the

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,7 +56,12 @@ from app.routers.setup import router as setup_router
 from app.routers.study import router as study_router
 from app.routers.summarize import router as summarize_router
 from app.routers.tags import router as tags_router
-from app.services.components import activate_extras, install_ollama_model, resolve_tool
+from app.services.components import (
+    activate_extras,
+    install_ollama_model,
+    resolve_tool,
+    running_in_container,
+)
 from app.services.concept_linker import concept_link_handler
 from app.services.diagram_extractor import diagram_extract_handler
 from app.services.enrichment_worker import get_enrichment_worker
@@ -170,8 +175,10 @@ async def lifespan(app: FastAPI):
     _ffmpeg_path = resolve_tool("ffmpeg")
     if _ffmpeg_path is None:
         logger.warning(
-            "ffmpeg not found at startup — video (MP4) ingestion will be unavailable. "
-            "Add audio and video support from Settings."
+            "ffmpeg not found at startup — video (MP4) ingestion will be unavailable. %s",
+            "Rebuild the image with WITH_MEDIA=1."
+            if running_in_container()
+            else "Add audio and video support from Settings.",
         )
     else:
         logger.info("ffmpeg found at startup", extra={"path": _ffmpeg_path})

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -3,6 +3,7 @@ import hashlib
 import logging
 import re
 import shutil
+import sys
 import tempfile
 import uuid
 from datetime import UTC, datetime
@@ -517,6 +518,15 @@ def _component_labels(component_ids: list[str]) -> str:
 _DETECT_TIMEOUT_SECONDS = 20
 
 
+def _ffmpeg_install_hint() -> str:
+    """The install command for the platform actually running this."""
+    if sys.platform == "win32":
+        return "winget install Gyan.FFmpeg"
+    if sys.platform == "darwin":
+        return "brew install ffmpeg"
+    return "apt install ffmpeg"
+
+
 def _media_missing_message(required: list[str]) -> str:
     """One sentence naming everything missing, and what to do about each kind."""
     fetchable, manual = _installable(required)
@@ -542,9 +552,12 @@ def _media_missing_message(required: list[str]) -> str:
                 f"installing on the host does not reach the container."
             )
         else:
+            # One command for the platform running this, not a list to pick
+            # from. Windows was in neither of the two the message used to name,
+            # so a Windows user was shown brew and apt and left to guess.
             parts.append(
                 f"{names} is found automatically once installed on this machine "
-                f"(for example `brew install ffmpeg` on macOS, `apt install ffmpeg` on Linux)."
+                f"(for example `{_ffmpeg_install_hint()}`)."
             )
     return " ".join(parts)
 

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -518,6 +518,19 @@ def _component_labels(component_ids: list[str]) -> str:
 _DETECT_TIMEOUT_SECONDS = 20
 
 
+def _all_withheld_for_licence(component_ids: list[str]) -> bool:
+    """Whether every named component is genuinely held back by its licence.
+
+    The catalogue marks those "(not distributed with Luminary)". A component
+    with no entry, or a permissive one, is missing for some other reason and
+    must not be described as a licensing decision.
+    """
+    comps = [get_component(cid) for cid in component_ids]
+    return bool(comps) and all(
+        c is not None and "not distributed with Luminary" in (c.licence or "") for c in comps
+    )
+
+
 def _ffmpeg_install_hint() -> str:
     """The install command for the platform actually running this."""
     if sys.platform == "win32":
@@ -530,10 +543,18 @@ def _ffmpeg_install_hint() -> str:
 def _media_missing_message(required: list[str]) -> str:
     """One sentence naming everything missing, and what to do about each kind."""
     fetchable, manual = _installable(required)
-    parts = [
-        f"YouTube needs {_component_labels(required)}, "
-        f"{'which are' if len(required) > 1 else 'which is'} not bundled for licensing reasons."
-    ]
+    # Only claim a licence reason where one exists. yt-dlp is Unlicense, and
+    # saying it was "not bundled for licensing reasons" stated a constraint
+    # that is not real and pointed the user at nothing they could act on.
+    if _all_withheld_for_licence(required):
+        lead = (
+            f"YouTube needs {_component_labels(required)}, "
+            f"{'which are' if len(required) > 1 else 'which is'} not bundled for "
+            f"licensing reasons."
+        )
+    else:
+        lead = f"YouTube needs {_component_labels(required)}."
+    parts = [lead]
     if fetchable:
         parts.append(f"Install {_component_labels(fetchable)} below.")
     if manual:
@@ -573,7 +594,12 @@ def _installable(component_ids: list[str]) -> tuple[list[str], list[str]]:
     fetchable, manual = [], []
     for cid in component_ids:
         comp = get_component(cid)
-        (manual if comp is not None and comp.kind == "tool" else fetchable).append(cid)
+        # An id with no catalogue entry is not fetchable -- there is nothing to
+        # fetch it from. It used to default the other way, so a missing
+        # component the app has no installer for still rendered an "Install"
+        # button, which is the failure this docstring warns about.
+        fetchable_here = comp is not None and comp.kind != "tool"
+        (fetchable if fetchable_here else manual).append(cid)
     return fetchable, manual
 
 
@@ -1040,6 +1066,11 @@ async def ingest_url(
             status_code=503,
             detail={
                 "message": _media_missing_message(required),
+                # Everything missing, whether or not the app can install it.
+                # `components` alone could be empty -- a component with no
+                # catalogue entry is not installable -- and then the payload
+                # named nothing at all while the ingest still refused.
+                "missing": list(required),
                 # Only what the app can actually fetch: a button that fails on
                 # click is worse than no button.
                 "components": _installable(required)[0],

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -74,7 +74,7 @@ from app.services import graph as _graph_module  # indirect: get_graph_service i
 from app.services import youtube_downloader as _yt_module
 from app.services.activity_service import ActivityService
 from app.services.article_extractor import get_article_extractor
-from app.services.components import capabilities, get_component
+from app.services.components import capabilities, get_component, running_in_container
 from app.services.content_classifier import classify_content
 from app.services.document_deletion_service import get_document_deletion_service
 from app.services.document_search import get_document_search_service
@@ -532,10 +532,20 @@ def _media_missing_message(required: list[str]) -> str:
         # bundle's PATH could not see it. It is found automatically now, so the
         # remaining case is genuinely not having it.
         names = _component_labels(manual)
-        parts.append(
-            f"{names} is found automatically once installed on this machine "
-            f"(for example `brew install ffmpeg` on macOS, `apt install ffmpeg` on Linux)."
-        )
+        if running_in_container():
+            # Host advice cannot reach a container: the user installs ffmpeg on
+            # their Mac, the Linux container still cannot see it, and the wall
+            # is identical. The image is the thing that has to change.
+            parts.append(
+                f"{names} is not in this Docker image. Rebuild it with "
+                f"`WITH_MEDIA=1 docker compose --profile ai up --build`; "
+                f"installing on the host does not reach the container."
+            )
+        else:
+            parts.append(
+                f"{names} is found automatically once installed on this machine "
+                f"(for example `brew install ffmpeg` on macOS, `apt install ffmpeg` on Linux)."
+            )
     return " ".join(parts)
 
 

--- a/backend/app/services/components.py
+++ b/backend/app/services/components.py
@@ -277,6 +277,18 @@ _WELL_KNOWN_TOOL_DIRS = (
 )
 
 
+def running_in_container() -> bool:
+    """Whether this process is inside a container.
+
+    This changes what a user can be told to do, not what the app does. A
+    containerised backend cannot see the host's PATH, so `brew install ffmpeg`
+    is advice that succeeds on the host and changes nothing here -- the user
+    follows it and hits the same wall, which is the exact trap the media
+    error message was rewritten once already to avoid.
+    """
+    return Path("/.dockerenv").exists() or Path("/run/.containerenv").exists()
+
+
 def resolve_tool(name: str) -> str | None:
     """Find a tool the user installed, falling back to whatever is on PATH.
 

--- a/backend/app/services/retriever.py
+++ b/backend/app/services/retriever.py
@@ -549,43 +549,51 @@ class HybridRetriever:
                 span.set_attribute("retrieval.rerank_depth", candidate_pool)
                 if threshold is not None:
                     span.set_attribute("retrieval.rerank_threshold", threshold)
+            # Single-leg strategies once returned three steps early, before
+            # rerank, context expansion and location filling. Both halves of
+            # that mattered: the API accepted `strategy=fts&rerank=true` and
+            # silently dropped the rerank, and the ablation's leg arms were
+            # compared against rrf arms that had been through two extra stages,
+            # so "fusion beats its legs" was partly measuring expansion.
+            # Depth mirrors the rrf path: hold the whole candidate pool when
+            # something downstream still has to re-score or filter it.
+            leg_k = candidate_pool if (rerank or date_filtering) else k
             if strategy == "vector":
-                results = await asyncio.to_thread(
-                    self.vector_search, query, document_ids, candidate_pool
+                results = (
+                    await asyncio.to_thread(
+                        self.vector_search, vector_query, document_ids, candidate_pool
+                    )
+                )[:leg_k]
+            elif strategy == "fts":
+                results = (
+                    await self.keyword_search(keyword_query, document_ids, k=candidate_pool)
+                )[:leg_k]
+            elif strategy == "graph":
+                expanded_query = await _graph_expand(vector_query)
+                results = (
+                    await asyncio.to_thread(
+                        self.vector_search, expanded_query, document_ids, candidate_pool
+                    )
+                )[:leg_k]
+            else:
+                vector_results, keyword_results = await asyncio.gather(
+                    asyncio.to_thread(
+                        self.vector_search, vector_query, document_ids, candidate_pool
+                    ),
+                    self.keyword_search(keyword_query, document_ids, k=candidate_pool),
                 )
-                results = results[:k]
-                span.set_attribute("retrieval.chunk_count", len(results))
-                return results
-            if strategy == "fts":
-                results = await self.keyword_search(query, document_ids, k=candidate_pool)
-                results = results[:k]
-                span.set_attribute("retrieval.chunk_count", len(results))
-                return results
-            if strategy == "graph":
-                expanded_query = await _graph_expand(query)
-                results = await asyncio.to_thread(
-                    self.vector_search, expanded_query, document_ids, candidate_pool
+                # When reranking, ask rrf_merge for the full candidate pool so
+                # the cross-encoder can re-score them. Skip diversification
+                # regardless of single-doc scope -- relevance reranking and
+                # section breadth are orthogonal goals; mixing them dilutes the
+                # rerank signal.
+                diversify = (not rerank) and (not scoped_single_doc)
+                results = self.rrf_merge(
+                    vector_results,
+                    keyword_results,
+                    k=leg_k,
+                    diversify=diversify,
                 )
-                results = results[:k]
-                span.set_attribute("retrieval.chunk_count", len(results))
-                return results
-
-            vector_results, keyword_results = await asyncio.gather(
-                asyncio.to_thread(self.vector_search, vector_query, document_ids, candidate_pool),
-                self.keyword_search(keyword_query, document_ids, k=candidate_pool),
-            )
-            # When reranking, ask rrf_merge for the full candidate pool so the
-            # cross-encoder can re-score them. Skip diversification regardless
-            # of single-doc scope -- relevance reranking and section breadth
-            # are orthogonal goals; mixing them dilutes the rerank signal.
-            merge_k = candidate_pool if (rerank or date_filtering) else k
-            diversify = (not rerank) and (not scoped_single_doc)
-            results = self.rrf_merge(
-                vector_results,
-                keyword_results,
-                k=merge_k,
-                diversify=diversify,
-            )
             if date_filtering:
                 results = await self._filter_by_entry_date(results, date_from, date_to)
                 if not rerank:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = [
     "beautifulsoup4>=4.14.3",
     "bleach>=6.3.0",
     "chardet>=6.0.0.post1",
+    # web_ingest is a `public` surface, so the article path has to work in
+    # every install -- these were in `full`, which the Docker image omits.
+    "cloudscraper>=1.2.71",
     "ebooklib>=0.20",
     "fastapi>=0.132.0",
     "fsrs>=6.3.0",
@@ -32,10 +35,16 @@ dependencies = [
     "pydantic-settings>=2.13.1",
     "pillow>=11.0.0",
     "pymupdf>=1.27.1",
+    # Runtime, not tooling: memory_profile.host_ram_gb() sizes the model
+    # profile from it. In `dev` it was absent wherever the app actually
+    # ships, so host RAM read 0 -- which fits_host treats as "unknown" and
+    # waves every model through. The residency guard was inert in Docker.
+    "psutil>=6.1.0",
     "python-docx>=1.2.0",
     "python-json-logger>=4.0.0",
     "python-multipart>=0.0.22",
     "sentence-transformers>=5.2.3",
+    "trafilatura>=2.0.0",
     "sqlalchemy[asyncio]>=2.0.46",
     "uvicorn[standard]>=0.41.0",
     "pymupdf4llm>=1.28.2",
@@ -107,6 +116,16 @@ markers = [
 ]
 
 [dependency-groups]
+# Its own group because two install paths need it and neither needs the other's
+# extras: the desktop bundle takes it through `full`, the Docker media build
+# through `media`. yt-dlp is Unlicense, so it carries none of the constraint
+# below.
+youtube = [
+    # YouTube breaks yt-dlp regularly; a pin that drifts months behind stops
+    # downloading entirely. 2026.3.13 returned "HTTP Error 403: Forbidden" on
+    # every video while 2026.8.19 succeeded on the same URL and machine.
+    "yt-dlp>=2026.8.19",
+]
 # Speech-to-text, kept OUT of `full` on purpose. faster-whisper pulls PyAV,
 # whose wheels bundle libx264 and libx265 (GPL-2.0-or-later). Luminary is
 # Apache-2.0, so those cannot travel inside a distributed installer. The
@@ -116,26 +135,23 @@ markers = [
 # See docs/desktop-bundle.md.
 media = [
     "faster-whisper>=1.2.1",
+    { include-group = "youtube" },
 ]
+# `code_parsing` is a `full`-mode surface, so the grammars stay out of the
+# public image rather than riding along with it.
 full = [
-    # YouTube breaks yt-dlp regularly; a pin that drifts months behind stops
-    # downloading entirely. 2026.3.13 returned "HTTP Error 403: Forbidden" on
-    # every video while 2026.8.19 succeeded on the same URL and machine.
-    "yt-dlp>=2026.8.19",
     "tree-sitter>=0.25.2",
     "tree-sitter-go>=0.25.0",
     "tree-sitter-javascript>=0.25.0",
     "tree-sitter-python>=0.25.0",
     "tree-sitter-rust>=0.24.0",
     "tree-sitter-typescript>=0.23.2",
-    "trafilatura>=2.0.0",
-    "cloudscraper>=1.2.71",
+    { include-group = "youtube" },
 ]
 dev = [
     "arize-phoenix>=13.3.0",
     "langfuse>=3.14.5",
     "httpx>=0.28.1",
-    "psutil>=6.1.0",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "pytest-timeout>=2.4.0",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -45,6 +45,13 @@ dependencies = [
     "python-multipart>=0.0.22",
     "sentence-transformers>=5.2.3",
     "trafilatura>=2.0.0",
+    # Unlicense, so no distribution constraint -- and youtube_ingest is a
+    # `public` surface. Withholding it only moved the user to a second wall
+    # behind a licence message that does not apply to this package.
+    # YouTube breaks yt-dlp regularly; a pin that drifts months behind stops
+    # downloading entirely. 2026.3.13 returned "HTTP Error 403: Forbidden" on
+    # every video while 2026.8.19 succeeded on the same URL and machine.
+    "yt-dlp>=2026.8.19",
     "sqlalchemy[asyncio]>=2.0.46",
     "uvicorn[standard]>=0.41.0",
     "pymupdf4llm>=1.28.2",
@@ -116,16 +123,6 @@ markers = [
 ]
 
 [dependency-groups]
-# Its own group because two install paths need it and neither needs the other's
-# extras: the desktop bundle takes it through `full`, the Docker media build
-# through `media`. yt-dlp is Unlicense, so it carries none of the constraint
-# below.
-youtube = [
-    # YouTube breaks yt-dlp regularly; a pin that drifts months behind stops
-    # downloading entirely. 2026.3.13 returned "HTTP Error 403: Forbidden" on
-    # every video while 2026.8.19 succeeded on the same URL and machine.
-    "yt-dlp>=2026.8.19",
-]
 # Speech-to-text, kept OUT of `full` on purpose. faster-whisper pulls PyAV,
 # whose wheels bundle libx264 and libx265 (GPL-2.0-or-later). Luminary is
 # Apache-2.0, so those cannot travel inside a distributed installer. The
@@ -135,7 +132,6 @@ youtube = [
 # See docs/desktop-bundle.md.
 media = [
     "faster-whisper>=1.2.1",
-    { include-group = "youtube" },
 ]
 # `code_parsing` is a `full`-mode surface, so the grammars stay out of the
 # public image rather than riding along with it.
@@ -146,7 +142,6 @@ full = [
     "tree-sitter-python>=0.25.0",
     "tree-sitter-rust>=0.24.0",
     "tree-sitter-typescript>=0.23.2",
-    { include-group = "youtube" },
 ]
 dev = [
     "arize-phoenix>=13.3.0",

--- a/backend/tests/dependency_groups.py
+++ b/backend/tests/dependency_groups.py
@@ -1,0 +1,33 @@
+"""Resolve PEP 735 dependency groups the way uv installs them.
+
+Shared because two tests ask what a group contains and a naive
+`" ".join(group)` answers differently from the resolver: with
+`{include-group = ...}` a group's real contents are its transitive closure, so
+a GPL dependency could be one hop away from a group that must not carry it and
+a string check would still pass.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+PYPROJECT = tomllib.loads((REPO / "backend" / "pyproject.toml").read_text())
+RAW_GROUPS: dict[str, list] = PYPROJECT["dependency-groups"]
+
+
+def distributions(requirements, *, seen: frozenset[str] = frozenset()) -> set[str]:
+    """Distribution names in a requirement list, following include-group."""
+    out: set[str] = set()
+    for req in requirements:
+        if isinstance(req, str):
+            out.add(re.split(r"[<>=!~\[ ]", req, maxsplit=1)[0].strip().lower())
+        elif isinstance(req, dict) and "include-group" in req:
+            included = req["include-group"]
+            assert included not in seen, f"dependency-group cycle at {included!r}"
+            out |= distributions(RAW_GROUPS[included], seen=seen | {included})
+    return out
+
+
+BASE: set[str] = distributions(PYPROJECT["project"]["dependencies"])
+GROUPS: dict[str, set[str]] = {name: distributions(reqs) for name, reqs in RAW_GROUPS.items()}

--- a/backend/tests/test_ablation_eval.py
+++ b/backend/tests/test_ablation_eval.py
@@ -42,7 +42,9 @@ async def test_retriever_strategy_vector_skips_keyword_and_graph(monkeypatch):
     monkeypatch.setattr(retriever, "vector_search", fake_vector)
     monkeypatch.setattr(retriever, "keyword_search", fail_keyword)
 
-    rows = await retriever.retrieve("query", ["doc-1"], 5, strategy="vector")
+    rows = await retriever.retrieve(
+        "query", ["doc-1"], 5, strategy="vector", expand_context=False
+    )
 
     assert calls == ["vector:query"]
     assert rows[0].chunk_id == "vector-1"
@@ -61,7 +63,9 @@ async def test_retriever_strategy_fts_skips_vector(monkeypatch):
     monkeypatch.setattr(retriever, "vector_search", fail_vector)
     monkeypatch.setattr(retriever, "keyword_search", fake_keyword)
 
-    rows = await retriever.retrieve("query", ["doc-1"], 5, strategy="fts")
+    rows = await retriever.retrieve(
+        "query", ["doc-1"], 5, strategy="fts", expand_context=False
+    )
 
     assert rows[0].chunk_id == "keyword-1"
 
@@ -84,7 +88,9 @@ async def test_retriever_strategy_graph_expands_then_vector(monkeypatch):
     monkeypatch.setattr(retriever_module, "_graph_expand", fake_graph_expand)
     monkeypatch.setattr(retriever, "vector_search", fake_vector)
 
-    rows = await retriever.retrieve("query", ["doc-1"], 5, strategy="graph")
+    rows = await retriever.retrieve(
+        "query", ["doc-1"], 5, strategy="graph", expand_context=False
+    )
 
     assert calls == ["graph:query", "vector:expanded query"]
     assert rows[0].chunk_id == "graph-1"

--- a/backend/tests/test_hint_matching.py
+++ b/backend/tests/test_hint_matching.py
@@ -14,7 +14,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from evals.lib.retrieval_metrics import _norm, compute_hit_rate_5, count_boundary_misses
+from evals.lib.retrieval_metrics import _norm, arm_metrics, compute_hit_rate_5, count_boundary_misses
 
 
 def _sample(hint: str, *chunks: str) -> dict:
@@ -55,3 +55,26 @@ def test_a_genuinely_absent_hint_is_not_a_boundary_miss():
 def test_a_hit_is_never_counted_as_a_boundary_miss():
     hint = "the machine was a thing of brass and ivory and quartz that shimmered oddly"
     assert count_boundary_misses([_sample(hint, hint)]) == 0
+
+
+def test_an_ablation_arm_reports_boundary_misses_alongside_its_hit_rate():
+    """The ablation is the arm a retrieval change is chosen on, and it reported
+    HR@5, MRR and nDCG only. A hint the chunker split scores a miss on every
+    strategy and every depth, so without this it reads as a ranking failure the
+    funnel could fix -- and the whole point of an arm is attribution."""
+    hint = "the machine was a thing of brass and ivory and quartz that shimmered oddly"
+    left, right = hint[:40], hint[40:]
+    split = [_sample(hint, f"prelude {left}", f"{right} coda")]
+
+    metrics = arm_metrics(split)
+
+    assert set(metrics) == {"hit_rate_5", "mrr", "ndcg_10", "boundary_misses"}
+    assert metrics["hit_rate_5"] == 0.0
+    assert metrics["boundary_misses"] == 1, "a split hint is a chunking miss, not a ranking one"
+
+
+def test_an_arm_that_genuinely_missed_reports_no_boundary_miss():
+    """Otherwise the column would excuse every miss and could never fail."""
+    metrics = arm_metrics([_sample("a passage that was never retrieved at all", "unrelated")])
+    assert metrics["hit_rate_5"] == 0.0
+    assert metrics["boundary_misses"] == 0

--- a/backend/tests/test_hint_matching.py
+++ b/backend/tests/test_hint_matching.py
@@ -14,7 +14,12 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from evals.lib.retrieval_metrics import _norm, arm_metrics, compute_hit_rate_5, count_boundary_misses
+from evals.lib.retrieval_metrics import (
+    _norm,
+    arm_metrics,
+    compute_hit_rate_5,
+    count_boundary_misses,
+)
 
 
 def _sample(hint: str, *chunks: str) -> dict:

--- a/backend/tests/test_launchers_do_not_resolve.py
+++ b/backend/tests/test_launchers_do_not_resolve.py
@@ -1,0 +1,65 @@
+"""A shipped launcher must run what was installed, never re-resolve it.
+
+`uv run` resolves the project before executing, and resolves DEFAULT groups --
+here `dev`, `full` and `media`. Every launch therefore reinstalled exactly what
+the installer had deliberately left out, including faster-whisper, whose PyAV
+wheels carry the GPL binaries the licence carve-out exists to keep out of a
+distributed install. It also made a local-first app require the network to
+start, and in the Docker image it pulled 46 packages on every container boot.
+
+Developer entry points (`make dev`, luminary.sh, dev-logs.sh) are excluded on
+purpose: there, resolving on run is the point.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Launchers a user runs after installing, and the Docker image's entrypoint.
+SHIPPED_LAUNCHERS = ("scripts/start.sh", "scripts/install.ps1", "Dockerfile")
+
+
+def _logical_lines(text: str) -> list[str]:
+    """Join shell and PowerShell line continuations.
+
+    PowerShell continues with a trailing backtick, so `Start-Process -FilePath
+    "uv"` and the `-ArgumentList "run", "uvicorn", ...` that follows are one
+    invocation split across physical lines. Scanning physical lines missed it
+    entirely -- this guard passed on install.ps1 while it was still broken.
+    """
+    joined, buf = [], ""
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if line.endswith(("`", "\\")):
+            buf += line[:-1] + " "
+            continue
+        joined.append((buf + line).strip())
+        buf = ""
+    if buf:
+        joined.append(buf.strip())
+    return joined
+
+
+@pytest.mark.parametrize("relpath", SHIPPED_LAUNCHERS)
+def test_a_shipped_launcher_never_resolves_dependencies(relpath):
+    for line in _logical_lines((REPO / relpath).read_text()):
+        if line.startswith("#") or "uvicorn" not in line:
+            continue
+        if not re.search(r"\buv\b", line):
+            continue
+        assert "--no-sync" in line or "--frozen" in line, (
+            f"{relpath} launches uvicorn through uv without --no-sync: {line}"
+        )
+
+
+def test_the_docker_entrypoint_does_not_go_through_uv_at_all():
+    """Nothing to resolve and nothing to shell out to: the image was built with
+    exactly the dependencies it should run."""
+    cmd = [
+        ln for ln in (REPO / "Dockerfile").read_text().splitlines() if ln.startswith("CMD ")
+    ]
+    assert len(cmd) == 1
+    assert "uv" not in cmd[0].split()

--- a/backend/tests/test_media_component_message.py
+++ b/backend/tests/test_media_component_message.py
@@ -60,3 +60,16 @@ def test_the_build_arg_the_message_names_is_wired_end_to_end():
     # full-mode surface, so pulling it here would ship libraries this image
     # has no surface for.
     assert "--group full" not in media_step
+
+
+def test_the_container_runs_what_the_image_was_built_with():
+    """`uv run` resolves the project before executing, and resolves DEFAULT
+    groups. As the CMD it installed 46 packages over the network on every
+    container start -- undoing the image's curation, requiring the network to
+    boot a local-first app, and pulling in the GPL components the licence
+    carve-out keeps out of distribution."""
+    dockerfile = (Path(__file__).resolve().parents[2] / "Dockerfile").read_text()
+    cmd = [ln for ln in dockerfile.splitlines() if ln.startswith("CMD ")]
+    assert len(cmd) == 1, "one CMD, or this guard is reading the wrong line"
+    assert "uv" not in cmd[0].split(), "the runtime entrypoint must not resolve dependencies"
+    assert "/app/.venv/bin/python" in cmd[0]

--- a/backend/tests/test_media_component_message.py
+++ b/backend/tests/test_media_component_message.py
@@ -36,9 +36,20 @@ def test_a_container_says_why_installing_on_the_host_will_not_work(in_container)
     assert "does not reach the container" in _media_missing_message(["ffmpeg"])
 
 
-def test_a_host_install_still_gets_host_advice(on_a_host):
+@pytest.mark.parametrize(
+    "platform,command",
+    [
+        ("win32", "winget install Gyan.FFmpeg"),
+        ("darwin", "brew install ffmpeg"),
+        ("linux", "apt install ffmpeg"),
+    ],
+)
+def test_a_host_install_gets_its_own_platform_command(on_a_host, monkeypatch, platform, command):
+    """Windows was in neither platform the message named, so a Windows user was
+    shown brew and apt and left to work it out."""
+    monkeypatch.setattr("app.routers.documents.sys.platform", platform)
     message = _media_missing_message(["ffmpeg"])
-    assert "brew install ffmpeg" in message
+    assert command in message
     assert "WITH_MEDIA" not in message
 
 

--- a/backend/tests/test_media_component_message.py
+++ b/backend/tests/test_media_component_message.py
@@ -84,3 +84,32 @@ def test_the_container_runs_what_the_image_was_built_with():
     assert len(cmd) == 1, "one CMD, or this guard is reading the wrong line"
     assert "uv" not in cmd[0].split(), "the runtime entrypoint must not resolve dependencies"
     assert "/app/.venv/bin/python" in cmd[0]
+
+
+def test_a_component_with_no_licence_constraint_is_not_blamed_on_licensing(on_a_host):
+    """The dialog said yt-dlp was "not bundled for licensing reasons". yt-dlp is
+    Unlicense; nothing about its licence keeps it out of anything."""
+    from app.routers import documents as docs
+
+    message = docs._media_missing_message(["yt-dlp"])
+    assert "licensing" not in message, message
+
+
+def test_an_unknown_component_is_never_offered_an_install_button():
+    """`_installable` defaulted an unrecognised id to fetchable, so the dialog
+    rendered "Install yt-dlp below" for a component with no catalogue entry and
+    therefore no source to install from."""
+    from app.routers.documents import _installable
+
+    fetchable, manual = _installable(["definitely-not-a-component"])
+    assert fetchable == []
+    assert manual == ["definitely-not-a-component"]
+
+
+def test_the_image_puts_the_venv_on_path_so_tools_resolve():
+    """`resolve_tool` finds tools with `shutil.which`. Running the venv
+    interpreter directly (instead of `uv run`) does not put the venv's bin on
+    PATH, so yt-dlp was installed and invisible: the YouTube dialog reported it
+    missing while `/app/.venv/bin/yt-dlp --version` answered fine."""
+    dockerfile = (Path(__file__).resolve().parents[2] / "Dockerfile").read_text()
+    assert 'ENV PATH="/app/.venv/bin:${PATH}"' in dockerfile

--- a/backend/tests/test_media_component_message.py
+++ b/backend/tests/test_media_component_message.py
@@ -1,0 +1,59 @@
+"""What a user is told when audio/video support is missing.
+
+The remediation has been wrong twice for the same underlying reason: it named
+an action the user could not usefully take. First it said `brew install ffmpeg`
+to bundled-app users who had already done exactly that (the bundle's minimal
+PATH could not see it). Now it said the same thing to a Docker user, whose
+backend is a Linux container that cannot see the host's PATH at all -- they run
+it, it succeeds, and nothing changes.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from app.routers.documents import _media_missing_message
+
+
+@pytest.fixture()
+def in_container(monkeypatch):
+    monkeypatch.setattr("app.routers.documents.running_in_container", lambda: True)
+
+
+@pytest.fixture()
+def on_a_host(monkeypatch):
+    monkeypatch.setattr("app.routers.documents.running_in_container", lambda: False)
+
+
+def test_a_container_is_told_to_rebuild_the_image(in_container):
+    message = _media_missing_message(["ffmpeg"])
+    assert "WITH_MEDIA=1" in message, "the fix is a rebuild, and it must name the flag"
+    assert "brew install" not in message, "host advice cannot reach a container"
+
+
+def test_a_container_says_why_installing_on_the_host_will_not_work(in_container):
+    """Otherwise the user tries the obvious thing first and loses another hour."""
+    assert "does not reach the container" in _media_missing_message(["ffmpeg"])
+
+
+def test_a_host_install_still_gets_host_advice(on_a_host):
+    message = _media_missing_message(["ffmpeg"])
+    assert "brew install ffmpeg" in message
+    assert "WITH_MEDIA" not in message
+
+
+def test_the_build_arg_the_message_names_is_wired_end_to_end():
+    """A rebuild flag that reaches nothing is worse than no advice: the user
+    runs it, the build succeeds, and the feature is still missing."""
+    repo = Path(__file__).resolve().parents[2]
+    dockerfile = (repo / "Dockerfile").read_text()
+    compose = (repo / "docker-compose.yml").read_text()
+
+    assert "ARG WITH_MEDIA" in dockerfile
+    assert "WITH_MEDIA: ${WITH_MEDIA:-0}" in compose, "compose must pass the arg through"
+    # One flag has to cover the whole path. ffmpeg alone leaves the downloader
+    # and the transcriber missing and the user hits a second wall.
+    media_step = dockerfile.split("ARG WITH_MEDIA", 1)[1]
+    assert "ffmpeg" in media_step
+    assert "--group full" in media_step, "yt-dlp lives in the full group"
+    assert "--group media" in media_step, "faster-whisper lives in the media group"

--- a/backend/tests/test_media_component_message.py
+++ b/backend/tests/test_media_component_message.py
@@ -55,5 +55,8 @@ def test_the_build_arg_the_message_names_is_wired_end_to_end():
     # and the transcriber missing and the user hits a second wall.
     media_step = dockerfile.split("ARG WITH_MEDIA", 1)[1]
     assert "ffmpeg" in media_step
-    assert "--group full" in media_step, "yt-dlp lives in the full group"
-    assert "--group media" in media_step, "faster-whisper lives in the media group"
+    assert "--group media" in media_step, "yt-dlp and faster-whisper live there"
+    # `full` also carries the tree-sitter grammars and code_parsing is a
+    # full-mode surface, so pulling it here would ship libraries this image
+    # has no surface for.
+    assert "--group full" not in media_step

--- a/backend/tests/test_public_surface_dependencies.py
+++ b/backend/tests/test_public_surface_dependencies.py
@@ -1,0 +1,94 @@
+"""A `public` surface must be able to run in the image that serves public mode.
+
+Three of them could not. The Docker image installs base dependencies only
+(`uv sync --no-default-groups`), while `web_ingest`, `youtube_ingest` and
+`audio_transcribe` are all declared `mode: public` and every one of their
+libraries sat in a group that install drops. `web_ingest`'s own manifest
+description said "requires the full dependency group" -- the contradiction was
+written down and still shipped.
+
+The GPL carve-out is real and stays, but it has to be declared here rather than
+discovered by a user whose ingest fails.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PYPROJECT = tomllib.loads((REPO / "backend" / "pyproject.toml").read_text())
+
+# The distributions each public ingest surface cannot run without.
+PUBLIC_SURFACE_DISTRIBUTIONS = {
+    "web_ingest": ("trafilatura", "cloudscraper"),
+    "youtube_ingest": ("yt-dlp",),
+    "audio_transcribe": ("faster-whisper",),
+}
+
+# Public surfaces whose dependencies carry GPL-2.0-or-later components, which
+# may not travel inside anything Luminary distributes. These are opt-in at
+# build time (WITH_MEDIA=1) instead of shipping by default.
+GPL_GATED = {"youtube_ingest", "audio_transcribe"}
+
+
+_RAW_GROUPS = PYPROJECT["dependency-groups"]
+
+
+def _names(requirements, *, seen: frozenset[str] = frozenset()) -> set[str]:
+    """Distribution names in a requirement list, resolving PEP 735 includes.
+
+    Without the include-group arm this reports `media` as holding only
+    faster-whisper, which is what uv installs plus everything the include
+    pulls in -- a test that reads groups differently from the resolver would
+    pass while the built image lacked the package.
+    """
+    out: set[str] = set()
+    for req in requirements:
+        if isinstance(req, str):
+            out.add(re.split(r"[<>=!~\[ ]", req, maxsplit=1)[0].strip().lower())
+        elif isinstance(req, dict) and "include-group" in req:
+            included = req["include-group"]
+            assert included not in seen, f"dependency-group cycle at {included!r}"
+            out |= _names(_RAW_GROUPS[included], seen=seen | {included})
+    return out
+
+
+BASE = _names(PYPROJECT["project"]["dependencies"])
+GROUPS = {name: _names(reqs) for name, reqs in _RAW_GROUPS.items()}
+
+
+@pytest.mark.parametrize(
+    "surface", sorted(set(PUBLIC_SURFACE_DISTRIBUTIONS) - GPL_GATED)
+)
+def test_an_ungated_public_surface_ships_in_the_public_image(surface):
+    """Base dependencies are all the Docker image installs, so anything a
+    public surface needs and is allowed to ship has to be there."""
+    missing = [d for d in PUBLIC_SURFACE_DISTRIBUTIONS[surface] if d not in BASE]
+    assert not missing, (
+        f"{surface} is mode=public but {missing} are not base dependencies, "
+        f"so the public image cannot serve it"
+    )
+
+
+@pytest.mark.parametrize("surface", sorted(GPL_GATED))
+def test_a_gpl_gated_surface_is_reachable_through_the_media_opt_in(surface):
+    """The carve-out may withhold these from the image; it may not strand them
+    where no documented install reaches them at all."""
+    missing = [d for d in PUBLIC_SURFACE_DISTRIBUTIONS[surface] if d not in GROUPS["media"]]
+    assert not missing, f"{surface} needs {missing}, which WITH_MEDIA=1 does not install"
+
+
+def test_the_memory_guard_can_actually_read_memory_where_the_app_ships():
+    """psutil sat in `dev`. Absent, host_ram_gb() returns 0, and fits_host reads
+    0 as "unmeasurable" and waves every model through -- so the residency check
+    was inert in exactly the constrained install it exists for."""
+    assert "psutil" in BASE
+
+
+def test_the_public_image_does_not_carry_full_mode_grammars():
+    """code_parsing is mode=full. Shipping five tree-sitter grammars in an image
+    with no surface for them is weight with no feature behind it."""
+    assert not {d for d in BASE if d.startswith("tree-sitter")}
+    assert {d for d in GROUPS["full"] if d.startswith("tree-sitter")}

--- a/backend/tests/test_public_surface_dependencies.py
+++ b/backend/tests/test_public_surface_dependencies.py
@@ -44,8 +44,18 @@ def test_an_ungated_public_surface_ships_in_the_public_image(surface):
 def test_a_gpl_gated_surface_is_reachable_through_the_media_opt_in(surface):
     """The carve-out may withhold these from the image; it may not strand them
     where no documented install reaches them at all."""
-    missing = [d for d in PUBLIC_SURFACE_DISTRIBUTIONS[surface] if d not in GROUPS["media"]]
+    reachable = BASE | GROUPS["media"]
+    missing = [d for d in PUBLIC_SURFACE_DISTRIBUTIONS[surface] if d not in reachable]
     assert not missing, f"{surface} needs {missing}, which WITH_MEDIA=1 does not install"
+
+
+def test_only_a_real_licence_constraint_keeps_a_library_out_of_the_image():
+    """yt-dlp is Unlicense. Holding it back put a permissive 3MB package behind
+    a "not bundled for licensing reasons" dialog naming a constraint that does
+    not exist, and moved the user from the ffmpeg wall to a second one."""
+    assert "yt-dlp" in BASE, "nothing licences yt-dlp out of the public image"
+    # faster-whisper carries PyAV's GPL binaries, so it stays gated.
+    assert "faster-whisper" not in BASE
 
 
 def test_the_memory_guard_can_actually_read_memory_where_the_app_ships():

--- a/backend/tests/test_public_surface_dependencies.py
+++ b/backend/tests/test_public_surface_dependencies.py
@@ -11,14 +11,8 @@ The GPL carve-out is real and stays, but it has to be declared here rather than
 discovered by a user whose ingest fails.
 """
 
-import re
-import tomllib
-from pathlib import Path
-
 import pytest
-
-REPO = Path(__file__).resolve().parents[2]
-PYPROJECT = tomllib.loads((REPO / "backend" / "pyproject.toml").read_text())
+from dependency_groups import BASE, GROUPS
 
 # The distributions each public ingest surface cannot run without.
 PUBLIC_SURFACE_DISTRIBUTIONS = {
@@ -31,32 +25,6 @@ PUBLIC_SURFACE_DISTRIBUTIONS = {
 # may not travel inside anything Luminary distributes. These are opt-in at
 # build time (WITH_MEDIA=1) instead of shipping by default.
 GPL_GATED = {"youtube_ingest", "audio_transcribe"}
-
-
-_RAW_GROUPS = PYPROJECT["dependency-groups"]
-
-
-def _names(requirements, *, seen: frozenset[str] = frozenset()) -> set[str]:
-    """Distribution names in a requirement list, resolving PEP 735 includes.
-
-    Without the include-group arm this reports `media` as holding only
-    faster-whisper, which is what uv installs plus everything the include
-    pulls in -- a test that reads groups differently from the resolver would
-    pass while the built image lacked the package.
-    """
-    out: set[str] = set()
-    for req in requirements:
-        if isinstance(req, str):
-            out.add(re.split(r"[<>=!~\[ ]", req, maxsplit=1)[0].strip().lower())
-        elif isinstance(req, dict) and "include-group" in req:
-            included = req["include-group"]
-            assert included not in seen, f"dependency-group cycle at {included!r}"
-            out |= _names(_RAW_GROUPS[included], seen=seen | {included})
-    return out
-
-
-BASE = _names(PYPROJECT["project"]["dependencies"])
-GROUPS = {name: _names(reqs) for name, reqs in _RAW_GROUPS.items()}
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_retriever_rerank.py
+++ b/backend/tests/test_retriever_rerank.py
@@ -369,3 +369,58 @@ async def test_retrieve_with_rerank_falls_back_when_reranker_fails():
 
     # Fallback to RRF top-5 -- no exception propagated.
     assert len(results) == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strategy", ["vector", "fts", "graph"])
+async def test_a_single_leg_strategy_honours_rerank(strategy):
+    """`strategy=fts&rerank=true` used to return unreranked keyword results.
+
+    The three single-leg branches returned before the rerank block, so /search
+    accepted both parameters and silently applied one. It also skipped context
+    expansion and location filling, which made the eval ablation's leg arms
+    incomparable with its rrf arms -- the comparison the ablation exists for.
+    """
+    pool = [_make_chunk(f"c{i}", f"text {i}", score=1.0 - i * 0.01) for i in range(50)]
+    mock_reranker = MagicMock()
+    # Reverse the leg's own order, so a result that honours the reranker cannot
+    # be confused with one that merely truncated the leg.
+    mock_reranker.score.return_value = [float(i) for i in range(len(pool))]
+
+    retriever = HybridRetriever()
+    with (
+        patch.object(retriever, "vector_search", return_value=pool),
+        patch.object(retriever, "keyword_search", new=AsyncMock(return_value=pool)),
+        patch("app.services.retriever._graph_expand", new=AsyncMock(side_effect=lambda q: q)),
+        patch("app.services.retriever._get_reranker", return_value=mock_reranker),
+        patch("app.services.retriever._expand_context", new=AsyncMock(side_effect=lambda r, k: r)),
+    ):
+        results = await retriever.retrieve(
+            "q", document_ids=["doc-1"], k=5, rerank=True, rerank_blend=0.0,
+            graph_expand=False, strategy=strategy,
+        )
+
+    mock_reranker.score.assert_called_once()
+    scored = mock_reranker.score.call_args[0][1]
+    assert len(scored) == 50, f"{strategy} handed the reranker {len(scored)} candidates, not a pool"
+    assert [c.chunk_id for c in results] == ["c49", "c48", "c47", "c46", "c45"]
+
+
+@pytest.mark.asyncio
+async def test_a_single_leg_strategy_expands_context_like_the_fused_one():
+    """Leg arms skipped expansion while rrf arms got it, so any leg-vs-fusion
+    number was partly measuring the extra stage rather than the ranking."""
+    pool = [_make_chunk(f"c{i}", f"text {i}", score=1.0 - i * 0.01) for i in range(10)]
+    expand = AsyncMock(side_effect=lambda r, k: r)
+
+    retriever = HybridRetriever()
+    with (
+        patch.object(retriever, "vector_search", return_value=pool),
+        patch.object(retriever, "keyword_search", new=AsyncMock(return_value=pool)),
+        patch("app.services.retriever._expand_context", new=expand),
+    ):
+        await retriever.retrieve(
+            "q", document_ids=["doc-1"], k=5, graph_expand=False, strategy="fts"
+        )
+
+    expand.assert_awaited_once()

--- a/backend/tests/test_setup_and_paths.py
+++ b/backend/tests/test_setup_and_paths.py
@@ -366,17 +366,16 @@ def test_transcription_is_kept_out_of_the_bundle_dependency_set():
     installs. The bundle builds `--no-default-groups --group full`; this is the
     guard that keeps `media` separate.
     """
-    import tomllib
+    from dependency_groups import BASE, GROUPS
 
-    from app.paths import pyproject_path
-
-    with pyproject_path().open("rb") as fh:
-        groups = tomllib.load(fh)["dependency-groups"]
-
-    full = " ".join(groups["full"])
-    media = " ".join(groups["media"])
-    assert "faster-whisper" in media
-    assert "faster-whisper" not in full, "GPL-carrying deps must not ship in the installer"
+    assert "faster-whisper" in GROUPS["media"]
+    # Transitive: `full` and `media` both include the `youtube` group, so a
+    # string search over `full`'s own entries would no longer see everything
+    # the installer actually gets.
+    assert "faster-whisper" not in GROUPS["full"], (
+        "GPL-carrying deps must not ship in the installer"
+    )
+    assert "faster-whisper" not in BASE, "nor in the base set every install takes"
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_youtube_ingestion.py
+++ b/backend/tests/test_youtube_ingestion.py
@@ -77,7 +77,11 @@ async def test_ingest_url_returns_503_when_ytdlp_missing(test_db):
     # it can offer the in-app install rather than printing shell instructions.
     detail = resp.json()["detail"]
     assert isinstance(detail, dict)
-    assert detail["components"], "the error must name what is missing"
+    assert detail["missing"], "the error must name what is missing"
+    # yt-dlp has no catalogue entry, so there is nothing to install in-app and
+    # no button may be offered for it. `components` used to carry it anyway,
+    # because an unknown id defaulted to installable.
+    assert detail["components"] == []
 
 
 async def test_ingest_url_returns_503_when_ffmpeg_missing(test_db):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1677,6 +1677,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "bleach" },
     { name = "chardet" },
+    { name = "cloudscraper" },
     { name = "ebooklib" },
     { name = "fastapi" },
     { name = "fsrs" },
@@ -1698,6 +1699,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-sdk" },
     { name = "pillow" },
+    { name = "psutil" },
     { name = "pydantic-settings" },
     { name = "pymupdf" },
     { name = "pymupdf4llm" },
@@ -1706,6 +1708,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "sentence-transformers" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "trafilatura" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -1714,7 +1717,6 @@ dev = [
     { name = "arize-phoenix" },
     { name = "httpx" },
     { name = "langfuse" },
-    { name = "psutil" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
@@ -1723,8 +1725,6 @@ dev = [
     { name = "tiktoken" },
 ]
 full = [
-    { name = "cloudscraper" },
-    { name = "trafilatura" },
     { name = "tree-sitter" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-javascript" },
@@ -1735,6 +1735,10 @@ full = [
 ]
 media = [
     { name = "faster-whisper" },
+    { name = "yt-dlp" },
+]
+youtube = [
+    { name = "yt-dlp" },
 ]
 
 [package.metadata]
@@ -1744,6 +1748,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "bleach", specifier = ">=6.3.0" },
     { name = "chardet", specifier = ">=6.0.0.post1" },
+    { name = "cloudscraper", specifier = ">=1.2.71" },
     { name = "ebooklib", specifier = ">=0.20" },
     { name = "fastapi", specifier = ">=0.132.0" },
     { name = "fsrs", specifier = ">=6.3.0" },
@@ -1765,6 +1770,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.60b1" },
     { name = "opentelemetry-sdk", specifier = ">=1.39.1" },
     { name = "pillow", specifier = ">=11.0.0" },
+    { name = "psutil", specifier = ">=6.1.0" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "pymupdf", specifier = ">=1.27.1" },
     { name = "pymupdf4llm", specifier = ">=1.28.2" },
@@ -1773,6 +1779,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "sentence-transformers", specifier = ">=5.2.3" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.46" },
+    { name = "trafilatura", specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
 ]
 
@@ -1781,7 +1788,6 @@ dev = [
     { name = "arize-phoenix", specifier = ">=13.3.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "langfuse", specifier = ">=3.14.5" },
-    { name = "psutil", specifier = ">=6.1.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
@@ -1790,8 +1796,6 @@ dev = [
     { name = "tiktoken", specifier = ">=0.12.0" },
 ]
 full = [
-    { name = "cloudscraper", specifier = ">=1.2.71" },
-    { name = "trafilatura", specifier = ">=2.0.0" },
     { name = "tree-sitter", specifier = ">=0.25.2" },
     { name = "tree-sitter-go", specifier = ">=0.25.0" },
     { name = "tree-sitter-javascript", specifier = ">=0.25.0" },
@@ -1800,7 +1804,11 @@ full = [
     { name = "tree-sitter-typescript", specifier = ">=0.23.2" },
     { name = "yt-dlp", specifier = ">=2026.8.19" },
 ]
-media = [{ name = "faster-whisper", specifier = ">=1.2.1" }]
+media = [
+    { name = "faster-whisper", specifier = ">=1.2.1" },
+    { name = "yt-dlp", specifier = ">=2026.8.19" },
+]
+youtube = [{ name = "yt-dlp", specifier = ">=2026.8.19" }]
 
 [[package]]
 name = "lxml"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1710,6 +1710,7 @@ dependencies = [
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "trafilatura" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "yt-dlp" },
 ]
 
 [package.dev-dependencies]
@@ -1731,14 +1732,9 @@ full = [
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
     { name = "tree-sitter-typescript" },
-    { name = "yt-dlp" },
 ]
 media = [
     { name = "faster-whisper" },
-    { name = "yt-dlp" },
-]
-youtube = [
-    { name = "yt-dlp" },
 ]
 
 [package.metadata]
@@ -1781,6 +1777,7 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.46" },
     { name = "trafilatura", specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
+    { name = "yt-dlp", specifier = ">=2026.8.19" },
 ]
 
 [package.metadata.requires-dev]
@@ -1802,13 +1799,8 @@ full = [
     { name = "tree-sitter-python", specifier = ">=0.25.0" },
     { name = "tree-sitter-rust", specifier = ">=0.24.0" },
     { name = "tree-sitter-typescript", specifier = ">=0.23.2" },
-    { name = "yt-dlp", specifier = ">=2026.8.19" },
 ]
-media = [
-    { name = "faster-whisper", specifier = ">=1.2.1" },
-    { name = "yt-dlp", specifier = ">=2026.8.19" },
-]
-youtube = [{ name = "yt-dlp", specifier = ">=2026.8.19" }]
+media = [{ name = "faster-whisper", specifier = ">=1.2.1" }]
 
 [[package]]
 name = "lxml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # Audio/video ingestion (MP4, YouTube). Off by default because it
+        # installs GPL components; see the Dockerfile. Turn on with
+        # `WITH_MEDIA=1 docker compose --profile ai up --build`.
+        WITH_MEDIA: ${WITH_MEDIA:-0}
     ports:
       # Loopback-only. The API has no authentication, so publishing on all host
       # interfaces exposed the full library to whatever network the machine was

--- a/evals/lib/retrieval_metrics.py
+++ b/evals/lib/retrieval_metrics.py
@@ -79,6 +79,22 @@ def compute_hit_rate_5(samples: list[dict]) -> float:
     return hits / len(samples)
 
 
+def arm_metrics(samples: list[dict]) -> dict[str, float | int]:
+    """Every metric one ablation arm reports.
+
+    boundary_misses belongs in this set rather than at the call site. An arm is
+    what a retrieval change is chosen on, and HR@5 alone cannot say whether an
+    arm missed because ranking failed or because the chunker split the hint --
+    the second moves with chunk size and is not a funnel property at all.
+    """
+    return {
+        "hit_rate_5": compute_hit_rate_5(samples),
+        "mrr": compute_mrr(samples),
+        "ndcg_10": compute_ndcg_10(samples),
+        "boundary_misses": count_boundary_misses(samples),
+    }
+
+
 def count_boundary_misses(samples: list[dict], k: int = 5) -> int:
     """Misses whose hint spans two retrieved chunks instead of being absent.
 

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -63,6 +63,7 @@ from evals.lib.manifest import (  # noqa: E402
 from evals.lib.retrieval_metrics import (  # noqa: E402
     _extract_hint_norms,
     _norm,
+    arm_metrics,
     compute_hit_rate_5,
     compute_mrr,
     compute_ndcg_10,
@@ -395,15 +396,21 @@ def print_ablation_table(dataset: str, model: str, ablation_metrics: dict) -> No
     print(f"\n{'=' * 56}")
     print(f"  Retrieval ablation -- dataset={dataset}  model={model}")
     print(f"{'=' * 56}")
-    print(f"  {'strategy':<12} {'HR@5':>10} {'MRR':>10} {'NDCG@10':>10}")
+    print(
+        f"  {'strategy':<18} {'HR@5':>9} {'MRR':>9} {'NDCG@10':>9} {'bound':>6}"
+    )
     for strategy, metrics in ablation_metrics.items():
         if strategy == "rrf-pool":
             continue
+        # Indexed, not .get(_, 0.0): a metric that could not be computed must
+        # raise here rather than print a plausible 0.0000 that reads as a
+        # measured collapse.
         print(
-            f"  {strategy:<12} "
-            f"{metrics.get('hit_rate_5', 0.0):>10.4f} "
-            f"{metrics.get('mrr', 0.0):>10.4f} "
-            f"{metrics.get('ndcg_10', 0.0):>10.4f}"
+            f"  {strategy:<18} "
+            f"{metrics['hit_rate_5']:>9.4f} "
+            f"{metrics['mrr']:>9.4f} "
+            f"{metrics['ndcg_10']:>9.4f} "
+            f"{metrics['boundary_misses']:>6d}"
         )
     pool = ablation_metrics.get("rrf-pool")
     if pool:
@@ -411,7 +418,7 @@ def print_ablation_table(dataset: str, model: str, ablation_metrics: dict) -> No
         print("  L1 pool recall (raw RRF, no rerank):")
         for key in sorted(pool, key=lambda s: int(s.rsplit("_", 1)[1])):
             depth = key.rsplit("_", 1)[1]
-            print(f"  {'recall@' + depth:<12} {pool[key]:>10.4f}")
+            print(f"  {'recall@' + depth:<18} {pool[key]:>9.4f}")
     print(f"{'=' * 56}\n")
 
 
@@ -769,11 +776,7 @@ def main() -> None:
                         "relevance": row.get("relevance") or [],
                     }
                 )
-            ablation_metrics[label] = {
-                "hit_rate_5": compute_hit_rate_5(samples),
-                "mrr": compute_mrr(samples),
-                "ndcg_10": compute_ndcg_10(samples),
-            }
+            ablation_metrics[label] = arm_metrics(samples)
 
         # L1 pool recall: Recall@K over the raw RRF pool (no rerank, no fixed-k
         # cut). This is the funnel's recall ceiling stated directly -- a flat

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -198,9 +198,9 @@ _info "uv $("$UV" --version 2>/dev/null | awk '{print $2}')"
 
 _info "Installing dependencies (this pulls Python 3.13 and ~1.6GB of packages)..."
 # Both flags are load-bearing. --no-default-groups drops dev/media (Phoenix,
-# pytest, whisper); --group full adds back trafilatura, cloudscraper, yt-dlp and
-# tree-sitter, without which the install refuses every URL. Keep in step with
-# scripts/macos/stage_python.sh, which builds the same profile.
+# pytest, whisper); --group full adds back yt-dlp and the tree-sitter grammars,
+# without which YouTube and code ingestion refuse everything offered to them.
+# Keep in step with scripts/macos/stage_python.sh, which builds the same profile.
 (
     cd "$APP_DIR/backend"
     UV_PROJECT_ENVIRONMENT="$VENV_DIR" "$UV" sync --no-default-groups --group full --quiet

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -396,8 +396,10 @@ $RepoRoot = (Get-Item -Path $PSScriptRoot).Parent.FullName
 # Backend sync
 Write-Host "[install] Installing backend dependencies..." -ForegroundColor Yellow
 Set-Location -Path "$RepoRoot\backend"
-# `full` carries trafilatura, cloudscraper, yt-dlp and tree-sitter. Without it
-# the install comes up but refuses every URL the UI offers to ingest.
+# `full` adds yt-dlp and the tree-sitter grammars. The article path
+# (trafilatura, cloudscraper) moved to base dependencies, because web_ingest is
+# a `public` surface and the Docker image installs base only -- it was shipping
+# without the libraries its own manifest advertised.
 uv sync --no-default-groups --group full
 
 # Frontend build

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -505,8 +505,12 @@ $env:LUMINARY_MODE = "public"
 $port = 7820
 
 Write-Host "Starting Luminary... (first run downloads models and can take a few minutes)" -ForegroundColor Cyan
+# --no-sync is load-bearing: `uv run` resolves DEFAULT groups (dev, full,
+# media) before executing, so every launch reinstalled what install.ps1
+# deliberately left out -- faster-whisper among them, whose PyAV wheels carry
+# GPL binaries -- and made startup need the network.
 $proc = Start-Process -FilePath "uv" `
-    -ArgumentList "run", "uvicorn", "app.main:app", "--host", "127.0.0.1", "--port", "$port" `
+    -ArgumentList "run", "--no-sync", "uvicorn", "app.main:app", "--host", "127.0.0.1", "--port", "$port" `
     -NoNewWindow -PassThru
 
 # Poll /health so the "ready" banner reflects reality. First run downloads models,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -358,8 +358,10 @@ done
 # Backend deps — public profile (no labs/dev groups)
 # ---------------------------------------------------------------------------
 _info "Syncing backend deps (public profile)..."
-# `full` carries trafilatura, cloudscraper, yt-dlp and tree-sitter. Without it
-# the install comes up but refuses every URL the UI offers to ingest.
+# `full` adds yt-dlp and the tree-sitter grammars. The article path
+# (trafilatura, cloudscraper) moved to base dependencies, because web_ingest is
+# a `public` surface and the Docker image installs base only -- it was shipping
+# without the libraries its own manifest advertised.
 (cd backend && uv sync --no-default-groups --group full)
 
 # ---------------------------------------------------------------------------

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -18,9 +18,15 @@ if [ ! -f "$DIST" ]; then
 fi
 
 cd "$REPO_ROOT/backend"
+# --no-sync is load-bearing. `uv run` resolves the project before executing and
+# resolves DEFAULT groups (dev, full, media), so every launch re-installed what
+# the installer deliberately left out -- including faster-whisper, whose PyAV
+# wheels carry GPL binaries the carve-out exists to keep out of a distributed
+# install. It also made a local-first app need the network to start. Run what
+# the installer chose; never re-resolve it here.
 DATA_DIR="$REPO_ROOT/.luminary" \
 LUMINARY_MODE=public \
-    uv run uvicorn app.main:app --port "$PORT" 2>&1 &
+    uv run --no-sync uvicorn app.main:app --port "$PORT" 2>&1 &
 SERVER_PID=$!
 
 cleanup() {

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -292,7 +292,7 @@
       "labels": {
         "en": "Web search & URL ingestion"
       },
-      "description": "Augment answers with live web search and ingest articles from URLs (requires the full dependency group)."
+      "description": "Augment answers with live web search and ingest articles from URLs."
     },
     {
       "id": "youtube_ingest",


### PR DESCRIPTION
Five Docker-path defects found while chasing a 0.7.6 bug report (Intel Mac, 16 GB, Docker install: PDF ingest failed after a container restart), plus two retrieval-eval fixes found earlier on the same branch.

## Docker

**The container installed 46 packages on every start.** `CMD` was `uv run uvicorn`; `uv run` resolves the project before executing, and resolves *default* groups. Every boot downloaded `av`, `ctranslate2`, `faster-whisper`, `yt-dlp`, `arize-phoenix`, `ruff` and `pytest` into the image that had just been built without them. Three failures in one line: the image's curation was undone at runtime, a local-first app needed the network to boot, and the GPL components the licence carve-out exists to exclude were installed automatically regardless of `WITH_MEDIA`. Now runs the venv interpreter directly — 0 downloads.

**The public image shipped none of its public surfaces' libraries.** `web_ingest`, `youtube_ingest` and `audio_transcribe` are all `mode: public`, and every library behind them sat in a group `uv sync --no-default-groups` drops. `web_ingest`'s own manifest description said "requires the full dependency group".

**`psutil` was a dev dependency.** `memory_profile.host_ram_gb()` reads it; absent, it returns 0, which `fits_host` treats as unmeasurable and waves every model through. The residency guard was inert in exactly the constrained install it exists for. It now fires: `ollama/qwen3.5:4b needs 8GB and this machine has 7GB`.

**Audio/video was unreachable.** No `apt-get` in the image, so no ffmpeg — and the error told users to `brew install ffmpeg`, which installs on a host a Linux container cannot see. Now opt-in via `WITH_MEDIA=1` (+850 MB measured), which installs ffmpeg, yt-dlp and faster-whisper together so there is no second wall.

**Windows.** The media opt-in was documented only under macOS Intel; PowerShell has no inline `VAR=value` form. The missing-ffmpeg message named brew and apt, so Windows users got two commands for other platforms.

## Retrieval eval

`strategy=fts&rerank=true` silently ignored the rerank — the leg strategies returned before the rerank, context-expansion and location-filling steps, so ablation leg arms were being compared against rrf arms that had been through two extra stages.

The ablation reported HR@5/MRR/nDCG but not `boundary_misses`, so an arm could not distinguish a ranking failure from a hint the chunker split.

## Verification

`make ci` green. Both image variants built and run: 0 startup downloads, required libraries present, dev/GPL/full-mode libraries absent, container-aware messages correct.

Not fixed here: ingestion memory scales with document size (measured 0.92 GiB idle → 4.58 GiB peak on a 4.2 MB PDF), which is the actual cause of the reported failure. Separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)