### PR TITLE
fix: container CPU/model budget, install prerequisites, and two measured rejections

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -27,6 +27,25 @@ def _enable_sqlite_pragmas(dbapi_connection, connection_record):  # noqa: ARG001
     cursor.execute("PRAGMA foreign_keys=ON")
     cursor.execute("PRAGMA journal_mode=WAL")
     cursor.execute("PRAGMA busy_timeout=5000")
+    # synchronous stays at WAL's default of FULL, and cache_size/temp_store stay
+    # at their defaults. All three were proposed as "zero risk, high impact" and
+    # measured instead, inside the container on the real data volume:
+    #
+    #   commit cost   FULL 0.960 ms   NORMAL 0.005 ms   (400 commits)
+    #   full ingest   FULL 137s/139s  NORMAL 157s/146s  (same PDF, same image)
+    #
+    # NORMAL is ~190x cheaper per commit and bought nothing end to end, because
+    # commits are not a meaningful share of ingest -- that is GLiNER and the
+    # embedder. Trading durability for an unmeasurable gain is not a trade.
+    #
+    # cache_size=-64000 was rejected outright: the pragma is PER CONNECTION and
+    # make_engine below pools up to 30 (pool_size 10 + max_overflow 20), so it
+    # allows ~1.9GB of page cache on hosts already measured at ~7.7GB of demand
+    # against a 7.8GB Docker VM.
+    #
+    # The premise offered for all three -- that fsync crosses a VirtioFS
+    # boundary -- describes a bind mount. `luminary-data` is a named volume and
+    # lives inside the VM's own filesystem.
     cursor.close()
 
 

--- a/backend/tests/test_compose_matches_the_memory_profile.py
+++ b/backend/tests/test_compose_matches_the_memory_profile.py
@@ -1,0 +1,42 @@
+"""Compose must not hand Ollama a budget the backend has already declined.
+
+`memory_profile` resolves a host under 16GB to `low`, which keeps ONE model
+resident. Compose defaulted OLLAMA_MAX_LOADED_MODELS=2, so on a small container
+the runtime was configured to hold two models while the app had already decided
+it could hold one. `config.py` warns about exactly this class of disagreement,
+citing I-31: a backend and a runtime that disagree about capacity leave the
+extra capacity idle at best, and overcommit the host at worst.
+
+Compose cannot measure the host, so like OLLAMA_NUM_PARALLEL the default is a
+floor that a larger host raises -- never a guess that a smaller host has to
+survive.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+COMPOSE = (REPO / "docker-compose.yml").read_text()
+
+
+def _default_for(var: str) -> str:
+    match = re.search(rf"{var}=\$\{{{var}:-([^}}]+)\}}", COMPOSE)
+    assert match, f"{var} is not set with an overridable default in compose"
+    return match.group(1)
+
+
+def test_compose_defaults_to_one_resident_model():
+    from app.memory_profile import max_resident_models
+
+    assert _default_for("OLLAMA_MAX_LOADED_MODELS") == str(max_resident_models("low"))
+
+
+def test_the_serving_width_default_matches_the_same_profile():
+    """The two knobs are sized by the same reasoning and must not drift apart."""
+    assert _default_for("OLLAMA_NUM_PARALLEL") == "1"
+
+
+def test_python_output_is_unbuffered_in_the_container():
+    """Buffered stdout makes `docker logs` lag the work it describes, which is
+    how a bug report arrives with the interesting lines missing."""
+    assert "PYTHONUNBUFFERED=1" in COMPOSE

--- a/backend/tests/test_ollama_runtime_budget.py
+++ b/backend/tests/test_ollama_runtime_budget.py
@@ -21,6 +21,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 COMPOSE = (REPO / "docker-compose.yml").read_text()
 INSTALL_PS1 = (REPO / "scripts" / "install.ps1").read_text()
+INSTALL_SH = (REPO / "scripts" / "install.sh").read_text()
 
 
 def test_compose_bounds_the_prompt_cache():
@@ -38,3 +39,24 @@ def test_the_bound_is_not_zero():
     every other entry in the registry."""
     assert "LLAMA_ARG_CACHE_RAM:-0}" not in COMPOSE
     assert 'SetEnvironmentVariable("LLAMA_ARG_CACHE_RAM", "0"' not in INSTALL_PS1
+
+
+def test_every_installer_we_control_sets_both_runtime_knobs():
+    """Ollama's defaults are wrong for a laptop in two ways -- an 8192MB prompt
+    cache and a 5-minute unload -- and the backend can set neither, so each
+    install path has to. Compose and the Windows user environment are ours to
+    write; on macOS and Linux the server belongs to the user, so install.sh
+    exports them where it starts one and names them where it cannot."""
+    for knob in ("OLLAMA_KEEP_ALIVE", "LLAMA_ARG_CACHE_RAM"):
+        assert knob in COMPOSE, f"compose does not set {knob}"
+        assert f'SetEnvironmentVariable("{knob}"' in INSTALL_PS1, f"install.ps1 misses {knob}"
+        assert knob in INSTALL_SH, f"install.sh neither exports nor mentions {knob}"
+
+
+def test_the_native_installer_exports_them_to_the_server_it_starts():
+    """Exporting only the two older knobs meant a server this script launched
+    itself still ran with Ollama's defaults for the two new ones."""
+    assert (
+        "export OLLAMA_MAX_LOADED_MODELS OLLAMA_NUM_PARALLEL "
+        "OLLAMA_KEEP_ALIVE LLAMA_ARG_CACHE_RAM" in INSTALL_SH
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,18 @@ services:
     environment:
       - LUMINARY_MODE=public
       - DATA_DIR=/data
+      # Without this, Python buffers stdout when it is a pipe, so `docker logs`
+      # lags the work it is describing -- which is how a bug report arrives with
+      # the interesting lines missing.
+      - PYTHONUNBUFFERED=1
+      # No OMP_NUM_THREADS / MKL_NUM_THREADS cap here, deliberately. Bounding
+      # PyTorch to 4 threads was proposed as the highest-impact laptop fix and
+      # measured the other way: on a 12-vCPU container, the same PDF ingested in
+      # 137s/139s unbounded against 179s/181s at 4 threads -- about 30% slower,
+      # two runs each. Embedding and NER are batched tensor work over thousands
+      # of chunks, which uses the threads; the spin-wait contention story fits
+      # small ops, not this. Set them yourself if you want Luminary to leave
+      # cores for something else.
       # Point the backend at the ollama service. The backend reads OLLAMA_URL
       # (NOT OLLAMA_HOST); its default 127.0.0.1 would resolve to this container.
       - OLLAMA_URL=http://ollama:11434
@@ -45,10 +57,14 @@ services:
     volumes:
       - ollama-models:/root/.ollama
     environment:
-      # Keep the text and vision models resident together so enrichment does
-      # not thrash reloading them. Which models those are is the app's
-      # decision, not compose's -- see LITELLM_DEFAULT_MODEL below.
-      - OLLAMA_MAX_LOADED_MODELS=${OLLAMA_MAX_LOADED_MODELS:-2}
+      # A floor, not a guess -- the same reasoning as OLLAMA_NUM_PARALLEL below.
+      # Two resident models let enrichment keep a reader loaded beside the chat
+      # model instead of thrashing between them, and that is right on a host
+      # with the memory for it. Compose cannot measure the host, and the backend
+      # on a small one resolves to `low`, which keeps ONE model resident -- so
+      # the default here disagreed with the profile the app had already chosen.
+      # Raise it to 2 on a host with 16GB+ available to the container.
+      - OLLAMA_MAX_LOADED_MODELS=${OLLAMA_MAX_LOADED_MODELS:-1}
       # A floor, not a guess: compose cannot measure the host and each slot
       # costs a full KV cache. Set OLLAMA_NUM_PARALLEL=2 on a 24GB+ host.
       - OLLAMA_NUM_PARALLEL=${OLLAMA_NUM_PARALLEL:-1}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -490,6 +490,11 @@ Set-Content -Path $EnvFile -Value $EnvLines -Encoding UTF8
 # more than most machines can spare. A saved prompt state measures 105-206MB, so
 # 512MB holds the two or three recent prompts reuse actually draws on.
 [Environment]::SetEnvironmentVariable("LLAMA_ARG_CACHE_RAM", "512", "User")
+# Residency must be set on the server: LiteLLM's `ollama/` completion path folds
+# a per-call keep_alive into `options`, where Ollama rejects it, so the backend
+# cannot ask for this. Without it the model unloads on Ollama's 5-minute default
+# and the next question pays a full reload.
+[Environment]::SetEnvironmentVariable("OLLAMA_KEEP_ALIVE", "30m", "User")
 Write-Host "[install] Restart Ollama for the server-side profile to take effect." -ForegroundColor Gray
 
 # ---------------------------------------------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,6 +73,12 @@ fi
 # curl for it -- died on a raw "command not found" instead of this script's own
 # error convention. Measured on stock ubuntu:24.04 and debian:bookworm images.
 _have curl || { _err "curl is required and not on PATH. Install it and re-run."; exit 1; }
+# `make` is checked HERE rather than where the SPA build uses it. The guard at
+# the build step already existed and still let a Debian/Fedora/Arch adopter sit
+# through node, uv, ~1.6GB of Python wheels, npm and the model pull before being
+# told to install a prerequisite and start again. Measured on debian:bookworm-slim:
+# the run reached "Building production SPA" and failed there after ten minutes.
+_have make || { _err "make is required and not on PATH. Install it (e.g. build-essential/base-devel) and re-run."; exit 1; }
 
 # ---------------------------------------------------------------------------
 # uv — Python package + project manager
@@ -248,7 +254,14 @@ case "$PROFILE" in
     performance) OLLAMA_MAX_LOADED_MODELS=2; OLLAMA_NUM_PARALLEL=4; VISION_CONCURRENCY=4 ;;
     *)           OLLAMA_MAX_LOADED_MODELS=2; OLLAMA_NUM_PARALLEL=2; VISION_CONCURRENCY=2 ;;
 esac
-export OLLAMA_MAX_LOADED_MODELS OLLAMA_NUM_PARALLEL
+# Ollama's own defaults are not sized for a laptop: the prompt cache is allowed
+# 8192MB (more than a small machine has in total) and models unload after 5
+# minutes, paying a full reload on the next question. The backend cannot set
+# either -- LiteLLM's `ollama/` completion path folds keep_alive into `options`,
+# where Ollama rejects it -- so they belong wherever the server is started.
+OLLAMA_KEEP_ALIVE="${OLLAMA_KEEP_ALIVE:-30m}"
+LLAMA_ARG_CACHE_RAM="${LLAMA_ARG_CACHE_RAM:-512}"
+export OLLAMA_MAX_LOADED_MODELS OLLAMA_NUM_PARALLEL OLLAMA_KEEP_ALIVE LLAMA_ARG_CACHE_RAM
 _info "Profile '$PROFILE': OLLAMA_MAX_LOADED_MODELS=$OLLAMA_MAX_LOADED_MODELS OLLAMA_NUM_PARALLEL=$OLLAMA_NUM_PARALLEL ENRICHMENT_VISION_CONCURRENCY=$VISION_CONCURRENCY"
 
 # The chat model follows the profile, because on `public` the runtime keeps one
@@ -330,11 +343,11 @@ if ! curl -sf --max-time 2 http://localhost:11434/api/version >/dev/null 2>&1; t
     # brew services / launchd do not inherit our exported env; warn if that path ran.
     if [ "$OS" = "Darwin" ] && _have brew && pgrep -f "Ollama" >/dev/null 2>&1; then
         _warn "If Ollama is managed by brew services, apply the profile with:"
-        _warn "  launchctl setenv OLLAMA_MAX_LOADED_MODELS $OLLAMA_MAX_LOADED_MODELS && launchctl setenv OLLAMA_NUM_PARALLEL $OLLAMA_NUM_PARALLEL && brew services restart ollama"
+        _warn "  launchctl setenv OLLAMA_MAX_LOADED_MODELS $OLLAMA_MAX_LOADED_MODELS && launchctl setenv OLLAMA_NUM_PARALLEL $OLLAMA_NUM_PARALLEL && launchctl setenv OLLAMA_KEEP_ALIVE $OLLAMA_KEEP_ALIVE && launchctl setenv LLAMA_ARG_CACHE_RAM $LLAMA_ARG_CACHE_RAM && brew services restart ollama"
     fi
 else
     _warn "Ollama already running — restart it to apply the profile:"
-    _warn "  OLLAMA_MAX_LOADED_MODELS=$OLLAMA_MAX_LOADED_MODELS OLLAMA_NUM_PARALLEL=$OLLAMA_NUM_PARALLEL ollama serve   (after stopping the current server)"
+    _warn "  OLLAMA_MAX_LOADED_MODELS=$OLLAMA_MAX_LOADED_MODELS OLLAMA_NUM_PARALLEL=$OLLAMA_NUM_PARALLEL OLLAMA_KEEP_ALIVE=$OLLAMA_KEEP_ALIVE LLAMA_ARG_CACHE_RAM=$LLAMA_ARG_CACHE_RAM ollama serve   (after stopping the current server)"
 fi
 
 # Pull models only if not already cached.
@@ -374,10 +387,6 @@ if [ ! -d frontend/node_modules ] \
 fi
 
 _info "Building production SPA..."
-# Fedora and Arch base images carry curl but not make, so a bare container got
-# all the way through uv/node/ollama and the model pull before dying here on
-# the same raw "command not found" curl now has a guard against above.
-_have make || { _err "make is required and not on PATH. Install it (e.g. build-essential/base-devel) and re-run."; exit 1; }
 make build
 
 if [ "$OLLAMA_MAX_LOADED_MODELS" -le 1 ]; then


### PR DESCRIPTION
Continues the runtime-budget work with items verified by running them, plus a review of a proposed optimisation plan where two of its headline items were measured and rejected.

## Shipped

**`OLLAMA_MAX_LOADED_MODELS` 2 → 1.** Compose configured the runtime to hold two resident models while the backend on a host under 16GB resolves to `low`, which holds one — the runtime was given a budget the app had already declined. `config.py` warns about this class of disagreement citing I-31. Like `OLLAMA_NUM_PARALLEL`, it is a floor a larger host raises, not a guess a smaller host must survive.

**`make` is checked before downloading 1.6GB, not after.** Found by running `scripts/install.sh` on a clean `debian:bookworm-slim`: it installed Node, uv, every Python wheel and all 748 npm packages, then failed at "Building production SPA" because `make` was absent — roughly ten minutes in. The guard existed but sat at the point of use, and its own comment records the same failure being found on Fedora and Arch. Now 0s instead of ~10 minutes, with the full install verified to `exit=0` afterwards.

**Both Ollama runtime knobs now set on every install path.** Compose had `OLLAMA_KEEP_ALIVE` and `LLAMA_ARG_CACHE_RAM`; `install.ps1` had only the cache bound; `install.sh` had neither — so a server it launches itself ran with Ollama's defaults (8192MB prompt cache, 5-minute unload) that the backend cannot override, because LiteLLM's `ollama/` completion path folds `keep_alive` into `options` where Ollama rejects it. `install.sh` now exports both to a server it starts and names both in the guidance where the server is the user's.

**`PYTHONUNBUFFERED=1`**, so `docker logs` stops lagging the work it describes.

## Measured and rejected

Recorded as comments at the exact lines where someone would add them next, so the evidence is found before the experiment is repeated.

**PyTorch threads bounded to 4** — proposed as the highest-impact laptop fix. Same PDF, same image, 12-vCPU container: **137s/139s unbounded against 179s/181s at 4 threads**, two runs each. About 30% slower. Embedding and NER are batched tensor work over thousands of chunks, which uses the threads; the spin-wait contention story fits small ops, not this.

**SQLite `synchronous=NORMAL`** — 0.960 ms/commit at FULL against 0.005 ms at NORMAL, and **137s/139s against 157s/146s** for a full ingest. 190x cheaper per commit, nothing end to end, because commits are not a meaningful share of ingest. `cache_size=-64000` rejected outright: the pragma is per connection and `make_engine` pools up to 30, so it permits ~1.9GB of page cache on hosts already at ~7.7GB of demand against a 7.8GB VM. The premise offered for all three — fsync crossing a VirtioFS boundary — describes a bind mount; `luminary-data` is a named volume inside the VM.

## Verification

`make ci` green. `make smoke` 172 passed / 4 failed, all four explained and none a regression: S212 (the known MRR gate), S167 (known intermittent), and S79/S80, which are model-expiry latency — both pass with the model warm (S79 14s, relational 8.4s, comparative 14.1s). Proven rather than assumed: `keep_alive` inside `options` leaves Ollama's UNTIL at 4 minutes, top-level sets it to 29, so the kwarg never worked and removing it changed nothing.

Not verified: `install.ps1` cannot be executed here (it fetches Windows binaries), so Windows remains syntax-checked by CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)