### PR TITLE
fix: deferred summaries leaked past shutdown, and the Docker disk budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,15 @@ Memory**. Luminary reads the VM, not the Mac, and says so at startup:
 model configuration: ollama/qwen3.5:4b needs 8GB and this machine has 7GB -- it will swap under load
 ```
 
+**Docker also needs disk, and more than people expect.** The image is 3.4 GB, or
+4.2 GB with `WITH_MEDIA=1`, and the model blob is another 3.4 GB — so budget
+**10 GB free** in Docker Desktop's disk image before the first build, or `apt`
+fails partway through with `You don't have enough free space in
+/var/cache/apt/archives/`. Reclaim it with `docker builder prune -af` (build
+cache only) and `docker image prune -af` (unused images), or raise the slider in
+**Settings → Resources → Disk image size**. Do not pass `--volumes` to a prune:
+that deletes `luminary-data`, which is your library.
+
 Docker on any Mac is CPU-only — no GPU passes through — so generation runs at a
 few tokens per second whatever the memory. On an Intel Mac especially, prefer
 more RAM and expect ingestion to take minutes.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -317,6 +317,33 @@ async def lifespan(app: FastAPI):
 
         _background_tasks.add(asyncio.create_task(backfill_note_vectors()))
 
+        async def backfill_section_summaries():
+            """Finish section summaries an earlier run did not get to.
+
+            Deferred summarisation is fire-and-forget: the task is cancelled at
+            shutdown and nothing records that it was owed. That was survivable
+            while deferral only happened above 40 sections; it is now the path
+            every local-model ingest takes, so a laptop closed mid-ingest would
+            leave a document permanently without summaries and nothing would
+            ever notice. Runs after the note backfill so the two do not compete
+            for the one model slot.
+            """
+            try:
+                await asyncio.sleep(90)
+                from app.services.section_summarizer import (
+                    resummarize_documents_missing_summaries,
+                )
+
+                repaired = await resummarize_documents_missing_summaries()
+                if repaired:
+                    logger.info(
+                        "Section summary backfill: repaired %d document(s)", repaired
+                    )
+            except Exception as exc:
+                logger.warning("Section summary backfill failed (non-fatal): %s", exc)
+
+        _background_tasks.add(asyncio.create_task(backfill_section_summaries()))
+
     logger.info("Luminary backend started", extra={"data_dir": str(data_dir)})
     yield
     logger.info("Luminary backend shutting down")
@@ -327,11 +354,27 @@ async def lifespan(app: FastAPI):
     await get_enrichment_worker().stop()
     await get_ingestion_jobs().cancel_all()
 
-    for task in list(_background_tasks):
+    # Both sets, not just this module's. The ingestion nodes keep their own
+    # (`ingestion_nodes._shared._background_tasks`) and shutdown never touched
+    # it, so post-ingest work -- deferred section summaries, pregeneration --
+    # kept running against a database that was closing underneath it:
+    #
+    #   deferred section summaries failed (non-fatal):
+    #   (sqlite3.ProgrammingError) Cannot operate on a closed database.
+    #
+    # It was survivable while deferral only happened above 40 sections. It is
+    # now the path every local-model ingest takes, so the leak is on every one.
+    from app.workflows.ingestion_nodes._shared import (  # noqa: PLC0415
+        _background_tasks as _ingestion_background_tasks,
+    )
+
+    pending = set(_background_tasks) | set(_ingestion_background_tasks)
+    for task in pending:
         task.cancel()
-    if _background_tasks:
-        await asyncio.wait(_background_tasks, timeout=_SHUTDOWN_GRACE_S)
-        _background_tasks.clear()
+    if pending:
+        await asyncio.wait(pending, timeout=_SHUTDOWN_GRACE_S)
+    _background_tasks.clear()
+    _ingestion_background_tasks.clear()
 
     shutdown_model_executor()
 

--- a/backend/app/services/section_summarizer.py
+++ b/backend/app/services/section_summarizer.py
@@ -326,3 +326,41 @@ def get_section_summarizer_service() -> SectionSummarizerService:
     if _service is None:
         _service = SectionSummarizerService()
     return _service
+
+
+async def resummarize_documents_missing_summaries(limit: int = 20) -> int:
+    """Regenerate summaries for completed documents that have none.
+
+    Deferred summarisation runs as a background task, so a shutdown between
+    `stage='complete'` and the task finishing loses the work with nothing
+    recording that it was owed. This is the repair: a completed document that
+    has qualifying sections and no summary rows gets another pass.
+
+    Bounded per boot, because each document is one LLM call per section and a
+    library that has never been summarised must not turn startup into an hours
+    long job that competes with the user's first question.
+    """
+    from app.models import DocumentModel  # noqa: PLC0415
+
+    async with get_session_factory()() as session:
+        summarised = select(SectionSummaryModel.document_id).distinct().scalar_subquery()
+        result = await session.execute(
+            select(DocumentModel.id)
+            .join(SectionModel, SectionModel.document_id == DocumentModel.id)
+            .where(DocumentModel.stage == "complete")
+            .where(DocumentModel.id.notin_(summarised))
+            .group_by(DocumentModel.id)
+            .limit(limit)
+        )
+        doc_ids = [row[0] for row in result.all()]
+
+    repaired = 0
+    for doc_id in doc_ids:
+        try:
+            if await get_section_summarizer_service().generate(doc_id, per_section=True):
+                repaired += 1
+        except Exception as exc:
+            logger.warning(
+                "section summary repair failed (non-fatal): %s", exc, extra={"doc_id": doc_id}
+            )
+    return repaired

--- a/backend/tests/test_compose_schema_compatibility.py
+++ b/backend/tests/test_compose_schema_compatibility.py
@@ -49,3 +49,22 @@ def test_the_documented_profile_still_orders_the_model_pull():
     app = COMPOSE["services"]["app"]["depends_on"]
     assert app["ollama-pull"]["condition"] == "service_completed_successfully"
     assert app["ollama"]["condition"] == "service_started"
+
+
+def test_no_nested_interpolation_in_environment_defaults():
+    """`${A:-${B:-c}}` is not supported by older Compose: it substitutes the
+    outer and passes the inner through verbatim. A reported 0.7.6 log shows the
+    app receiving the literal string `${LITELLM_DEFAULT_MODEL:-ollama/qwen3.5:4b}`
+    as VISION_MODEL. It degraded gracefully, but the value was never a model id.
+    """
+    import re
+
+    # Config lines only: the comment above VISION_MODEL quotes the broken form
+    # deliberately, and a guard that trips on its own documentation is noise.
+    config = "\n".join(
+        line
+        for line in (REPO / "docker-compose.yml").read_text().splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    nested = re.findall(r"\$\{[^{}]*\$\{", config)
+    assert not nested, f"nested interpolation is not portable: {nested}"

--- a/backend/tests/test_deferred_summaries_are_durable.py
+++ b/backend/tests/test_deferred_summaries_are_durable.py
@@ -1,0 +1,40 @@
+"""Deferred section summaries must survive the app stopping.
+
+0.7.7 made deferral the path every local-model ingest takes. It had been the
+rare path (>40 sections), and two things about it were survivable while rare and
+are not now:
+
+- Ingestion keeps its own `_background_tasks` set, and shutdown only ever
+  drained `main`'s. The deferred task ran on against a closing database:
+  `(sqlite3.ProgrammingError) Cannot operate on a closed database`.
+- Nothing recorded that summaries were owed. A cancelled task lost them, and no
+  later run would notice a document that was complete and had none.
+"""
+
+import inspect
+
+from app import main as main_module
+from app.services import section_summarizer
+
+
+def test_shutdown_drains_the_ingestion_task_set_too():
+    source = inspect.getsource(main_module.lifespan)
+    assert "_ingestion_background_tasks" in source, (
+        "shutdown cancelled only main's tasks; ingestion keeps a separate set"
+    )
+
+
+def test_a_repair_exists_for_summaries_a_shutdown_lost():
+    assert callable(section_summarizer.resummarize_documents_missing_summaries)
+
+
+def test_the_repair_is_bounded_per_boot():
+    """Each document is one LLM call per section. A library that has never been
+    summarised must not turn startup into an hours-long job competing with the
+    user's first question."""
+    sig = inspect.signature(section_summarizer.resummarize_documents_missing_summaries)
+    assert sig.parameters["limit"].default > 0
+
+
+def test_startup_schedules_the_repair():
+    assert "backfill_section_summaries" in inspect.getsource(main_module.lifespan)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,17 @@ services:
       # Set with the ollama/ prefix (config.py's own convention); ollama-pull
       # strips it defensively either way.
       - LITELLM_DEFAULT_MODEL=${LITELLM_DEFAULT_MODEL:-ollama/qwen3.5:4b}
-      - VISION_MODEL=${VISION_MODEL:-${LITELLM_DEFAULT_MODEL:-ollama/qwen3.5:4b}}
+      # A plain default, not ${VISION_MODEL:-${LITELLM_DEFAULT_MODEL:-...}}.
+      # Nested interpolation is not supported by older Compose, which passes the
+      # inner expression through verbatim -- a reported 0.7.6 log shows the app
+      # receiving the literal string:
+      #
+      #   vision was configured as ${LITELLM_DEFAULT_MODEL:-ollama/qwen3.5:4b}
+      #
+      # It degraded gracefully because the router falls back, but the value was
+      # never a model id. Overriding LITELLM_DEFAULT_MODEL no longer moves this
+      # with it: set VISION_MODEL too if you want them to match.
+      - VISION_MODEL=${VISION_MODEL:-ollama/qwen3.5:4b}
     # No `required: false` here. It is valid Compose Spec, and it is what would
     # make the default profile a valid project -- but Compose only understands
     # it from v2.20-ish, and v2.29.7 accepts it while older daemons reject the

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.7.5",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.7.5",
+      "version": "0.7.8",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.4",

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -10,6 +10,11 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PYPROJECT="$REPO_ROOT/backend/pyproject.toml"
 PKG="$REPO_ROOT/frontend/package.json"
+# npm rewrites this from package.json whenever it runs, so a version.sh that
+# skipped it left the lockfile on an older number until some unrelated build
+# silently corrected it and dirtied the tree. It sat on 0.7.5 through three
+# releases before a docker build happened to fix it.
+PKG_LOCK="$REPO_ROOT/frontend/package-lock.json"
 # The desktop shell carries the version twice more. Missed here, the .app
 # reports a stale version in Finder and About while the backend reports the new
 # one -- and the DMG filename comes from a different source again.
@@ -24,9 +29,9 @@ UV_LOCK="$REPO_ROOT/backend/uv.lock"
 CARGO_LOCK="$REPO_ROOT/src-tauri/Cargo.lock"
 
 if [ "$#" -eq 0 ]; then
-    python3 - "$PYPROJECT" "$PKG" "$TAURI_CONF" "$CARGO" "$UV_LOCK" "$CARGO_LOCK" <<'PY'
+    python3 - "$PYPROJECT" "$PKG" "$PKG_LOCK" "$TAURI_CONF" "$CARGO" "$UV_LOCK" "$CARGO_LOCK" <<'PY'
 import re, sys
-pyproject, pkg, tauri_conf, cargo, uv_lock, cargo_lock = sys.argv[1:7]
+pyproject, pkg, pkg_lock, tauri_conf, cargo, uv_lock, cargo_lock = sys.argv[1:8]
 
 
 def show(label, path, pattern):
@@ -42,6 +47,9 @@ show("backend:", pyproject, r'(?m)^version\s*=\s*"([^"]+)"')
 show("frontend:", pkg, r'"version"\s*:\s*"([^"]+)"')
 show("tauri:", tauri_conf, r'"version"\s*:\s*"([^"]+)"')
 show("cargo:", cargo, r'(?m)^version\s*=\s*"([^"]+)"')
+# The capturing group is the version itself here, not the surrounding literal
+# the bump patterns use -- show() prints group(1).
+show("pkg-lock:", pkg_lock, r'"version"\s*:\s*"([^"]+)"')
 show("uv.lock:", uv_lock, lock_pattern("luminary-backend"))
 show("Cargo.lock:", cargo_lock, lock_pattern("luminary-desktop"))
 PY
@@ -54,9 +62,9 @@ if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+.].*)?$ ]]; then
     exit 1
 fi
 
-python3 - "$PYPROJECT" "$PKG" "$TAURI_CONF" "$CARGO" "$UV_LOCK" "$CARGO_LOCK" "$VERSION" <<'PY'
+python3 - "$PYPROJECT" "$PKG" "$PKG_LOCK" "$TAURI_CONF" "$CARGO" "$UV_LOCK" "$CARGO_LOCK" "$VERSION" <<'PY'
 import re, sys
-pyproject, pkg, tauri_conf, cargo, uv_lock, cargo_lock, version = sys.argv[1:8]
+pyproject, pkg, pkg_lock, tauri_conf, cargo, uv_lock, cargo_lock, version = sys.argv[1:9]
 
 
 def bump(path, pattern, label):
@@ -82,6 +90,28 @@ def lock_pattern(package: str) -> str:
 
 bump(pyproject, r'(?m)^(version\s*=\s*")[^"]+(")', "pyproject.toml")
 bump(pkg, r'("version"\s*:\s*")[^"]+(")', "package.json")
+
+
+def bump_pkg_lock(path: str) -> None:
+    """Both project fields, and no dependency's.
+
+    npm records the project version twice -- top level and packages[""] -- and
+    keeps them in step. A regex with count=1 moved only the first, leaving the
+    file internally inconsistent so npm rewrote it on the next run; a regex
+    without count would have rewritten every dependency pinned at that version.
+    Parsed, so neither can happen.
+    """
+    import json  # noqa: PLC0415
+
+    data = json.loads(open(path).read())
+    data["version"] = version
+    if "" in data.get("packages", {}):
+        data["packages"][""]["version"] = version
+    open(path, "w").write(json.dumps(data, indent=2) + "\n")
+    print("  package-lock.json")
+
+
+bump_pkg_lock(pkg_lock)
 bump(tauri_conf, r'("version"\s*:\s*")[^"]+(")', "tauri.conf.json")
 bump(cargo, r'(?m)^(version\s*=\s*")[^"]+(")', "src-tauri/Cargo.toml")
 # Targeted rather than `uv lock` / `cargo update`: re-resolving dependencies is
@@ -91,6 +121,6 @@ bump(cargo_lock, lock_pattern("luminary-desktop"), "src-tauri/Cargo.lock")
 PY
 
 echo "Set version to $VERSION"
-echo "  backend/pyproject.toml, frontend/package.json,"
+echo "  backend/pyproject.toml, frontend/package.json, frontend/package-lock.json,"
 echo "  src-tauri/tauri.conf.json, src-tauri/Cargo.toml,"
 echo "  backend/uv.lock, src-tauri/Cargo.lock"


### PR DESCRIPTION
Closes the regression 0.7.7 introduced, and documents a disk requirement nothing stated.

## The regression

0.7.7 made section-summary deferral the path **every** local-model ingest takes. It had been the rare path — only above 40 sections — and two things about it were survivable while rare and are not now.

**Shutdown never drained it.** `main.py` cancels its own `_background_tasks`; the ingestion nodes keep a *separate* set that nothing touched. Post-ingest work carried on against a closing database:

```
deferred section summaries failed (non-fatal):
(sqlite3.ProgrammingError) Cannot operate on a closed database
```

**Nothing recorded the work was owed.** A cancelled task lost its summaries silently, and no later run would notice a document that was complete and had none — so a laptop closed mid-ingest left it permanently unsummarised.

Shutdown now drains both sets, and a bounded startup pass regenerates summaries for completed documents that have none. Bounded deliberately: each document is one LLM call per section (`per_section=True` is the point of the deferred path), so an unsummarised library must not turn startup into an hours-long job competing with the user's first question.

```
before 0.7.7:  test_e2e_upload  3 passed in 8.15s
after 0.7.7:   hangs past 120s
now:           3 passed in 35.36s     (live Ollama)
```

## Why CI never saw it

GitHub CI has no Ollama, so the deferred task failed instantly instead of making thirteen real calls. The suite stayed green through the entire regression. `make ci` here is green **with Ollama running**, which is the stricter configuration and the one that would have caught it.

That is a blind spot in the gate, not just in this change: CI cannot see any defect that only appears when a real model answers.

## Disk budget

A build failed with `You don't have enough free space in /var/cache/apt/archives/` and nothing had said how much disk the Docker path needs. Measured: image 3.4 GB, 4.2 GB with `WITH_MEDIA=1`, model blob 3.4 GB — so ~10 GB. README names the safe reclaim commands and says explicitly not to pass `--volumes` to a prune, which would delete the user's library.

Not changed: adding `apt-get clean` to the media layer looked like a 133 MB saving and measured as exactly zero, because `python:3.13-slim` ships `/etc/apt/apt.conf.d/docker-clean` and the `.deb`s were never retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)