### PR TITLE
release: 0.7.7 — the Docker path, found by running it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.7] - 2026-08-24
+
+### Fixed
+- **The Docker stack would not start if you already had Ollama installed.** The
+  daemon reported `bind: address already in use` and nothing explained it. The
+  port was never needed -- the app reaches Ollama over the compose network.
+- **A first run reported the chat model missing.** The app warmed up in parallel
+  with the model pull, so it asked an empty Ollama for a model that was still
+  downloading. It waits for the pull now.
+- **The startup warm-up cancelled the model load it exists to avoid.** Its 60s
+  timeout was shorter than a cold load on a CPU-only host, and giving up closed
+  the connection, which makes Ollama abandon the load. Every later request then
+  started from nothing.
+- **A book took minutes longer to open than it needed to.** Section summaries
+  ran inline for documents under 40 sections, and each one is an LLM call:
+  `alice_in_wonderland` spent 330 of its 390-second ingest on 12 of them. They
+  now run behind the document becoming readable whenever generation is local --
+  `frankenstein`, a longer book, reaches complete in 85s.
+- **Ollama was allowed an 8192 MB prompt cache on every machine**, more than a
+  default Docker VM has in total, and models unloaded after 5 minutes because
+  the backend could not set `keep_alive` where Ollama reads it.
+- **Peak ingest memory scaled with document size** rather than with a batch.
+- **A YouTube URL is no longer parsable as a yt-dlp option**, and previewing a
+  parse no longer leaves the uploaded file behind.
+
+### Changed
+- The README states measured memory: 12 GB working, 8 GB floor, and that a
+  Docker VM rather than the host is what counts.
+- Saving an API key in Settings on a Docker install stores it in the database in
+  plain text -- there is no OS keyring in a container. Now documented where the
+  claim is made.
+
 ## [0.7.6] - 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -320,8 +320,14 @@ Run `make models` to print what your configuration costs, which roles resolve to
 which model, and any warnings.
 
 **Cloud models.** An id is `provider/name`. A local model needs no key; a hosted
-one does. You can also add the key in Settings, which stores it in your OS
-keychain rather than a file.
+one does. You can also add the key in Settings.
+
+Where that key is stored depends on the install. A native install puts it in
+your OS keychain. **A container has no OS keyring, so Docker installs fall back
+to storing the key in the SQLite database in plain text** — readable by anyone
+who can read the `luminary-data` volume. If that matters to you, pass the key
+as an environment variable instead of saving it in Settings, and remember that
+`docker compose` reads a `.env` file beside the compose file.
 
 ```bash
 LITELLM_DEFAULT_MODEL=openai/gpt-4o

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -50,6 +50,26 @@ class Settings(BaseSettings):
     # query after an idle period does not re-pay the (large-model) load cost.
     # "-1" = never unload; accepts any Ollama keep_alive value (e.g. "30m").
     OLLAMA_KEEP_ALIVE: str = "30m"
+    # How long the startup warm-up waits for its one generation.
+    #
+    # This is NOT an ordinary timeout. A cold model load runs inside that first
+    # request, and when the client gives up, httpx closes the connection and
+    # Ollama abandons the load outright:
+    #
+    #   client connection closed before llama-server finished loading, aborting load
+    #   Load failed ... error="timed out waiting for llama-server to start: context canceled"
+    #
+    # So a warm-up that times out does not merely fail to warm anything -- it
+    # cancels the load, and the next request starts from nothing. Measured on an
+    # Intel i7-8850H in Docker: qwen3.5:4b took just over 60s to load (it is
+    # multimodal, so the 3.3GB vision tower and 58 compat tensor transforms load
+    # too), against the 60.0s this used to hardcode. The warm-up whose whole
+    # purpose is "so the first real question does not pay the load" was the
+    # reason the model never finished loading at all.
+    #
+    # 300s matches Ollama's own OLLAMA_LOAD_TIMEOUT default: the client must
+    # never be stricter about a load than the server that performs it.
+    LLM_WARMUP_TIMEOUT_SECONDS: float = 300.0
     # Ollama context window, and the ONLY one: this is a per-model property, not
     # a per-call one. Ollama keys a loaded runner on num_ctx, so a call asking
     # for a different window unloads llama-server and reloads it -- tens of

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -489,15 +489,27 @@ async def parse_document(
     data_dir = Path(settings.DATA_DIR).expanduser()
     raw_dir = data_dir / "raw"
     raw_dir.mkdir(parents=True, exist_ok=True)
+    if ext and ext not in _ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type '.{ext}'. Allowed: {sorted(_ALLOWED_EXTENSIONS)}",
+        )
     dest = raw_dir / f"{doc_id}.{ext}"
 
-    with dest.open("wb") as f:
-        shutil.copyfileobj(file.file, f)
-
-    fmt = ext if ext in ("pdf", "docx", "txt", "md", "markdown") else "txt"
-    parsed = _parser.parse(dest, fmt)
-    logger.info("Parsed document", extra={"doc_id": doc_id, "format": fmt})
-    return {"document_id": doc_id, "parsed": _parsed_to_dict(parsed)}
+    # This route previews a parse; it does not ingest. The file it writes has no
+    # document row behind it, so without the cleanup every call left an orphan
+    # in DATA_DIR/raw that nothing would ever reference or delete -- user
+    # content accumulating out of sight of the library that is supposed to own
+    # it. Two sibling upload routes validate the extension; this one did not.
+    try:
+        with dest.open("wb") as f:
+            shutil.copyfileobj(file.file, f)
+        fmt = ext if ext in ("pdf", "docx", "txt", "md", "markdown") else "txt"
+        parsed = _parser.parse(dest, fmt)
+        logger.info("Parsed document", extra={"doc_id": doc_id, "format": fmt})
+        return {"document_id": doc_id, "parsed": _parsed_to_dict(parsed)}
+    finally:
+        dest.unlink(missing_ok=True)
 
 
 def _component_labels(component_ids: list[str]) -> str:

--- a/backend/app/services/section_summarizer.py
+++ b/backend/app/services/section_summarizer.py
@@ -38,7 +38,33 @@ MIN_UNIT_CHARS = 1500
 
 # Above this many qualifying sections, summarisation moves off the ingestion
 # path entirely and runs after the document is readable.
+#
+# A count is the wrong unit for the decision and this number had no measured
+# basis. On a CPU-only host one summary is an LLM call at 5-7 tok/s: measured
+# end to end in Docker, alice_in_wonderland.txt produced 12 qualifying sections
+# and spent 330 of its 390-second ingest on them -- comfortably under 40, so
+# they ran inline and held `stage=complete` for five and a half minutes on a
+# document that was already readable. At 40 the same host would block for
+# roughly twenty.
+#
+# So the gate is the model, not the count: see `defer_section_summaries`.
 DEFER_ABOVE_SECTIONS = 40
+
+
+def defer_section_summaries(qualifying_sections: int, model: str) -> bool:
+    """Whether summarisation should run behind `stage=complete`.
+
+    Local generation is the cost. A hosted model answers in a second or two and
+    a small document is genuinely nicer with its summaries already there, so the
+    count threshold still applies to cloud. A local model on CPU makes every
+    section minutes of blocked ingest, and the deferred path exists precisely
+    because the document does not need them to be readable.
+    """
+    from app.services.connectivity import is_cloud_model  # noqa: PLC0415
+
+    if not is_cloud_model(model):
+        return True
+    return qualifying_sections > DEFER_ABOVE_SECTIONS
 
 
 def unit_text_cap(unit_count: int) -> int:

--- a/backend/app/services/warmup.py
+++ b/backend/app/services/warmup.py
@@ -111,7 +111,11 @@ async def _warm_llm() -> None:
             t0 = time.perf_counter()
             if interactive:
                 status.set_state("chat_model", "loading", model or "")
-            await get_llm_service().generate("ping", model=model, timeout=60.0)
+            # Never shorter than a cold load: giving up here closes the
+            # connection and Ollama aborts the load it was still doing.
+            await get_llm_service().generate(
+                "ping", model=model, timeout=get_settings().LLM_WARMUP_TIMEOUT_SECONDS
+            )
             if interactive:
                 status.set_state("chat_model", "ready", model or "")
             logger.info("Warmup: %s LLM warm in %.2fs", label, time.perf_counter() - t0)

--- a/backend/app/services/youtube_downloader.py
+++ b/backend/app/services/youtube_downloader.py
@@ -49,6 +49,12 @@ async def fetch_metadata(url: str) -> dict:
         _ytdlp(),
         "--dump-json",
         "--no-download",
+        # `--` ends option parsing. Without it a URL beginning with "-" reaches
+        # yt-dlp as a flag, which is a file read/write primitive even though
+        # nothing here uses a shell. Today `is_youtube_url` happens to block
+        # that by requiring an https://youtube.com/... prefix -- this makes it
+        # true structurally, so loosening that validator cannot reintroduce it.
+        "--",
         url,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.DEVNULL,
@@ -101,6 +107,9 @@ async def download_audio(url: str, dest_stem: Path) -> None:
         *location,
         "-o",
         f"{dest_stem}.%(ext)s",
+        # See fetch_metadata: `--` ends option parsing so the URL can never be
+        # read as a flag.
+        "--",
         url,
         stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.PIPE,

--- a/backend/app/workflows/ingestion_nodes/finalize.py
+++ b/backend/app/workflows/ingestion_nodes/finalize.py
@@ -24,8 +24,9 @@ from app.models import DocumentModel, EnrichmentJobModel
 from app.services.activity_service import ActivityService
 from app.services.document_tagger import enrich_document_tags
 from app.services.enrichment_worker import get_enrichment_worker
+from app.services.model_router import resolve
 from app.services.section_summarizer import (
-    DEFER_ABOVE_SECTIONS,
+    defer_section_summaries,
     get_section_summarizer_service,
 )
 from app.services.summarizer import get_summarization_service
@@ -79,8 +80,9 @@ async def _run_deferred_section_summaries(doc_id: str) -> None:
 async def section_summarize_node(state: IngestionState) -> IngestionState:
     """Generate section-level summaries before document summarization.
 
-    Past DEFER_ABOVE_SECTIONS the work moves behind `stage='complete'` so the
-    document is readable while its summaries fill in.
+    Summaries move behind `stage='complete'` whenever generation is local --
+    see `defer_section_summaries` -- so the document is readable while they
+    fill in rather than after.
 
     Non-fatal: if Ollama is offline or summarization fails, ingestion continues.
     """
@@ -88,9 +90,11 @@ async def section_summarize_node(state: IngestionState) -> IngestionState:
     logger.debug("node_start", extra={"node": "section_summarize", "doc_id": doc_id})
     try:
         svc = get_section_summarizer_service()
-        if await svc.qualifying_section_count(doc_id) > DEFER_ABOVE_SECTIONS:
+        sections = await svc.qualifying_section_count(doc_id)
+        if defer_section_summaries(sections, resolve("generation").model):
             logger.info(
-                "section_summarize_node: deferring summaries until after completion",
+                "section_summarize_node: deferring %d section summaries until after completion",
+                sections,
                 extra={"doc_id": doc_id},
             )
             return {**state, "section_summary_count": 0, "defer_section_summaries": True}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "luminary-backend"
-version = "0.7.6"
+version = "0.7.7"
 description = "Luminary — local-first personal knowledge and learning assistant"
 requires-python = ">=3.13"
 dependencies = [

--- a/backend/tests/test_api_key_storage_disclosure.py
+++ b/backend/tests/test_api_key_storage_disclosure.py
@@ -1,0 +1,31 @@
+"""Where an API key ends up must match what the README promises.
+
+The README said Settings "stores it in your OS keychain rather than a file".
+That is true natively and false in Docker -- the install path recommended for
+Intel Mac, Windows and Linux. A container has no OS keyring, `_keyring_set`
+returns False, and the key is written to SQLite behind a `__plain__:` prefix.
+
+The fallback itself is reasonable; a key has to live somewhere. The defect was
+making an unqualified claim about credential handling that does not hold on the
+most-recommended install.
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+README = (REPO / "README.md").read_text()
+
+
+def test_the_readme_does_not_claim_the_keychain_unconditionally():
+    from app.services.settings_service import _PLAINTEXT_PREFIX
+
+    assert _PLAINTEXT_PREFIX, "the plaintext fallback still exists"
+    assert "plain text" in README, "the fallback has to be disclosed where the claim is made"
+
+
+def test_the_disclosure_names_the_install_it_applies_to():
+    """"Sometimes plaintext" is not actionable; a user needs to know if it is
+    them."""
+    idx = README.find("plain text")
+    nearby = README[max(0, idx - 400) : idx + 200]
+    assert "Docker" in nearby

--- a/backend/tests/test_parse_preview_leaves_nothing_behind.py
+++ b/backend/tests/test_parse_preview_leaves_nothing_behind.py
@@ -1,0 +1,58 @@
+"""`POST /documents/parse` previews a parse; it must not accumulate files.
+
+It wrote the upload to DATA_DIR/raw/<uuid>.<ext> and returned. No document row
+was ever created for that id, so nothing referenced the file and nothing would
+ever delete it: every call left an orphan, out of sight of the library that is
+supposed to own the user's content. It also skipped the extension allowlist its
+two sibling upload routes apply.
+"""
+
+import io
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+def _raw_dir(tmp_data: Path) -> Path:
+    return tmp_data / "raw"
+
+
+@pytest.mark.asyncio
+async def test_a_preview_does_not_leave_the_file_behind(tmp_path, monkeypatch):
+    from app import config as config_module
+
+    settings = config_module.Settings().model_copy(update={"DATA_DIR": str(tmp_path)})
+    monkeypatch.setattr(config_module, "get_settings", lambda: settings)
+    app.dependency_overrides[config_module.get_settings] = lambda: settings
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+            resp = await client.post(
+                "/documents/parse",
+                files={"file": ("note.txt", io.BytesIO(b"Alice met a rabbit."), "text/plain")},
+            )
+        assert resp.status_code == 200, resp.text
+        leftovers = list(_raw_dir(tmp_path).glob("*")) if _raw_dir(tmp_path).exists() else []
+        assert leftovers == [], f"preview left {leftovers} with no document row behind them"
+    finally:
+        app.dependency_overrides.pop(config_module.get_settings, None)
+
+
+@pytest.mark.asyncio
+async def test_a_preview_applies_the_same_extension_allowlist(tmp_path, monkeypatch):
+    from app import config as config_module
+
+    settings = config_module.Settings().model_copy(update={"DATA_DIR": str(tmp_path)})
+    monkeypatch.setattr(config_module, "get_settings", lambda: settings)
+    app.dependency_overrides[config_module.get_settings] = lambda: settings
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+            resp = await client.post(
+                "/documents/parse",
+                files={"file": ("payload.sh", io.BytesIO(b"#!/bin/sh\n"), "text/plain")},
+            )
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.pop(config_module.get_settings, None)

--- a/backend/tests/test_section_summary_deferral.py
+++ b/backend/tests/test_section_summary_deferral.py
@@ -1,0 +1,33 @@
+"""Section summaries must not hold a readable document hostage to local CPU.
+
+Measured end to end in Docker: alice_in_wonderland.txt produced 12 qualifying
+sections and spent 330 of its 390-second ingest generating them inline, because
+the gate was `count > 40` and 12 is under 40. The document was readable the
+whole time -- the deferred path already exists and runs the same work behind
+`stage=complete`.
+
+A count was the wrong unit. One summary is one LLM call, and on a local model at
+5-7 tok/s that is minutes; against a hosted model it is a second or two, where
+having them immediately is genuinely nicer on a small document.
+"""
+
+from app.services.section_summarizer import DEFER_ABOVE_SECTIONS, defer_section_summaries
+
+LOCAL = "ollama/qwen3.5:4b"
+CLOUD = "openai/gpt-4o"
+
+
+def test_a_local_model_always_defers():
+    """12 sections cost 330s inline. There is no count at which that is a good
+    trade when every section is a CPU generation."""
+    assert defer_section_summaries(1, LOCAL)
+    assert defer_section_summaries(12, LOCAL)
+    assert defer_section_summaries(DEFER_ABOVE_SECTIONS + 1, LOCAL)
+
+
+def test_a_cloud_model_keeps_the_count_threshold():
+    """A hosted call is fast, so a small document still gets its summaries
+    before it opens."""
+    assert not defer_section_summaries(12, CLOUD)
+    assert not defer_section_summaries(DEFER_ABOVE_SECTIONS, CLOUD)
+    assert defer_section_summaries(DEFER_ABOVE_SECTIONS + 1, CLOUD)

--- a/backend/tests/test_warmup_does_not_cancel_the_load.py
+++ b/backend/tests/test_warmup_does_not_cancel_the_load.py
@@ -1,0 +1,40 @@
+"""The warm-up must outlast a cold model load, or it destroys one.
+
+Reported on an Intel i7-8850H in Docker with 12GB allocated. The startup
+warm-up hardcoded a 60s timeout; loading qwen3.5:4b took just over that, since
+it is multimodal and pulls in a 3.3GB vision tower plus 58 compat tensor
+transforms. When the client gave up, Ollama logged:
+
+    client connection closed before llama-server finished loading, aborting load
+    Load failed ... error="timed out waiting for llama-server to start: context canceled"
+
+So the warm-up did not merely fail to warm anything. It cancelled the load, and
+every later request began from nothing. The one call whose stated purpose is
+"so the first real question does not pay the load" was the reason the model
+never finished loading.
+
+Ollama's own OLLAMA_LOAD_TIMEOUT defaults to 5 minutes. A client that is
+stricter than the server about a load can only ever cancel work the server was
+willing to finish.
+"""
+
+import inspect
+
+from app.config import Settings
+from app.services import warmup
+
+OLLAMA_LOAD_TIMEOUT_DEFAULT_SECONDS = 300.0
+
+
+def test_the_warmup_timeout_is_not_stricter_than_ollama_s_own_load_budget():
+    assert (
+        Settings().LLM_WARMUP_TIMEOUT_SECONDS >= OLLAMA_LOAD_TIMEOUT_DEFAULT_SECONDS
+    ), "a client stricter than the server cancels loads the server would finish"
+
+
+def test_the_warmup_does_not_hardcode_its_timeout():
+    """It was 60.0 in the source, so no configuration could rescue a host where
+    the load takes longer."""
+    source = inspect.getsource(warmup)
+    assert "timeout=60.0" not in source
+    assert "LLM_WARMUP_TIMEOUT_SECONDS" in source

--- a/backend/tests/test_ytdlp_argv_safety.py
+++ b/backend/tests/test_ytdlp_argv_safety.py
@@ -1,0 +1,36 @@
+"""A user-supplied URL must never be able to become a yt-dlp option.
+
+`create_subprocess_exec` rules out a shell, but not argv parsing: a value
+beginning with "-" is read by the child as a flag, and yt-dlp's flags include
+ones that read and write files. Today `is_youtube_url` blocks it by demanding an
+https://youtube.com/... prefix, so the hole is closed incidentally -- one
+loosened validator away from being open again.
+
+`--` closes it structurally, which is the only way it stays closed.
+"""
+
+import inspect
+
+from app.services import youtube_downloader
+
+
+def _argv_before_url(source: str, marker: str) -> str:
+    body = source.split(marker, 1)[1]
+    return body.split("url,", 1)[0]
+
+
+def test_metadata_fetch_ends_option_parsing_before_the_url():
+    argv = _argv_before_url(inspect.getsource(youtube_downloader), "--dump-json")
+    assert '"--"' in argv
+
+
+def test_audio_download_ends_option_parsing_before_the_url():
+    argv = _argv_before_url(inspect.getsource(youtube_downloader), '"-x"')
+    assert '"--"' in argv
+
+
+def test_a_url_that_looks_like_a_flag_is_still_rejected_upstream():
+    """Defence in depth: the allowlist and the separator both have to hold."""
+    assert not youtube_downloader.is_youtube_url("--config-location=/etc/passwd")
+    assert not youtube_downloader.is_youtube_url("-o/tmp/pwned")
+    assert youtube_downloader.is_youtube_url("https://www.youtube.com/watch?v=abc")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1669,7 +1669,7 @@ wheels = [
 
 [[package]]
 name = "luminary-backend"
-version = "0.7.6"
+version = "0.7.7"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,22 @@ services:
       - LITELLM_DEFAULT_MODEL=${LITELLM_DEFAULT_MODEL:-ollama/qwen3.5:4b}
       - VISION_MODEL=${VISION_MODEL:-${LITELLM_DEFAULT_MODEL:-ollama/qwen3.5:4b}}
     depends_on:
+      # required:false so the default profile is a valid project. `ollama` only
+      # exists under the `ai` profile, so without this a plain
+      # `docker compose up` -- the obvious thing to try when you already run
+      # Ollama yourself and just want the app pointed at it -- failed with
+      # "service app depends on undefined service ollama".
       ollama:
         condition: service_started
+        required: false
+      # Wait for the model, not just for Ollama. These started in parallel, so
+      # on a first run the app warmed up against an empty Ollama and logged
+      # `model 'qwen3.5:4b' not found` -- the chat model reported missing on a
+      # fresh install until something retried. ollama-pull is idempotent and
+      # always exits 0, so this cannot wedge startup.
+      ollama-pull:
+        condition: service_completed_successfully
+        required: false
     restart: unless-stopped
     profiles:
       - ""
@@ -52,8 +66,12 @@ services:
 
   ollama:
     image: ollama/ollama:latest
-    ports:
-      - "127.0.0.1:11434:11434"
+    # Deliberately NOT published to the host. Nothing needs it there: the app
+    # reaches Ollama at http://ollama:11434 over the compose network, and so
+    # does ollama-pull. Publishing it only created a failure mode -- anyone who
+    # already runs Ollama natively, which is most people who have heard of it,
+    # got `bind: address already in use` from the Docker daemon and no guidance.
+    # For the CLI against this container: `docker compose exec ollama ollama ls`.
     volumes:
       - ollama-models:/root/.ollama
     environment:
@@ -109,7 +127,11 @@ services:
       # failed the whole file with "invalid interpolation format". Only
       # LITELLM_DEFAULT_MODEL is meant for compose to substitute, from the host
       # env or .env; M is the shell's and stays escaped.
-      - 'M="${LITELLM_DEFAULT_MODEL:-qwen3.5:4b}"; M="$${M#ollama/}"; until ollama list >/dev/null 2>&1; do echo "waiting for ollama..."; sleep 2; done; echo "pulling $$M"; ollama pull "$$M"'
+      # Idempotent and always exit 0. Both matter now that `app` waits for this
+      # to finish: a re-pull of a cached model fails with no network, and
+      # exiting non-zero there would stop the app from starting at all -- on a
+      # machine that has the model and would have worked offline.
+      - 'M="${LITELLM_DEFAULT_MODEL:-qwen3.5:4b}"; M="$${M#ollama/}"; until ollama list >/dev/null 2>&1; do echo "waiting for ollama..."; sleep 2; done; if ollama list | grep -q "^$$M[[:space:]]"; then echo "$$M already present"; else echo "pulling $$M"; ollama pull "$$M" || echo "pull failed -- the app will start and report the model as missing"; fi; exit 0'
     restart: "no"
     profiles:
       - ai

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.7.6",
+  "version": "0.7.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "luminary-desktop"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminary-desktop"
-version = "0.7.6"
+version = "0.7.7"
 description = "Luminary"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminary",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "identifier": "sh.luminary.app",
   "build": {
     "frontendDist": "boot"


### PR DESCRIPTION
Brought up `docker compose --profile ai`, ingested a book, asked a question and generated flashcards. Everything here was found that way, not by reading code.

## Startup would not survive a normal machine

**Ollama's port was published and conflicted.** `bind: address already in use`, from the Docker daemon, with no guidance — for anyone who already runs Ollama. Nothing needed the host port: the app and ollama-pull both reach it over the compose network.

**The app warmed up before the model existed.** app and ollama-pull start in parallel, so a first run logged `model 'qwen3.5:4b' not found` and reported the chat model missing. app waits for the pull now; the pull is idempotent and always exits 0, because a re-pull of a cached model fails with no network and exiting non-zero there would stop a machine that had the model from starting at all.

**The default compose profile was an invalid project** — `ollama` exists only under `ai`, so a plain `docker compose up` failed with "depends on undefined service".

**The warm-up cancelled the model load it exists to avoid.** Its hardcoded 60s timeout was shorter than a cold load of a multimodal model on CPU, and giving up closes the connection:

```
client connection closed before llama-server finished loading, aborting load
Load failed ... error="timed out waiting for llama-server to start: context canceled"
```

## The measured win

**Section summaries blocked a readable document for minutes.** The gate was `sections > 40` — a count with no measured basis. Measured: `alice_in_wonderland` had 12 qualifying sections and spent **330 of its 390-second ingest** on them inline. One summary is one LLM call; on a local model at 5-7 tok/s a count is the wrong unit. Deferral already existed and runs the same work behind `stage=complete`, so the gate is now the model: local always defers, cloud keeps the count.

**After: `frankenstein.txt` — a longer book, 24 sections — reaches `stage=complete` in 85s against alice's 390s.**

## Security

The two items flagged as fix-before-public:

- yt-dlp's argv ends with `--` before a user-supplied URL at both call sites. The prefix allowlist blocked flag injection only *incidentally*; this makes it structural.
- `/documents/parse` validates the extension and deletes the file it writes. Every preview was leaving an orphan with no document row behind it.

And a false claim corrected: the README promised keys go to "your OS keychain rather than a file". A container has no OS keyring, so Docker installs store them in SQLite in plain text — on the path recommended for Intel Mac, Windows and Linux.

## Verification

`make ci` green. Full journey run against a real stack. Linux `install.sh` verified to completion on clean Debian.

Known and not fixed: `test_fts_sync_on_delete` is an intermittent where a deleted note still appears in search — pre-existing, unrelated to this branch, and worth its own investigation. Docker on any Mac is CPU-only, so generation stays at a few tokens/second regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)