### PR TITLE
release: 0.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.9] - 2026-08-25
+
+### Fixed
+- **Section summaries could be lost when the app stopped.** They run behind the
+  document becoming readable, but nothing cancelled that work at shutdown and
+  nothing recorded it was owed — so closing a laptop mid-ingest left a document
+  permanently without summaries. Shutdown now waits for them, and a bounded pass
+  on the next start finishes any that were interrupted.
+- **`VISION_MODEL` was never a real model id on older Docker Compose.** The
+  default used nested interpolation, which older Compose passes through
+  verbatim. It fell back safely, but the setting did nothing.
+- **`frontend/package-lock.json` was not updated by a version bump**, so it sat
+  on 0.7.5 until an unrelated build corrected it.
+
+### Changed
+- The README states the disk the Docker path needs (~10 GB) and how to reclaim
+  it without deleting your library.
+
 ## [0.7.8] - 2026-08-25
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "luminary-backend"
-version = "0.7.8"
+version = "0.7.9"
 description = "Luminary — local-first personal knowledge and learning assistant"
 requires-python = ">=3.13"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1669,7 +1669,7 @@ wheels = [
 
 [[package]]
 name = "luminary-backend"
-version = "0.7.8"
+version = "0.7.9"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.7.8",
+  "version": "0.7.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "luminary-desktop"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "chrono",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminary-desktop"
-version = "0.7.8"
+version = "0.7.9"
 description = "Luminary"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminary",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "identifier": "sh.luminary.app",
   "build": {
     "frontendDist": "boot"


### PR DESCRIPTION
Version bump and changelog for the work merged in #74.

- Deferred section summaries no longer leak past shutdown or vanish with it: shutdown waits for them, and a bounded pass on the next start finishes any that were interrupted.
- `VISION_MODEL`'s nested-interpolation default never produced a model id on older Compose.
- `frontend/package-lock.json` is now owned by `version.sh` — it had been stale since 0.7.5. This release is the first where all seven version files move together.

`make ci` green with Ollama running, which is the configuration that catches defects CI cannot see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)