### PR TITLE
fix: eval arms, slow-host answering, and the numbers that describe them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-27
+
+### Added
+- **Inference can run on the host instead of inside the Docker VM.**
+  `make docker-run-host-ollama` leaves the Ollama container out, so the model
+  stops competing with the embedder, reranker and entity model for the VM's
+  capped CPU.
+- **`scripts/diagnose-slow-host.sh` answers "why is answering slow here" in one
+  command** — build, start-up probe, resolved context budget, and where a real
+  question's seconds went. It starts nothing and changes nothing.
+
+### Changed
+- **A host that measured local inference expensive at start-up now answers with
+  a narrower prompt**, and skips the LLM call that confirms the intent the
+  heuristic already chose. Both follow the same start-up measurement, never a
+  platform check; `QA_INTENT_LLM_FALLBACK_ON_SLOW_HOST=true` restores the call
+  at the cost of ~17s per affected question.
+
+### Fixed
+- **"Summarise" never routed to a summary.** Only two of the verb's eight
+  spellings matched, so every `-ise` form and every tense fell through to search.
+- **A cached document summary was prepended to the prompt unbounded.** The
+  context budget bounded the retrieved passages only, so a summary question
+  against a long document pushed the prompt past it.
+- **`OLLAMA_URL` was hardcoded in the compose file**, so exporting it to move
+  inference onto the host was accepted by the shell and silently discarded.
+- **The retrieval eval measured a funnel the app does not ship.** `/search`
+  defaults `rerank=false` and the arm never asked, while the same run's
+  answering path reranked. Retrieval baselines recorded before this are the
+  unreranked funnel and do not compare to later ones.
+
 ## [0.7.9] - 2026-08-25
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,13 @@ WITH_MEDIA ?= 0
 docker-build:
 	docker build --build-arg WITH_MEDIA=$(WITH_MEDIA) -t luminary:latest .
 
+# OLLAMA_URL pinned, not left to the ambient environment. The compose file now
+# interpolates it (so the host-Ollama target below can move it), which means a
+# shell that exports OLLAMA_URL for `make dev` -- 127.0.0.1, the loopback of the
+# machine, not of the container -- would otherwise reach in here and point the
+# container at itself.
 docker-run:
-	docker compose --profile ai up --build
+	OLLAMA_URL=http://ollama:11434 docker compose --profile ai up --build
 
 # Same stack, but inference runs on the HOST instead of in the compose network.
 # On a Mac, Docker Desktop is a Linux VM: the `ai` profile puts Ollama inside it,
@@ -167,13 +172,35 @@ docker-run:
 # Ollama must listen beyond loopback or the container cannot reach it: it binds
 # 127.0.0.1 by default, and `host.docker.internal` arrives from the bridge.
 #   OLLAMA_HOST=0.0.0.0:11434 ollama serve
+#
+# `--profile ai ... --no-deps app`, not a bare `docker compose up`. Every service
+# in this file carries a profile, so with none selected Compose 2.0.0-beta.4 built
+# nothing and exited with "no service selected". Enabling `ai` is what makes `app`
+# a selectable service at all; naming it and passing --no-deps is what leaves the
+# ollama sidecars out. Do not drop --no-deps to "simplify" this -- the ollama
+# container comes back and takes the VM's CPU with it, which is the whole point.
 docker-run-host-ollama:
 	@command -v ollama >/dev/null || { echo "Install Ollama first: https://ollama.com/download"; exit 1; }
 	@curl -sf http://localhost:11434/api/tags >/dev/null \
 		|| { echo "Ollama is not answering on :11434. Start it with:"; \
 		     echo "   OLLAMA_HOST=0.0.0.0:11434 ollama serve"; exit 1; }
-	@echo "Using host Ollama at :11434 (no ai profile, no ollama container)."
-	OLLAMA_URL=http://host.docker.internal:11434 docker compose up --build
+	@if command -v lsof >/dev/null 2>&1; then \
+		lsof -nP -iTCP:11434 -sTCP:LISTEN 2>/dev/null \
+			| grep -qE "TCP \*:11434|TCP 0\.0\.0\.0:11434" \
+		|| { echo "Ollama is listening on loopback only, so the container cannot reach it."; \
+		     echo "The curl above passes over 127.0.0.1 and proves nothing about the bridge:"; \
+		     echo "that is exactly the case this check exists to catch. Restart it as:"; \
+		     echo "   OLLAMA_HOST=0.0.0.0:11434 ollama serve"; exit 1; }; \
+	fi
+	@m=$${LITELLM_DEFAULT_MODEL:-ollama/qwen3.5:4b}; m=$${m#ollama/}; \
+	curl -sf http://localhost:11434/api/tags | grep -q "\"$$m\"" \
+		|| { echo "Host Ollama is up but does not have $$m."; \
+		     echo "The ollama-pull sidecar does not run in this topology, so nothing"; \
+		     echo "will fetch it for you and the app will report the model missing:"; \
+		     echo "   ollama pull $$m"; exit 1; }
+	@echo "Using host Ollama at :11434 (no ollama container)."
+	OLLAMA_URL=http://host.docker.internal:11434 \
+		docker compose --profile ai up --build --no-deps app
 
 stop:
 	@pids=$$(lsof -ti :$(LUMINARY_PORT) 2>/dev/null); \

--- a/Makefile
+++ b/Makefile
@@ -369,9 +369,11 @@ eval-all:
 
 # D2L technical-corpus retrieval (HR@5/MRR). Backend on :7820 with d2l ingested.
 # Retrieval-only (--judge-model "" disables the RAGAS judge) so it runs in seconds.
+# --no-rerank is explicit: this is the unreranked arm of the A/B below, and the
+# harness now defaults to the funnel the app ships (which reranks).
 eval-d2l:
-	@echo "Retrieval eval on the d2l technical corpus (HR@5/MRR, no judge)..."
-	cd evals && UV_CACHE_DIR=$(CURDIR)/.uv-cache uv run --no-sync python run_eval.py --dataset d2l --backend-url $(BACKEND_URL) --judge-model "" --assert-thresholds
+	@echo "Retrieval eval on the d2l technical corpus (HR@5/MRR, no judge, no rerank)..."
+	cd evals && UV_CACHE_DIR=$(CURDIR)/.uv-cache uv run --no-sync python run_eval.py --dataset d2l --backend-url $(BACKEND_URL) --judge-model "" --no-rerank --assert-thresholds
 
 # Same dataset WITH the cross-encoder reranker — compare HR@5/MRR against `eval-d2l`.
 eval-d2l-rerank:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev ci backend frontend build start stop lint test test-full test-concurrent test-perf test-e2e test-book-e2e test-book-content test-books-all test-v2 eval eval-intent eval-ingest eval-gen eval-variance prompt-dump eval-models eval-matrix eval-summary eval-routing eval-flashcards golden-flashcards eval-all eval-d2l eval-d2l-rerank eval-d2l-gen eval-topics golden-d2l golden-paper golden-legal golden-play golden-study golden-thoughts logs smoke luminary clean regen-api-types verify-router install release docker-build docker-run stage stage-payload stage-python stage-ollama verify-stage check-stage desktop-dev desktop-app desktop-adhoc desktop-test
+.PHONY: docker-run-host-ollama dev ci backend frontend build start stop lint test test-full test-concurrent test-perf test-e2e test-book-e2e test-book-content test-books-all test-v2 eval eval-intent eval-ingest eval-gen eval-variance prompt-dump eval-models eval-matrix eval-summary eval-routing eval-flashcards golden-flashcards eval-all eval-d2l eval-d2l-rerank eval-d2l-gen eval-topics golden-d2l golden-paper golden-legal golden-play golden-study golden-thoughts logs smoke luminary clean regen-api-types verify-router install release docker-build docker-run stage stage-payload stage-python stage-ollama verify-stage check-stage desktop-dev desktop-app desktop-adhoc desktop-test
 
 # Where the dev backend listens; `make dev` starts it here.
 BACKEND_URL ?= http://localhost:7820
@@ -155,6 +155,25 @@ docker-build:
 
 docker-run:
 	docker compose --profile ai up --build
+
+# Same stack, but inference runs on the HOST instead of in the compose network.
+# On a Mac, Docker Desktop is a Linux VM: the `ai` profile puts Ollama inside it,
+# where it shares a capped CPU and memory allowance with the app container --
+# which is also running the embedder, reranker and entity model. A measured 91.07s
+# start-up probe on an i7-8850H paid NO model load at all; those seconds were
+# contention for 8 vCPUs. Moving inference out gives it the whole machine, and is
+# the only latency lever measured so far that costs no answer quality.
+#
+# Ollama must listen beyond loopback or the container cannot reach it: it binds
+# 127.0.0.1 by default, and `host.docker.internal` arrives from the bridge.
+#   OLLAMA_HOST=0.0.0.0:11434 ollama serve
+docker-run-host-ollama:
+	@command -v ollama >/dev/null || { echo "Install Ollama first: https://ollama.com/download"; exit 1; }
+	@curl -sf http://localhost:11434/api/tags >/dev/null \
+		|| { echo "Ollama is not answering on :11434. Start it with:"; \
+		     echo "   OLLAMA_HOST=0.0.0.0:11434 ollama serve"; exit 1; }
+	@echo "Using host Ollama at :11434 (no ai profile, no ollama container)."
+	OLLAMA_URL=http://host.docker.internal:11434 docker compose up --build
 
 stop:
 	@pids=$$(lsof -ti :$(LUMINARY_PORT) 2>/dev/null); \

--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ ner-compare:
 eval-intent:
 	@echo "Intent routing accuracy (backend must be running)..."
 	uv run --project $(CURDIR)/backend python evals/run_intent_eval.py --backend-url $(BACKEND_URL) --assert-thresholds
-	@echo "Adversarial phrasing, heuristic only -- the floor, not the routing..."
+	@echo "Adversarial phrasing, heuristic only -- the floor, and the routing on a slow host..."
 	uv run --project $(CURDIR)/backend python evals/run_intent_eval.py \
 		--dataset intents_adversarial --backend-url $(BACKEND_URL)
 	@echo "Adversarial phrasing, heuristic + LLM fallback -- what a user gets..."

--- a/README.md
+++ b/README.md
@@ -195,6 +195,45 @@ to text** from Settings — Luminary fetches that one itself.
 <summary><b>macOS (Intel / x86_64) — via Docker</b></summary>
 
 Intel Macs have no native `lancedb` wheel, so `make install` cannot run there.
+Everything below is the Docker path. Apple Silicon Macs use the native path above.
+
+**Install first**
+
+1. [Docker Desktop](https://www.docker.com/products/docker-desktop/) — running,
+   with at least **10 GB free** in its disk image (see
+   [How much memory it actually needs](#how-much-memory-it-actually-needs)).
+2. [Homebrew](https://brew.sh), then `brew install ollama` — only for the
+   recommended path; the all-in-Docker path needs nothing but Docker.
+
+**Recommended: inference on the host, app in Docker**
+
+Docker Desktop on a Mac is a Linux VM with a capped CPU and memory allowance,
+and the app container is already running the embedder, reranker and entity
+model inside it. Putting Ollama there too makes them compete. Running Ollama on
+the host gives it the whole machine, and is the only latency change measured so
+far that costs nothing in answer quality.
+
+```bash
+# terminal 1 — Ollama must listen beyond loopback, or the container cannot
+# reach it. It binds 127.0.0.1 by default; the container arrives via the bridge.
+OLLAMA_HOST=0.0.0.0:11434 ollama serve
+
+# terminal 2
+ollama pull qwen3.5:4b
+git clone https://github.com/nupsea/luminary.git
+cd luminary
+make docker-run-host-ollama
+```
+
+The target refuses to start rather than fail obscurely: it checks that Ollama
+answers, that it is **not** bound to loopback only, and that the model is
+present — the model sidecar does not run in this topology, so nothing else
+will fetch it for you.
+
+**Simplest: everything in Docker**
+
+No Homebrew, no host Ollama. One command, and the model is pulled for you into
+a Docker volume on first run:
 
 ```bash
 git clone https://github.com/nupsea/luminary.git
@@ -204,7 +243,22 @@ make docker-run
 
 *(or directly via compose: `docker compose --profile ai up --build`)*
 
-Then open http://localhost:7820. Apple Silicon Macs use the native path above.
+Either way, open http://localhost:7820. First run pulls a ~3.4 GB model and
+builds the image, so give it time.
+
+**If answering feels slow**
+
+```bash
+bash scripts/diagnose-slow-host.sh
+```
+
+One command, one paste: which build is running, whether this host measured
+itself slow at start-up, which context budget that resolved to, and where a
+real question's seconds went. It starts nothing and changes nothing.
+
+Expect single-digit tokens per second either way — Docker on any Mac is
+CPU-only, no GPU passes through. On an Intel i7-8850H with host Ollama,
+`qwen3.5:4b` decodes at ~6 tok/s, so answer length is what you feel most.
 
 Audio, video and YouTube ingestion are **off** in this image. They need ffmpeg
 and a transcriber, which are GPL and so are never part of anything Luminary
@@ -261,7 +315,9 @@ that deletes `luminary-data`, which is your library.
 
 Docker on any Mac is CPU-only — no GPU passes through — so generation runs at a
 few tokens per second whatever the memory. On an Intel Mac especially, prefer
-more RAM and expect ingestion to take minutes.
+more RAM and expect ingestion to take minutes. The memory above is for the
+all-in-Docker path; `make docker-run-host-ollama` moves the model's share of it
+out of the VM and onto the host.
 
 Two runtime bounds ship set, because Ollama's own defaults are not sized for a
 laptop: the model stays resident for 30 minutes rather than Ollama's 5, and

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -169,15 +169,6 @@ class Settings(BaseSettings):
     # i7-8850H (~31 tok/s prefill) 1500 -> 750 is ~56s -> ~29s.
     # Read the `synthesize_node: packed N/M` log before changing it. Do NOT
     # restore the old table: it measured the pre-de-duplication funnel.
-    # Prepend each section's generated summary to its chunks in the prompt.
-    # Off, and the default is the measurement rather than a preference: the
-    # lookup is keyed on (document_id, section_heading), and every retrieved
-    # chunk carried an empty heading until that was fixed, so this has never
-    # actually fired in a shipped build. Switching it on inflates candidate text
-    # by 42.2% and, against QA_CONTEXT_TOKEN_BUDGET, drops the passages that
-    # reach the model from 39 to 28 across an 8-query sample -- one query fell
-    # from 4 passages to 1. Turning it on means raising the budget with it, and
-    # that costs prefill latency and KV cache (I-27).
     # Slow-host context budget, used in place of QA_CONTEXT_TOKEN_BUDGET where the
     # start-up probe says local inference is expensive. Same gate as the keep-warm
     # loop and for the same reason: a MEASUREMENT of this host, never a platform
@@ -207,21 +198,32 @@ class Settings(BaseSettings):
     # which no prompt or output bound reaches. It fires on 4% of `intents` and
     # 28% of `intents_adversarial`.
     #
-    # What it costs, measured on this branch against a live backend:
+    # What it costs, measured 2026-08-27 against a live backend on the model the
+    # app ships (`ollama/qwen3.5:4b`), fallback on -> fallback off:
     #   intents (50)              1.0000 -> 1.0000   the LLM changes nothing
-    #   intents_adversarial (29)  0.9655 -> 0.8276   4 rescues lost
+    #   intents_adversarial (29)  0.8966 -> 0.8276   2 rescues lost (26/29 -> 24/29)
+    # Read the model, not just the number: `scores_history.jsonl` has this arm at
+    # 0.9655 on `qwen2.5:14b-instruct` and 0.8276 on `qwen3.5:0.8b`, so a delta
+    # taken across two models prices this gate at something no user pays. The
+    # 0.8966 figure is eight recorded runs on the shipped model, all identical.
     # The committed threshold (routing_accuracy >= 0.85, `intents`) is untouched;
-    # the adversarial set is the floor the Makefile already labels "not the
-    # routing". Below 0.7 the heuristic is guessing, and here the guess stands.
+    # the adversarial set is report-only. Below 0.7 the heuristic is guessing,
+    # and on a slow host that guess now stands.
     #
-    # Set this True to buy those 4 rescues back at ~17s per affected question.
+    # Set this True to buy those 2 rescues back at ~17s per affected question.
     QA_INTENT_LLM_FALLBACK_ON_SLOW_HOST: bool = False
-    # Hard ceiling on everything the synthesis prompt carries, not just the chunk
+    # Alarm level for everything the synthesis prompt carries, not just the chunk
     # context. QA_CONTEXT_TOKEN_BUDGET bounds `chunks_context` only; section
     # context, image context and a prepended executive summary are appended AFTER
     # it, and the summary had no cap at all. A budget that bounds one component
     # while another is unbounded gives a good average and an unbounded worst case,
-    # which is the shape of the original 173s report. 0 disables the ceiling.
+    # which is the shape of the original 173s report.
+    #
+    # It WARNS, it does not truncate, and that is deliberate: cutting an assembled
+    # prompt would strip `[S<n>]` passages the model is told to cite (I-33), which
+    # buys latency by spending the answer's provenance. Bound the work upstream --
+    # the per-source caps below -- and let this line say when one of them has been
+    # outgrown. 0 disables the check.
     QA_PROMPT_TOKEN_CEILING: int = 4000
     # Cap on the prepended executive summary specifically, matching the 1000 the
     # section context has always carried. `_should_use_summary` is a keyword match
@@ -229,6 +231,15 @@ class Settings(BaseSettings):
     # be asked of a long document -- 0/60 on the `study` golden, which is why it
     # was never seen.
     QA_SUMMARY_INJECTION_TOKEN_CAP: int = 1000
+    # Prepend each section's generated summary to its chunks in the prompt.
+    # Off, and the default is the measurement rather than a preference: the
+    # lookup is keyed on (document_id, section_heading), and every retrieved
+    # chunk carried an empty heading until that was fixed, so this has never
+    # actually fired in a shipped build. Switching it on inflates candidate text
+    # by 42.2% and, against QA_CONTEXT_TOKEN_BUDGET, drops the passages that
+    # reach the model from 39 to 28 across an 8-query sample -- one query fell
+    # from 4 passages to 1. Turning it on means raising the budget with it, and
+    # that costs prefill latency and KV cache (I-27).
     QA_ATTACH_SECTION_SUMMARIES: bool = False
     # L2 funnel: how many RRF candidates the cross-encoder re-scores. HR@k of
     # the reranked list is bounded by HR@depth of the RRF pool, so depth is the

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -152,22 +152,23 @@ class Settings(BaseSettings):
     # under OLLAMA_NUM_CTX (with headroom for question/system/history) so the
     # prompt is never silently truncated.
     QA_CONTEXT_TOKEN_BUDGET: int = 1500
-    # 1500 is a cliff edge, not a dial, and lowering it for slow hosts was tried
-    # and reverted. `search_node` sets each chunk's `text` to the chunk PLUS its
-    # neighbours, so a packed passage here is ~750 tokens, not the ~250 a raw
-    # chunk measures. Every budget from 500 to 1250 therefore delivers exactly
-    # ONE passage; 1500 is the first value that delivers two. Measured on one
-    # live request (same chunks, packed at each budget):
+    # This WAS a cliff and is now a dial, because the neighbour expansion landed.
+    # Until 914e8b54, `search_node` set each chunk's `text` to the chunk PLUS its
+    # neighbours -- including neighbours that had themselves been retrieved -- so
+    # a packed passage cost ~750 tokens instead of ~250 and every budget from 500
+    # to 1250 delivered exactly ONE passage. Re-measured 2026-08-26 on the merged
+    # build, feeding real /qa passages to `pack_context_indexed`:
     #
-    #   500/750/1000/1250 -> 1 passage, 752 ctx tokens
-    #   1500              -> 2 passages, 1489
-    #   3000              -> 4 passages, 2918
+    #   budget   500  750 1000 1250 1500 2000 3000
+    #   Q1      1/10 2/10 3/10 4/10 5/10 7/10 10/10
+    #   Q2      4/13 6/13 8/13 11/13 13/13 13/13 13/13
     #
-    # So on an Intel i7-8850H the ~24s of prefill a narrower budget saves costs
-    # half the evidence -- the answer rests on a single retrieved region. Read
-    # the passage count in the `synthesize_node: packed N/M` log before changing
-    # this; a sweep over raw chunk sizes says 1250 keeps 4 passages and is wrong.
-    # The lever worth having is the neighbour expansion, not the budget.
+    # It now loses roughly one passage at a time, so narrowing it on a slow host
+    # is a graded trade rather than a collapse to a single region. What it buys is
+    # prefill: local prefill scales ~linearly with prompt size, and on an Intel
+    # i7-8850H (~31 tok/s prefill) 1500 -> 750 is ~56s -> ~29s.
+    # Read the `synthesize_node: packed N/M` log before changing it. Do NOT
+    # restore the old table: it measured the pre-de-duplication funnel.
     # Prepend each section's generated summary to its chunks in the prompt.
     # Off, and the default is the measurement rather than a preference: the
     # lookup is keyed on (document_id, section_heading), and every retrieved
@@ -177,6 +178,37 @@ class Settings(BaseSettings):
     # reach the model from 39 to 28 across an 8-query sample -- one query fell
     # from 4 passages to 1. Turning it on means raising the budget with it, and
     # that costs prefill latency and KV cache (I-27).
+    # Slow-host context budget, used in place of QA_CONTEXT_TOKEN_BUDGET where the
+    # start-up probe says local inference is expensive. Same gate as the keep-warm
+    # loop and for the same reason: a MEASUREMENT of this host, never a platform
+    # check. `platform.machine()` would guess at the cause; the probe measures the
+    # effect, and is right for a CPU-only Intel laptop, a Docker VM and a GPU box
+    # alike without naming any of them.
+    #
+    # 750 halves prefill (~56s -> ~29s at the i7-8850H's measured ~31 tok/s) and
+    # costs roughly half the passages -- see the dial table on
+    # QA_CONTEXT_TOKEN_BUDGET. Bracketing it: 500 drops one sampled query to a
+    # single passage, which is the collapse the 8244526 revert exists to prevent;
+    # 1250 saves only ~6s of prefill and is not worth a profile.
+    #
+    # NOT YET MEASURED: the generation-quality cost of answering at 750. Measure it
+    # with `QA_CONTEXT_TOKEN_BUDGET=750` and a study --generate run before treating
+    # this as a shipped default rather than an opt-in for hosts that are unusable
+    # without it.
+    QA_CONTEXT_TOKEN_BUDGET_SLOW_HOST: int = 750
+    # Hard ceiling on everything the synthesis prompt carries, not just the chunk
+    # context. QA_CONTEXT_TOKEN_BUDGET bounds `chunks_context` only; section
+    # context, image context and a prepended executive summary are appended AFTER
+    # it, and the summary had no cap at all. A budget that bounds one component
+    # while another is unbounded gives a good average and an unbounded worst case,
+    # which is the shape of the original 173s report. 0 disables the ceiling.
+    QA_PROMPT_TOKEN_CEILING: int = 4000
+    # Cap on the prepended executive summary specifically, matching the 1000 the
+    # section context has always carried. `_should_use_summary` is a keyword match
+    # ("summarise", "main takeaway"), so this fires on the questions most likely to
+    # be asked of a long document -- 0/60 on the `study` golden, which is why it
+    # was never seen.
+    QA_SUMMARY_INJECTION_TOKEN_CAP: int = 1000
     QA_ATTACH_SECTION_SUMMARIES: bool = False
     # L2 funnel: how many RRF candidates the cross-encoder re-scores. HR@k of
     # the reranked list is bounded by HR@depth of the RRF pool, so depth is the

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -196,6 +196,26 @@ class Settings(BaseSettings):
     # this as a shipped default rather than an opt-in for hosts that are unusable
     # without it.
     QA_CONTEXT_TOKEN_BUDGET_SLOW_HOST: int = 750
+    # Whether a host measured slow still spends a whole LLM call classifying
+    # intent. Same gate as the budget above, and the reason it is separate is
+    # that this one's cost IS measured.
+    #
+    # What it saves: on an i7-8850H with the model resident, `classify_node`
+    # spent 17.02s of a 50.12s question deciding `summary` -- the label the
+    # heuristic had already returned. ~8s of that is this host's floor for
+    # issuing any local call at all (the keep-warm ping measures the same floor),
+    # which no prompt or output bound reaches. It fires on 4% of `intents` and
+    # 28% of `intents_adversarial`.
+    #
+    # What it costs, measured on this branch against a live backend:
+    #   intents (50)              1.0000 -> 1.0000   the LLM changes nothing
+    #   intents_adversarial (29)  0.9655 -> 0.8276   4 rescues lost
+    # The committed threshold (routing_accuracy >= 0.85, `intents`) is untouched;
+    # the adversarial set is the floor the Makefile already labels "not the
+    # routing". Below 0.7 the heuristic is guessing, and here the guess stands.
+    #
+    # Set this True to buy those 4 rescues back at ~17s per affected question.
+    QA_INTENT_LLM_FALLBACK_ON_SLOW_HOST: bool = False
     # Hard ceiling on everything the synthesis prompt carries, not just the chunk
     # context. QA_CONTEXT_TOKEN_BUDGET bounds `chunks_context` only; section
     # context, image context and a prepended executive summary are appended AFTER

--- a/backend/app/routers/evals.py
+++ b/backend/app/routers/evals.py
@@ -589,6 +589,12 @@ class EvalEnvironmentResponse(BaseModel):
     rerank_blend_alpha: float | None
     # The app's resolved setting, not the eval arm's choice. See eval_environment.py.
     rerank_enabled: bool = True
+    # Slow-host profile state. None probe means start-up never measured this host,
+    # which is "unmeasured" and therefore NOT slow.
+    startup_probe_seconds: float | None = None
+    local_inference_slow: bool = False
+    qa_context_token_budget: int = 0
+    qa_context_budget_reason: str = "unknown"
     query_spell_correct: bool
     llm_mode: str
     chat_model: str

--- a/backend/app/routers/evals.py
+++ b/backend/app/routers/evals.py
@@ -587,6 +587,8 @@ class EvalEnvironmentResponse(BaseModel):
     rerank_model: str
     rerank_depth: int
     rerank_blend_alpha: float | None
+    # The app's resolved setting, not the eval arm's choice. See eval_environment.py.
+    rerank_enabled: bool = True
     query_spell_correct: bool
     llm_mode: str
     chat_model: str

--- a/backend/app/routers/qa.py
+++ b/backend/app/routers/qa.py
@@ -99,10 +99,18 @@ async def classify_only(
 ) -> ClassifyOnlyResponse:
     """Classify the chat route without executing retrieval/LLM graph nodes.
 
-    The heuristic alone is not what production routes on: `chat_graph` sends
-    anything below 0.7 to the LLM, and the catch-all sits at 0.5. Measuring this
-    endpoint without `llm_fallback` therefore measures a path no user takes on
-    its own -- it is the floor, not the routing.
+    The heuristic alone is not what production routes on -- on a quick host.
+    `chat_graph` sends anything below 0.7 to the LLM there, and the catch-all
+    sits at 0.5, so measuring this endpoint without `llm_fallback` measures the
+    floor rather than the routing. On a host the start-up probe measured slow the
+    two converge: `should_use_llm_fallback` drops that call, and the heuristic
+    alone IS what the user gets.
+
+    This parameter is deliberately NOT gated on the host the way the graph is.
+    An eval has to be able to measure both arms on whatever machine it runs on;
+    gating it here would have made the slow-host arm unmeasurable on exactly the
+    hosts the gate exists for, and the 0.9655 -> 0.8276 figure that quantifies
+    its cost came from asking for both arms on such a machine.
     """
     intent, confidence = classify_intent_heuristic(req.question)
     source = "heuristic"

--- a/backend/app/runtime/chat_graph.py
+++ b/backend/app/runtime/chat_graph.py
@@ -80,6 +80,7 @@ from app.services.intent import (
     LLM_FALLBACK_BELOW,
     _llm_classify_fallback,
     classify_intent_heuristic,
+    should_use_llm_fallback,
 )
 from app.services.qa import (
     _maybe_rewrite_query,
@@ -226,7 +227,19 @@ async def classify_node(state: ChatState) -> dict:
     intent, confidence = classify_intent_heuristic(question)
     source = "heuristic"
 
-    if confidence < LLM_FALLBACK_BELOW:
+    use_llm, why = should_use_llm_fallback(confidence)
+    if not use_llm and confidence < LLM_FALLBACK_BELOW:
+        # Skipped, not failed, and said out loud: the heuristic's guess is what
+        # the user gets, and a route that looks wrong needs this line to be
+        # readable from a log rather than inferred from its absence.
+        logger.info(
+            "classify_node: LLM fallback SKIPPED (%s) -- heuristic intent=%s at "
+            "%.2f stands",
+            why,
+            intent,
+            confidence,
+        )
+    if use_llm:
         t_clf = time.perf_counter()
         intent = await _llm_classify_fallback(question, scope=scope, default=intent)
         source = "llm"

--- a/backend/app/runtime/chat_nodes/synthesize.py
+++ b/backend/app/runtime/chat_nodes/synthesize.py
@@ -52,8 +52,6 @@ def _cap_text_tokens(text: str, token_cap: int) -> str:
     return " ".join(words[:cap_words]) + " ..."
 
 
-
-
 # Citation gating. A cited source should actually contain the text the user is
 # sent to — a weakly-related chunk only pollutes the reference list. Cap the list
 # and drop low-relevance sources, but always keep the single best source so a
@@ -211,19 +209,25 @@ async def synthesize_node(state: ChatState) -> dict:
         logger.info("synthesize_node: no context available — returning not_found")
         return {"not_found": True}
 
+    # Resolved before the first log line, not after it: this used to print the
+    # configured QA_CONTEXT_TOKEN_BUDGET while the pack below ran at the
+    # slow-host one, so the two `synthesize_node:` lines disagreed about the
+    # budget on exactly the hosts the profile exists for -- and both are what
+    # scripts/diagnose-slow-host.sh pastes.
+    token_budget, budget_reason = resolve_context_budget()
+
     logger.info(
-        "synthesize_node: intent=%s chunks=%d section_context=%s budget=%d",
+        "synthesize_node: intent=%s chunks=%d section_context=%s budget=%d (%s)",
         intent,
         len(chunks_dicts),
         "yes" if section_context else "no",
-        get_settings().QA_CONTEXT_TOKEN_BUDGET,
+        token_budget,
+        budget_reason,
     )
-
 
     # Assemble chunk context using the pure context packer (dedup + section grouping).
     # Indexed: each chunk carries an [S<n>] marker so a citation can name the chunk
     # it came from and have its excerpt filled in from that chunk (I-33).
-    token_budget, budget_reason = resolve_context_budget()
     chunks_context, cited_chunks = (
         pack_context_indexed(chunks_dicts, token_budget=token_budget)
         if chunks_dicts
@@ -238,13 +242,16 @@ async def synthesize_node(state: ChatState) -> dict:
         budget_reason,
     )
 
-    # section_context (graph results, executive summary) capped at 1000 tokens
+    # section_context (graph results, executive summary): the same cap as every
+    # other optional injection, through the same helper. It was an open-coded
+    # copy of _cap_text_tokens against a literal 1000, which is the number
+    # QA_SUMMARY_INJECTION_TOKEN_CAP was chosen to match -- two places to change
+    # for one decision.
     context_parts: list[str] = []
     if section_context:
-        words = section_context.split()
-        cap_words = int(1000 / 1.3)  # approx word count for 1000 tokens
-        if len(words) > cap_words:
-            section_context = " ".join(words[:cap_words]) + " ..."
+        section_context = _cap_text_tokens(
+            section_context, get_settings().QA_SUMMARY_INJECTION_TOKEN_CAP
+        )
         context_parts.append(section_context)
 
     if chunks_context:

--- a/backend/app/runtime/chat_nodes/synthesize.py
+++ b/backend/app/runtime/chat_nodes/synthesize.py
@@ -22,8 +22,7 @@ from app.models import DocumentModel, ImageModel
 from app.repos.document_repo import fetch_chunk_locations
 from app.runtime.chat_nodes._shared import _get_system_prompt
 from app.services import graph as _graph_module  # indirect: get_graph_service is patched
-from app.services import model_keepwarm
-from app.services.context_packer import pack_context_indexed
+from app.services.context_packer import pack_context_indexed, resolve_context_budget
 from app.services.qa import (
     CITATION_MIN_SCORE,
     CITATION_REL_RATIO,
@@ -53,27 +52,6 @@ def _cap_text_tokens(text: str, token_cap: int) -> str:
     return " ".join(words[:cap_words]) + " ..."
 
 
-def _resolve_context_budget() -> tuple[int, str]:
-    """(token budget, why) for the synthesis context on THIS host.
-
-    A measurement, never a platform check -- literally the same gate as the
-    keep-warm loop, via the `local_inference_is_slow()` host fact rather than a
-    second threshold that could drift away from it. Unmeasured is not slow, so a
-    host whose Ollama was down at start-up keeps the full budget.
-
-    Note the inherited coupling: that helper returns False when
-    LLM_KEEP_WARM_ENABLED is off, so switching keep-warm off also restores the
-    full budget. Both are "this host is expensive" behaviours, and one switch for
-    both beats two that can disagree.
-    """
-    settings = get_settings()
-    if model_keepwarm.local_inference_is_slow():
-        probe = model_keepwarm.measured_probe_seconds()
-        return (
-            settings.QA_CONTEXT_TOKEN_BUDGET_SLOW_HOST,
-            f"slow host (probe {probe:.1f}s)" if probe is not None else "slow host",
-        )
-    return settings.QA_CONTEXT_TOKEN_BUDGET, "default"
 
 
 # Citation gating. A cited source should actually contain the text the user is
@@ -245,7 +223,7 @@ async def synthesize_node(state: ChatState) -> dict:
     # Assemble chunk context using the pure context packer (dedup + section grouping).
     # Indexed: each chunk carries an [S<n>] marker so a citation can name the chunk
     # it came from and have its excerpt filled in from that chunk (I-33).
-    token_budget, budget_reason = _resolve_context_budget()
+    token_budget, budget_reason = resolve_context_budget()
     chunks_context, cited_chunks = (
         pack_context_indexed(chunks_dicts, token_budget=token_budget)
         if chunks_dicts

--- a/backend/app/runtime/chat_nodes/synthesize.py
+++ b/backend/app/runtime/chat_nodes/synthesize.py
@@ -22,6 +22,7 @@ from app.models import DocumentModel, ImageModel
 from app.repos.document_repo import fetch_chunk_locations
 from app.runtime.chat_nodes._shared import _get_system_prompt
 from app.services import graph as _graph_module  # indirect: get_graph_service is patched
+from app.services import model_keepwarm
 from app.services.context_packer import pack_context_indexed
 from app.services.qa import (
     CITATION_MIN_SCORE,
@@ -33,6 +34,46 @@ from app.services.summarizer import get_summarization_service
 from app.types import ChatState, TransparencyInfo
 
 logger = logging.getLogger(__name__)
+
+
+def _cap_text_tokens(text: str, token_cap: int) -> str:
+    """Trim *text* to roughly *token_cap* tokens on a word boundary.
+
+    Same ~1.3 tokens-per-word approximation the section-context cap has always
+    used. Applied to the OPTIONAL prompt injections only -- never to the packed
+    chunk context, because an `[S3]` marker the model is told to cite must still
+    have its passage present when the citation is resolved (I-33).
+    """
+    if token_cap <= 0 or not text:
+        return text
+    words = text.split()
+    cap_words = int(token_cap / 1.3)
+    if len(words) <= cap_words:
+        return text
+    return " ".join(words[:cap_words]) + " ..."
+
+
+def _resolve_context_budget() -> tuple[int, str]:
+    """(token budget, why) for the synthesis context on THIS host.
+
+    A measurement, never a platform check -- literally the same gate as the
+    keep-warm loop, via the `local_inference_is_slow()` host fact rather than a
+    second threshold that could drift away from it. Unmeasured is not slow, so a
+    host whose Ollama was down at start-up keeps the full budget.
+
+    Note the inherited coupling: that helper returns False when
+    LLM_KEEP_WARM_ENABLED is off, so switching keep-warm off also restores the
+    full budget. Both are "this host is expensive" behaviours, and one switch for
+    both beats two that can disagree.
+    """
+    settings = get_settings()
+    if model_keepwarm.local_inference_is_slow():
+        probe = model_keepwarm.measured_probe_seconds()
+        return (
+            settings.QA_CONTEXT_TOKEN_BUDGET_SLOW_HOST,
+            f"slow host (probe {probe:.1f}s)" if probe is not None else "slow host",
+        )
+    return settings.QA_CONTEXT_TOKEN_BUDGET, "default"
 
 
 # Citation gating. A cited source should actually contain the text the user is
@@ -204,18 +245,19 @@ async def synthesize_node(state: ChatState) -> dict:
     # Assemble chunk context using the pure context packer (dedup + section grouping).
     # Indexed: each chunk carries an [S<n>] marker so a citation can name the chunk
     # it came from and have its excerpt filled in from that chunk (I-33).
-    token_budget = get_settings().QA_CONTEXT_TOKEN_BUDGET
+    token_budget, budget_reason = _resolve_context_budget()
     chunks_context, cited_chunks = (
         pack_context_indexed(chunks_dicts, token_budget=token_budget)
         if chunks_dicts
         else ("", [])
     )
     logger.info(
-        "synthesize_node: packed %d/%d passages into %d chars at budget %d",
+        "synthesize_node: packed %d/%d passages into %d chars at budget %d (%s)",
         len(cited_chunks),
         len(chunks_dicts),
         len(chunks_context),
         token_budget,
+        budget_reason,
     )
 
     # section_context (graph results, executive summary) capped at 1000 tokens
@@ -241,6 +283,9 @@ async def synthesize_node(state: ChatState) -> dict:
             image_doc_titles = await _fetch_doc_titles_for_chunks(chunks_dicts)
             image_context = await _fetch_image_context(image_ids, image_doc_titles)
             if image_context:
+                image_context = _cap_text_tokens(
+                    image_context, get_settings().QA_SUMMARY_INJECTION_TOKEN_CAP
+                )
                 context = f"{context}\n\n---\n\n{image_context}" if context else image_context
                 logger.info(
                     "synthesize_node: injected image context (%d chars)", len(image_context)
@@ -261,7 +306,14 @@ async def synthesize_node(state: ChatState) -> dict:
                 state["doc_ids"][0], "executive"
             )
             if exec_summary:
-                context = f"[Document Summary]\n{exec_summary.content}\n\n---\n\n{context}"
+                # Uncapped until 2026-08-27: `_should_use_summary` is a keyword
+                # match, so this fires on exactly the questions asked of long
+                # documents and prepended a whole cached summary past the context
+                # budget. The budget bounded chunks_context only.
+                summary_text = _cap_text_tokens(
+                    exec_summary.content, get_settings().QA_SUMMARY_INJECTION_TOKEN_CAP
+                )
+                context = f"[Document Summary]\n{summary_text}\n\n---\n\n{context}"
         except Exception:
             logger.warning("synthesize_node: failed to fetch executive summary", exc_info=True)
 
@@ -295,6 +347,9 @@ async def synthesize_node(state: ChatState) -> dict:
         try:
             contradiction_ctx = await _fetch_contradiction_context(state["doc_ids"])
             if contradiction_ctx:
+                contradiction_ctx = _cap_text_tokens(
+                    contradiction_ctx, get_settings().QA_SUMMARY_INJECTION_TOKEN_CAP
+                )
                 context = contradiction_ctx + "\n\n---\n\n" + context
                 logger.info(
                     "synthesize_node: injected contradiction context (%d chars)",
@@ -308,6 +363,25 @@ async def synthesize_node(state: ChatState) -> dict:
     else:
         prompt = f"Context:\n\n{context}\n\nQuestion: {question}"
     system_prompt = _get_system_prompt(intent)
+
+    # Prefill is ~linear in prompt size and is the whole wait on a CPU-only host,
+    # yet nothing reported what the prompt actually weighed -- only what the chunk
+    # packer contributed, which is one of five additive sources. Approximate
+    # (~1.3 tokens/word) on purpose: an exact count costs a tokenizer pass on every
+    # answer to inform a log line.
+    _approx_prompt_tokens = int(len((prompt + system_prompt).split()) * 1.3)
+    _ceiling = get_settings().QA_PROMPT_TOKEN_CEILING
+    if _ceiling and _approx_prompt_tokens > _ceiling:
+        logger.warning(
+            "synthesize_node: prompt ~%d tokens exceeds ceiling %d (context %d chars, "
+            "budget %d) -- an injection is outgrowing the context budget",
+            _approx_prompt_tokens,
+            _ceiling,
+            len(context),
+            token_budget,
+        )
+    else:
+        logger.info("synthesize_node: prompt ~%d tokens", _approx_prompt_tokens)
 
     # For library-wide factual/exploratory queries, instruct the LLM to attribute sources
     if scope == "all" and intent in ("factual", "exploratory"):

--- a/backend/app/services/context_packer.py
+++ b/backend/app/services/context_packer.py
@@ -207,6 +207,35 @@ def _pack(
     return "".join(parts), emitted_src
 
 
+def resolve_context_budget() -> tuple[int, str]:
+    """(token budget, why) for the synthesis context on THIS host.
+
+    A measurement, never a platform check -- literally the same gate as the
+    keep-warm loop, via the `local_inference_is_slow()` host fact rather than a
+    second threshold that could drift from it. Unmeasured is not slow, so a host
+    whose Ollama was down at start-up keeps the full budget.
+
+    Note the inherited coupling: that helper returns False when
+    LLM_KEEP_WARM_ENABLED is off, so switching keep-warm off also restores the
+    full budget. Both are "this host is expensive" behaviours, and one switch for
+    both beats two that can disagree.
+
+    Lives here rather than in the chat node so `eval_environment` can report the
+    resolved budget without a service importing runtime.
+    """
+    from app.config import get_settings  # noqa: PLC0415
+    from app.services import model_keepwarm  # noqa: PLC0415
+
+    settings = get_settings()
+    if model_keepwarm.local_inference_is_slow():
+        probe = model_keepwarm.measured_probe_seconds()
+        return (
+            settings.QA_CONTEXT_TOKEN_BUDGET_SLOW_HOST,
+            f"slow host (probe {probe:.1f}s)" if probe is not None else "slow host",
+        )
+    return settings.QA_CONTEXT_TOKEN_BUDGET, "default"
+
+
 def pack_context(
     chunks: list[dict],
     token_budget: int = 3000,

--- a/backend/app/services/eval_environment.py
+++ b/backend/app/services/eval_environment.py
@@ -51,6 +51,8 @@ async def collect_environment(db: AsyncSession) -> dict[str, Any]:
 
     generation_model = resolve("generation").model
 
+    context_budget, context_budget_reason = resolve_context_budget()
+
     # Both arms, because `hybrid` resolves them to different models: interactive
     # goes to the cloud while background stays local. A run that records one
     # model for a mode with two describes a system that does not exist.
@@ -92,8 +94,8 @@ async def collect_environment(db: AsyncSession) -> dict[str, Any]:
         # outside the process previously needed the container's logs.
         "startup_probe_seconds": model_keepwarm.measured_probe_seconds(),
         "local_inference_slow": model_keepwarm.local_inference_is_slow(),
-        "qa_context_token_budget": resolve_context_budget()[0],
-        "qa_context_budget_reason": resolve_context_budget()[1],
+        "qa_context_token_budget": context_budget,
+        "qa_context_budget_reason": context_budget_reason,
         "query_spell_correct": settings.QUERY_SPELL_CORRECT,
         "llm_mode": llm["mode"],
         "chat_model": interactive_model,

--- a/backend/app/services/eval_environment.py
+++ b/backend/app/services/eval_environment.py
@@ -79,6 +79,12 @@ async def collect_environment(db: AsyncSession) -> dict[str, Any]:
         "rerank_model": settings.RERANK_MODEL,
         "rerank_depth": settings.RERANK_DEPTH,
         "rerank_blend_alpha": settings.RERANK_BLEND_ALPHA,
+        # Whether the reranker actually runs, not merely which one is configured.
+        # `/search` defaults `rerank=false` while the chat path resolves this
+        # setting, so an eval arm querying `/search` measured a funnel the app
+        # does not ship -- and the block still named a reranker, which read as
+        # proof it had been used. Recorded so the two can be compared.
+        "rerank_enabled": await settings_service.get_rerank_enabled(db),
         "query_spell_correct": settings.QUERY_SPELL_CORRECT,
         "llm_mode": llm["mode"],
         "chat_model": interactive_model,

--- a/backend/app/services/eval_environment.py
+++ b/backend/app/services/eval_environment.py
@@ -20,7 +20,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import get_settings
 from app.paths import app_version
 from app.repos.document_repo import DocumentRepo
-from app.services import settings_service
+from app.services import model_keepwarm, settings_service
+from app.services.context_packer import resolve_context_budget
 from app.services.embedder import MODEL_NAME as EMBEDDING_MODEL
 from app.services.prompt_spec import withheld
 from app.services.vector_store import TABLE_NAME as CHUNK_VECTOR_TABLE
@@ -85,6 +86,14 @@ async def collect_environment(db: AsyncSession) -> dict[str, Any]:
         # does not ship -- and the block still named a reranker, which read as
         # proof it had been used. Recorded so the two can be compared.
         "rerank_enabled": await settings_service.get_rerank_enabled(db),
+        # The slow-host profile, readable without log access. "Still slow" has
+        # several independent causes -- wrong build, no start-up probe recorded,
+        # profile engaged but prefill still dominant -- and separating them from
+        # outside the process previously needed the container's logs.
+        "startup_probe_seconds": model_keepwarm.measured_probe_seconds(),
+        "local_inference_slow": model_keepwarm.local_inference_is_slow(),
+        "qa_context_token_budget": resolve_context_budget()[0],
+        "qa_context_budget_reason": resolve_context_budget()[1],
         "query_spell_correct": settings.QUERY_SPELL_CORRECT,
         "llm_mode": llm["mode"],
         "chat_model": interactive_model,

--- a/backend/app/services/intent.py
+++ b/backend/app/services/intent.py
@@ -164,6 +164,16 @@ _SUMMARY_PATTERNS: tuple[re.Pattern[str], ...] = (
         r"[\w\s-]{0,24}\babout\b"
     ),
     re.compile(r"\bwhat\s+(?:is|are)\s+[\w\s-]{0,24}\b(?:mainly|broadly|generally)\s+about\b"),
+    # The verb, in both spellings and all four forms. `summarize` and `summary`
+    # are keywords, but _inflected_regex only adds an optional (e)s -- so
+    # "summarised", "summarising" and every -ise spelling matched nothing and
+    # fell to the 0.5 catch-all, which is BELOW LLM_FALLBACK_BELOW. On a slow
+    # host that turned "Summarise the main argument in two sentences." into a
+    # 17s LLM call to be told `summary`; with the fallback gated off it routes
+    # to search instead, which is the wrong answer rather than a slow one.
+    # A shape, not a phrase list: it generalises to the spellings and tenses no
+    # golden enumerates, which is why it lives here and not in _SUMMARY_KWS.
+    re.compile(r"\bsummari[sz](?:e|es|ed|ing)\b"),
 )
 
 _RELATIONAL_KWS: frozenset[str] = frozenset(
@@ -543,6 +553,47 @@ def classify_intent_heuristic(question: str) -> tuple[str, float]:
 # Below this the heuristic is guessing and the LLM decides. Shared so the chat
 # graph and anything measuring it cannot drift apart.
 LLM_FALLBACK_BELOW = 0.7
+
+
+def should_use_llm_fallback(confidence: float) -> tuple[bool, str]:
+    """(ask the LLM classifier, why) for THIS host.
+
+    Lives here rather than in the chat node for the same reason
+    `resolve_context_budget` lives in the packer: one predicate, so the graph
+    and anything measuring the graph cannot drift apart.
+
+    The gate is the same measured host fact as the keep-warm loop and the
+    context budget -- `local_inference_is_slow()` -- rather than a third
+    threshold that could disagree with them. Unmeasured is not slow, so a host
+    nothing is known about keeps the shipped behaviour.
+
+    Why a classifier call is worth gating at all: it is not a rounding error
+    against the answer on a host like this. Measured on an i7-8850H with the
+    model already resident (`/api/ps` showed one model, no load), `classify_node`
+    spent 17.02s of a 50.12s question to return `summary` -- the label the
+    heuristic had already returned at 0.50.
+
+    The cost is real and is NOT hidden: below the threshold the heuristic is
+    guessing, and on a slow host the guess now stands. It is measured on
+    `intents_adversarial` (0.9655 -> 0.8276) and zero on `intents`, which is the
+    set carrying the committed threshold. `QA_INTENT_LLM_FALLBACK_ON_SLOW_HOST`
+    buys those rescues back.
+    """
+    if confidence >= LLM_FALLBACK_BELOW:
+        return (False, "heuristic confident")
+
+    from app.config import get_settings  # noqa: PLC0415
+    from app.services import model_keepwarm  # noqa: PLC0415
+
+    if get_settings().QA_INTENT_LLM_FALLBACK_ON_SLOW_HOST:
+        return (True, "heuristic below threshold")
+    if model_keepwarm.local_inference_is_slow():
+        probe = model_keepwarm.measured_probe_seconds()
+        return (
+            False,
+            f"slow host (probe {probe:.1f}s)" if probe is not None else "slow host",
+        )
+    return (True, "heuristic below threshold")
 
 
 # The classifier prompt as a contract plus what this model needed to follow it.

--- a/backend/app/services/intent.py
+++ b/backend/app/services/intent.py
@@ -574,10 +574,13 @@ def should_use_llm_fallback(confidence: float) -> tuple[bool, str]:
     heuristic had already returned at 0.50.
 
     The cost is real and is NOT hidden: below the threshold the heuristic is
-    guessing, and on a slow host the guess now stands. It is measured on
-    `intents_adversarial` (0.9655 -> 0.8276) and zero on `intents`, which is the
-    set carrying the committed threshold. `QA_INTENT_LLM_FALLBACK_ON_SLOW_HOST`
-    buys those rescues back.
+    guessing, and on a slow host the guess now stands. On the model the app ships
+    (`ollama/qwen3.5:4b`) that is `intents_adversarial` 0.8966 -> 0.8276, two of
+    29 rows, and zero on `intents`, which is the set carrying the committed
+    threshold. `QA_INTENT_LLM_FALLBACK_ON_SLOW_HOST` buys those rescues back.
+    The arm is strongly model-dependent -- 0.9655 on `qwen2.5:14b-instruct`,
+    0.8276 on `qwen3.5:0.8b` -- so price it on the model in `chat_model`, never
+    across two.
     """
     if confidence >= LLM_FALLBACK_BELOW:
         return (False, "heuristic confident")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "luminary-backend"
-version = "0.7.9"
+version = "0.8.0"
 description = "Luminary — local-first personal knowledge and learning assistant"
 requires-python = ">=3.13"
 dependencies = [

--- a/backend/tests/test_ablation_eval.py
+++ b/backend/tests/test_ablation_eval.py
@@ -99,6 +99,7 @@ async def test_retriever_strategy_graph_expands_then_vector(monkeypatch):
 def test_run_eval_ablation_produces_one_metric_set_per_arm(monkeypatch):
     strategies_seen: list[str] = []
     expand_flags: list[bool] = []
+    rerank_flags: list[bool] = []
     history_rows: list[tuple[str, dict]] = []
     store_rows: list[tuple[str, dict]] = []
 
@@ -116,15 +117,18 @@ def test_run_eval_ablation_produces_one_metric_set_per_arm(monkeypatch):
         ],
     )
     monkeypatch.setattr(run_eval, "load_manifest", lambda: {})
-    # An ablation sweep states its own arms, but the base run still resolves the
-    # retrieval arm against the backend's shipped funnel and refuses to guess.
-    monkeypatch.setattr(run_eval, "shipped_rerank", lambda *a, **k: False)
+    # The shipped funnel RERANKS, and the base run resolves `--rerank` against it.
+    # Pinned to True on purpose: an ablation states every arm itself, so the
+    # unreranked arms below must stay unreranked against a backend that ships
+    # reranking. Pinning it False here would hide exactly that.
+    monkeypatch.setattr(run_eval, "shipped_rerank", lambda *a, **k: True)
     monkeypatch.setattr(
         run_eval,
         "search_chunks",
         lambda *args, **kwargs: (
             strategies_seen.append(kwargs.get("strategy", "rrf")),
             expand_flags.append(kwargs.get("graph_expand", True)),
+            rerank_flags.append(bool(kwargs.get("rerank", False))),
         )
         and ["answer hint"],
     )
@@ -157,6 +161,9 @@ def test_run_eval_ablation_produces_one_metric_set_per_arm(monkeypatch):
     # Only the -nogx arms switch expansion off; everything else inherits the
     # /search default, which is what the shipped pipeline runs with.
     assert expand_flags == [True, True, True, True, False, True, True, False, True]
+    # Only the arms that declare a reranker get one. The last entry is the
+    # rrf-pool recall arm, which measures the L1 candidate pool and must not.
+    assert rerank_flags == [False, False, False, False, False, True, True, True, False]
     assert history_rows[0][0] == "ablation"
     assert set(history_rows[0][1]["ablation_metrics"]) == {
         "vector", "fts", "graph", "rrf", "rrf-nogx",

--- a/backend/tests/test_ablation_eval.py
+++ b/backend/tests/test_ablation_eval.py
@@ -116,6 +116,9 @@ def test_run_eval_ablation_produces_one_metric_set_per_arm(monkeypatch):
         ],
     )
     monkeypatch.setattr(run_eval, "load_manifest", lambda: {})
+    # An ablation sweep states its own arms, but the base run still resolves the
+    # retrieval arm against the backend's shipped funnel and refuses to guess.
+    monkeypatch.setattr(run_eval, "shipped_rerank", lambda *a, **k: False)
     monkeypatch.setattr(
         run_eval,
         "search_chunks",

--- a/backend/tests/test_context_budget_narrows_where_inference_is_expensive.py
+++ b/backend/tests/test_context_budget_narrows_where_inference_is_expensive.py
@@ -21,8 +21,8 @@ import pytest
 
 from app.config import get_settings
 from app.runtime.chat_nodes.synthesize import _cap_text_tokens
-from app.services.context_packer import resolve_context_budget
 from app.services import model_keepwarm
+from app.services.context_packer import resolve_context_budget
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_context_budget_narrows_where_inference_is_expensive.py
+++ b/backend/tests/test_context_budget_narrows_where_inference_is_expensive.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 import pytest
 
 from app.config import get_settings
-from app.runtime.chat_nodes.synthesize import _cap_text_tokens, _resolve_context_budget
+from app.runtime.chat_nodes.synthesize import _cap_text_tokens
+from app.services.context_packer import resolve_context_budget
 from app.services import model_keepwarm
 
 
@@ -33,21 +34,21 @@ def _clear_probe():
 
 def test_an_unmeasured_host_keeps_the_full_budget():
     """None is 'unmeasured', never 'fast' -- and never 'slow' either."""
-    budget, reason = _resolve_context_budget()
+    budget, reason = resolve_context_budget()
     assert budget == get_settings().QA_CONTEXT_TOKEN_BUDGET
     assert reason == "default"
 
 
 def test_a_quick_host_keeps_the_full_budget():
     model_keepwarm.record_startup_probe(get_settings().LLM_KEEP_WARM_ABOVE_SECONDS - 1.0)
-    budget, _ = _resolve_context_budget()
+    budget, _ = resolve_context_budget()
     assert budget == get_settings().QA_CONTEXT_TOKEN_BUDGET
 
 
 def test_an_expensive_host_narrows_the_budget():
     """The i7-8850H case: start-up probes there measured 9.59s-155.45s."""
     model_keepwarm.record_startup_probe(get_settings().LLM_KEEP_WARM_ABOVE_SECONDS + 1.0)
-    budget, reason = _resolve_context_budget()
+    budget, reason = resolve_context_budget()
     assert budget == get_settings().QA_CONTEXT_TOKEN_BUDGET_SLOW_HOST
     assert budget < get_settings().QA_CONTEXT_TOKEN_BUDGET
     assert "slow host" in reason

--- a/backend/tests/test_context_budget_narrows_where_inference_is_expensive.py
+++ b/backend/tests/test_context_budget_narrows_where_inference_is_expensive.py
@@ -1,0 +1,73 @@
+"""The synthesis context budget follows a measurement of the host, not a platform.
+
+Prefill is ~linear in prompt size and is the entire wait on a CPU-only host: an
+Intel i7-8850H in a 12GB Docker VM measured ~31 tok/s, so a 1739-token prompt is
+~56s before the first token. Narrowing the budget there is worth roughly half of
+that; narrowing it on an Apple M3 Pro is pure loss.
+
+The gate is `measured_probe_seconds()` -- what this machine charged for a trivial
+answer at start-up -- for the same reason the keep-warm loop uses it: it is right
+for a CPU-only laptop, a Docker VM and a GPU box without naming any of them, and
+`platform.machine()` would guess at the cause rather than measure the effect.
+
+An unmeasured host keeps the full budget. None means "never measured", never
+"fast", so a host whose Ollama was down at start-up is left alone rather than
+silently given a narrower prompt.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import get_settings
+from app.runtime.chat_nodes.synthesize import _cap_text_tokens, _resolve_context_budget
+from app.services import model_keepwarm
+
+
+@pytest.fixture(autouse=True)
+def _clear_probe():
+    model_keepwarm.reset_measurement()
+    yield
+    model_keepwarm.reset_measurement()
+
+
+def test_an_unmeasured_host_keeps_the_full_budget():
+    """None is 'unmeasured', never 'fast' -- and never 'slow' either."""
+    budget, reason = _resolve_context_budget()
+    assert budget == get_settings().QA_CONTEXT_TOKEN_BUDGET
+    assert reason == "default"
+
+
+def test_a_quick_host_keeps_the_full_budget():
+    model_keepwarm.record_startup_probe(get_settings().LLM_KEEP_WARM_ABOVE_SECONDS - 1.0)
+    budget, _ = _resolve_context_budget()
+    assert budget == get_settings().QA_CONTEXT_TOKEN_BUDGET
+
+
+def test_an_expensive_host_narrows_the_budget():
+    """The i7-8850H case: start-up probes there measured 9.59s-155.45s."""
+    model_keepwarm.record_startup_probe(get_settings().LLM_KEEP_WARM_ABOVE_SECONDS + 1.0)
+    budget, reason = _resolve_context_budget()
+    assert budget == get_settings().QA_CONTEXT_TOKEN_BUDGET_SLOW_HOST
+    assert budget < get_settings().QA_CONTEXT_TOKEN_BUDGET
+    assert "slow host" in reason
+
+
+def test_the_narrow_budget_still_carries_more_than_one_passage():
+    """8244526 reverted a narrower budget because 500-1250 all collapsed to ONE
+    passage pre-de-duplication. Post-914e8b54 the budget is a dial; a slow-host
+    value that drops back to a single retrieved region would re-introduce exactly
+    the defect that revert exists to prevent."""
+    settings = get_settings()
+    assert settings.QA_CONTEXT_TOKEN_BUDGET_SLOW_HOST >= 750
+
+
+def test_an_optional_injection_is_capped_on_a_word_boundary():
+    capped = _cap_text_tokens(" ".join(["word"] * 5000), 100)
+    assert capped.endswith(" ...")
+    assert len(capped.split()) < 200
+
+
+def test_capping_leaves_short_text_untouched():
+    assert _cap_text_tokens("a short summary", 1000) == "a short summary"
+    assert _cap_text_tokens("anything", 0) == "anything"

--- a/backend/tests/test_eval_gate.py
+++ b/backend/tests/test_eval_gate.py
@@ -70,6 +70,20 @@ def _wire(monkeypatch, history, *, qa=None, judge_scores=None, nli_score=0.95):
     monkeypatch.setattr(run_eval, "is_document_alive", lambda *a, **k: True)
     monkeypatch.setattr(run_eval, "resolve_backend_base", lambda url: url)
     monkeypatch.setattr(run_eval, "require_backend", lambda *a, **k: None)
+    # The retrieval arm defaults to the funnel the backend reports shipping, and
+    # refuses to guess when it cannot read it. These tests have no backend, so
+    # state the funnel here rather than letting every one of them exit 2.
+    monkeypatch.setattr(run_eval, "shipped_rerank", lambda *a, **k: False)
+    # These tests assert gate MECHANICS -- that a violation exits, that a clean run
+    # does not, that an absent metric is a skip rather than a failure -- against a
+    # 2-row synthetic golden whose HR@5 is 0.5 by construction. Pin the floors to
+    # the global defaults so re-deriving a real dataset's floor cannot silently turn
+    # a mechanics test red, which is exactly what per-dataset retrieval floors did.
+    monkeypatch.setattr(
+        run_eval,
+        "thresholds_for_dataset",
+        lambda dataset: {**run_eval.THRESHOLDS},
+    )
     monkeypatch.setattr(run_eval, "search_chunks", lambda *a, **k: [_CHUNK])
     monkeypatch.setattr(
         run_eval,

--- a/backend/tests/test_eval_metrics.py
+++ b/backend/tests/test_eval_metrics.py
@@ -72,13 +72,19 @@ def test_an_override_exists_only_where_it_differs_from_the_default():
 
     `paper` carried 0.45/0.30 because 17 of its 40 questions asked about scrape
     furniture; the floor had been lowered instead of the data fixed. Regenerated
-    clean it measures 0.850/0.703, so it takes the default like everything else.
+    clean it measures 0.850/0.703.
+
+    It carries an override again since 2026-08-26, in the opposite direction and
+    for the opposite reason: measured on the shipped (reranked) funnel it scores
+    HR@5 0.9000, against which the global 0.50 floor would let it halve before
+    firing. A floor RAISED to match a measurement is a collapse detector doing its
+    job; a floor lowered to make a run pass is what this test exists to catch.
     """
     for dataset, overrides in DATASET_THRESHOLDS.items():
         differing = {k: v for k, v in overrides.items() if THRESHOLDS.get(k) != v}
         assert differing == overrides, f"{dataset} restates the default for {overrides}"
 
-    assert thresholds_for_dataset("paper")["hit_rate_5"] == THRESHOLDS["hit_rate_5"]
+    assert thresholds_for_dataset("paper")["hit_rate_5"] > THRESHOLDS["hit_rate_5"]
 
 
 # HR@5 tests

--- a/backend/tests/test_intent_fallback_costs_more_than_it_buys_on_slow_hosts.py
+++ b/backend/tests/test_intent_fallback_costs_more_than_it_buys_on_slow_hosts.py
@@ -1,0 +1,148 @@
+"""The intent classifier's LLM fallback is gated on a measurement of the host.
+
+Below confidence 0.7 the heuristic is guessing and an LLM decides. That call is
+free on a GPU box and is not free here: measured on an Intel i7-8850H with the
+model already resident -- `/api/ps` showed one model and the log has no load --
+`classify_node` spent 17.02s of a 50.12s question returning `summary`, which is
+the label `classify_intent_heuristic` had already returned at 0.50. About 8s of
+that is this host's floor for issuing any local call at all, the same floor the
+keep-warm ping measures, and no prompt or output bound reaches it.
+
+The gate is `local_inference_is_slow()` -- the same measured fact as the
+keep-warm loop and the context budget, not a third threshold that could drift
+from them. Unmeasured is not slow.
+
+What the gate costs is measured, not assumed, against a live backend:
+
+    intents (50)              1.0000 -> 1.0000   the LLM changes nothing
+    intents_adversarial (29)  0.9655 -> 0.8276   4 rescues lost
+
+`intents` carries the committed threshold (routing_accuracy >= 0.85) and does
+not move, because the 2 of 50 rows that reach the LLM there are ones the
+heuristic already routes correctly. `QA_INTENT_LLM_FALLBACK_ON_SLOW_HOST` buys
+the adversarial rescues back at ~17s per affected question.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import get_settings
+from app.services import model_keepwarm
+from app.services.intent import (
+    LLM_FALLBACK_BELOW,
+    classify_intent_heuristic,
+    should_use_llm_fallback,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_probe():
+    model_keepwarm.reset_measurement()
+    yield
+    model_keepwarm.reset_measurement()
+
+
+def _slow():
+    model_keepwarm.record_startup_probe(get_settings().LLM_KEEP_WARM_ABOVE_SECONDS + 1.0)
+
+
+def _quick():
+    model_keepwarm.record_startup_probe(get_settings().LLM_KEEP_WARM_ABOVE_SECONDS - 1.0)
+
+
+def test_a_confident_heuristic_never_asks_the_llm_on_any_host():
+    """The gate must not change what happens above the threshold."""
+    for setup in (_quick, _slow, model_keepwarm.reset_measurement):
+        setup()
+        use_llm, why = should_use_llm_fallback(0.95)
+        assert use_llm is False
+        assert why == "heuristic confident"
+
+
+def test_an_unmeasured_host_still_asks_the_llm():
+    """None is 'unmeasured', never 'slow' -- a host whose Ollama was down at
+    start-up keeps the shipped behaviour rather than silently losing a check."""
+    use_llm, _ = should_use_llm_fallback(0.5)
+    assert use_llm is True
+
+
+def test_a_quick_host_still_asks_the_llm():
+    _quick()
+    use_llm, _ = should_use_llm_fallback(0.5)
+    assert use_llm is True
+
+
+def test_an_expensive_host_keeps_its_17_seconds():
+    _slow()
+    use_llm, why = should_use_llm_fallback(0.5)
+    assert use_llm is False
+    assert "slow host" in why
+
+
+def test_the_reason_carries_the_probe_that_decided_it():
+    """A route that looks wrong is diagnosed from this string."""
+    _slow()
+    _, why = should_use_llm_fallback(0.5)
+    assert "probe" in why
+
+
+def test_the_setting_buys_the_rescues_back(monkeypatch):
+    """Turning a check off is a decision: the flag exists so a slow host that
+    wants the 4 adversarial rescues can pay 17s for them."""
+    _slow()
+    settings = get_settings()
+    monkeypatch.setattr(settings, "QA_INTENT_LLM_FALLBACK_ON_SLOW_HOST", True)
+    use_llm, _ = should_use_llm_fallback(0.5)
+    assert use_llm is True
+
+
+def test_the_gate_only_ever_applies_below_the_threshold():
+    """Bracketing the two cases: at the threshold the heuristic decides on every
+    host, one step below it the host's measurement decides."""
+    _slow()
+    assert should_use_llm_fallback(LLM_FALLBACK_BELOW)[0] is False
+    assert should_use_llm_fallback(LLM_FALLBACK_BELOW)[1] == "heuristic confident"
+    assert should_use_llm_fallback(LLM_FALLBACK_BELOW - 0.01)[0] is False
+    assert "slow host" in should_use_llm_fallback(LLM_FALLBACK_BELOW - 0.01)[1]
+
+
+# -- the spelling gap the gate would otherwise expose -------------------------
+#
+# With the fallback gated off, a summary request the heuristic misses no longer
+# gets corrected -- it routes to search, which is a wrong answer rather than a
+# slow one. "summarise" was exactly that case: _inflected_regex adds only an
+# optional (e)s to a keyword, so of the eight spellings of the verb only two
+# matched.
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        "Summarise the main argument in two sentences.",
+        "Summarize the main argument in two sentences.",
+        "Can you summarise this for me?",
+        "I summarised it already, do it properly",
+        "Summarising this document, what stands out?",
+        "Summarizing the whole thing, what stands out?",
+    ],
+)
+def test_every_spelling_of_the_verb_reaches_summary_without_an_llm(question):
+    intent, confidence = classify_intent_heuristic(question)
+    assert intent == "summary"
+    assert confidence >= LLM_FALLBACK_BELOW, "must not need the LLM to be routed"
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        # The bracketing counter-cases. The pattern matches the VERB, so a noun
+        # that merely starts the same way must not drag an unrelated question
+        # into summary -- "summarily" is the one that shares the most letters.
+        "Was the appeal dismissed summarily?",
+        "What is a summariser in this architecture?",
+    ],
+)
+def test_a_word_that_merely_starts_the_same_is_not_a_summary_request(question):
+    intent, _ = classify_intent_heuristic(question)
+    assert intent != "summary"

--- a/backend/tests/test_intent_fallback_costs_more_than_it_buys_on_slow_hosts.py
+++ b/backend/tests/test_intent_fallback_costs_more_than_it_buys_on_slow_hosts.py
@@ -12,10 +12,16 @@ The gate is `local_inference_is_slow()` -- the same measured fact as the
 keep-warm loop and the context budget, not a third threshold that could drift
 from them. Unmeasured is not slow.
 
-What the gate costs is measured, not assumed, against a live backend:
+What the gate costs is measured, not assumed, against a live backend running the
+model the app ships (`ollama/qwen3.5:4b`, 2026-08-27), fallback on -> off:
 
     intents (50)              1.0000 -> 1.0000   the LLM changes nothing
-    intents_adversarial (29)  0.9655 -> 0.8276   4 rescues lost
+    intents_adversarial (29)  0.8966 -> 0.8276   2 rescues lost
+
+Measure this arm on the model in `chat_model` and on no other. The same 29 rows
+score 0.9655 on `qwen2.5:14b-instruct` and 0.8276 on `qwen3.5:0.8b`
+(`evals/scores_history.jsonl`), so a delta taken across two models prices the
+gate at a cost no user pays.
 
 `intents` carries the committed threshold (routing_accuracy >= 0.85) and does
 not move, because the 2 of 50 rows that reach the LLM there are ones the

--- a/backend/tests/test_run_eval_generation_flow.py
+++ b/backend/tests/test_run_eval_generation_flow.py
@@ -57,6 +57,9 @@ def _wire_common(monkeypatch, history):
     monkeypatch.setattr(run_eval, "is_document_alive", lambda *a, **k: True)
     monkeypatch.setattr(run_eval, "resolve_backend_base", lambda url: url)
     monkeypatch.setattr(run_eval, "require_backend", lambda *a, **k: None)
+    # The retrieval arm defaults to the funnel the backend reports shipping and
+    # refuses to guess when it cannot read it. No backend here, so state it.
+    monkeypatch.setattr(run_eval, "shipped_rerank", lambda *a, **k: False)
     monkeypatch.setattr(
         run_eval, "search_chunks", lambda *args, **kwargs: ["chunk with hint one inside"]
     )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1669,7 +1669,7 @@ wheels = [
 
 [[package]]
 name = "luminary-backend"
-version = "0.7.9"
+version = "0.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,17 @@ services:
       # cores for something else.
       # Point the backend at the ollama service. The backend reads OLLAMA_URL
       # (NOT OLLAMA_HOST); its default 127.0.0.1 would resolve to this container.
-      - OLLAMA_URL=http://ollama:11434
+      #
+      # Interpolated, not hardcoded: `make docker-run-host-ollama` exports
+      # OLLAMA_URL=http://host.docker.internal:11434 to move inference onto the
+      # host. Hardcoded, that export was accepted by the shell and silently
+      # discarded here -- the container still dialled the `ollama` service name,
+      # which in that topology does not exist.
+      #
+      # Both make targets pass this explicitly, so an OLLAMA_URL exported for a
+      # native `make dev` (127.0.0.1 -- the container's own loopback) cannot leak
+      # in. A raw `docker compose --profile ai up` in such a shell still can.
+      - OLLAMA_URL=${OLLAMA_URL:-http://ollama:11434}
       # Must match the ollama service: the backend sizes its semaphore from it.
       - OLLAMA_NUM_PARALLEL=${OLLAMA_NUM_PARALLEL:-1}
       # Without these the app never learned which model `ollama-pull` below

--- a/docs/eval-coverage.md
+++ b/docs/eval-coverage.md
@@ -144,6 +144,15 @@ generation-side over repeated runs and compare distributions.
 weaker dataset. Passing means no leg of the pipeline died. It does not mean the product is good,
 and the number to beat is always the measured mean.
 
+**The retrieval arm measures the funnel the app ships.** `/search` defaults `rerank=false`
+while the answering path resolves `get_rerank_enabled()` (default true), so an arm that did not
+ask measured a funnel no user gets — and still recorded a `rerank_model`, which read as proof it
+had been used. The harness now defaults `--rerank` to the backend's `rerank_enabled` and refuses
+to guess when it cannot read it; `--no-rerank` measures the ablation and says so. Isolated on
+`study` in one library state: HR@5 0.5667 unreranked against 0.7000 shipped. Retrieval baselines
+and floors recorded before 2026-08-26 are the unreranked funnel and are not comparable to later
+ones.
+
 **Check the stage before attributing a change.** A retrieval regression can come from ingestion;
 a generation regression can come from retrieval. `eval-ingest` first, then `eval`, then
 `eval-gen` — in that order, because each is the ceiling on the next.

--- a/docs/eval-coverage.md
+++ b/docs/eval-coverage.md
@@ -118,10 +118,30 @@ this and cannot be compared to one that has it.
 and the classifier runs at temperature 0, so a single run is a valid measurement here and a small
 delta is real, unlike generation. Measured 1.0000 on all four routes.
 
-**The 1.0000 is on easy rows.** The same classifier scores **0.5862** on 29 adversarial
-phrasings, where search absorbs 11 of 12 misroutes: `graph` and `comparative` fire on their
-keyword and nothing else. Read the gated golden as a regression check, never as evidence that
-routing is solved.
+**The 1.0000 is on easy rows.** The same classifier scores **0.8276** on 29 adversarial
+phrasings with the heuristic alone, and **0.9655** with the LLM fallback that fires below
+confidence 0.7. Search absorbs all five heuristic misroutes: `graph` and `comparative` fire on
+their keyword and nothing else. Read the gated golden as a regression check, never as evidence
+that routing is solved.
+
+**Which of those two arms a user gets depends on the host.** `should_use_llm_fallback` drops the
+LLM call where the start-up probe measured local inference expensive — it cost 17.02s of a 50.12s
+question on an i7-8850H, with the model already resident — so on such a host the heuristic arm is
+not a floor, it is the routing:
+
+| dataset | heuristic alone | + LLM fallback |
+|---|---|---|
+| `intents` (50, gated) | 1.0000 | 1.0000 |
+| `intents_adversarial` (29, report-only) | 0.8276 | 0.9655 |
+
+The gated golden does not move, because the 2 of 50 rows that reach the LLM there are ones the
+heuristic already routes correctly. The cost is four adversarial rescues, and
+`QA_INTENT_LLM_FALLBACK_ON_SLOW_HOST=true` buys them back at ~17s per affected question. The
+fallback fires on 4% of `intents` and 28% of `intents_adversarial`.
+
+`/qa/classify-only` is deliberately NOT gated the same way: an eval must be able to measure both
+arms on whatever machine it runs on, and the numbers above were taken on a host where the graph
+itself would have skipped the call.
 
 **A perfect score on a 50-row golden proves very little**, which is why routing carries a
 generalisation suite as well (`tests/test_intent_generalisation.py`). It holds each phrasing and

--- a/docs/eval-coverage.md
+++ b/docs/eval-coverage.md
@@ -119,10 +119,15 @@ and the classifier runs at temperature 0, so a single run is a valid measurement
 delta is real, unlike generation. Measured 1.0000 on all four routes.
 
 **The 1.0000 is on easy rows.** The same classifier scores **0.8276** on 29 adversarial
-phrasings with the heuristic alone, and **0.9655** with the LLM fallback that fires below
+phrasings with the heuristic alone, and **0.8966** with the LLM fallback that fires below
 confidence 0.7. Search absorbs all five heuristic misroutes: `graph` and `comparative` fire on
 their keyword and nothing else. Read the gated golden as a regression check, never as evidence
 that routing is solved.
+
+**The fallback arm is a number about the model, not about the router.** The same 29 rows score
+0.9655 on `qwen2.5:14b-instruct`, 0.8966 on the shipped `qwen3.5:4b` and 0.8276 on
+`qwen3.5:0.8b` (`scores_history.jsonl` records `chat_model` per run). Quote it against the model
+in `chat_model`, and never subtract one model's arm from another's.
 
 **Which of those two arms a user gets depends on the host.** `should_use_llm_fallback` drops the
 LLM call where the start-up probe measured local inference expensive — it cost 17.02s of a 50.12s
@@ -132,10 +137,11 @@ not a floor, it is the routing:
 | dataset | heuristic alone | + LLM fallback |
 |---|---|---|
 | `intents` (50, gated) | 1.0000 | 1.0000 |
-| `intents_adversarial` (29, report-only) | 0.8276 | 0.9655 |
+| `intents_adversarial` (29, report-only) | 0.8276 | 0.8966 |
 
-The gated golden does not move, because the 2 of 50 rows that reach the LLM there are ones the
-heuristic already routes correctly. The cost is four adversarial rescues, and
+Measured 2026-08-27 on `ollama/qwen3.5:4b`, backend 0.7.9. The gated golden does not move,
+because the 2 of 50 rows that reach the LLM there are ones the heuristic already routes
+correctly. The cost is two adversarial rescues (26/29 → 24/29), and
 `QA_INTENT_LLM_FALLBACK_ON_SLOW_HOST=true` buys them back at ~17s per affected question. The
 fallback fires on 4% of `intents` and 28% of `intents_adversarial`.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,7 +23,7 @@ The named doc is the live contract. The plan that produced the work is gone.
 |---|---|
 | Frontend lint as a CI gate, `apiClient` used everywhere | `Makefile` `ci` target, `frontend/eslint.config.js` |
 | Six-layer architecture, stores, surface modes | `architecture.md` |
-| The 36 hard invariants | `invariants.md` |
+| The 37 hard invariants | `invariants.md` |
 | Backend implementation patterns | `patterns.md` |
 | Ingestion + reading (all 4 reader phases) | `universal-reader.md` |
 | Hybrid retrieval: RRF, cross-encoder rerank | `retrieval-funnel.md` |

--- a/evals/README.md
+++ b/evals/README.md
@@ -152,7 +152,7 @@ Corpus-wide numbers run well below scoped-ablation numbers — this is the least
 | `--export-html PATH` | — | Write a self-contained HTML report |
 | `--check-citations` | false | Judge whether inline citations support their claims |
 | `--hyde` | false | Enable HyDE-style query expansion |
-| `--rerank` | false | Enable cross-encoder reranking |
+| `--rerank` / `--no-rerank` | the backend's `rerank_enabled` | Cross-encoder reranking. Unset, the arm matches the funnel the app ships; `--no-rerank` measures the ablation. Exits 2 rather than guessing if the backend cannot be read. |
 | `--ablation` | false | Compare vector / fts / graph / rrf / rrf+rerank strategies |
 
 ---

--- a/evals/RUNBOOK.md
+++ b/evals/RUNBOOK.md
@@ -58,7 +58,8 @@ library or let `make eval-d2l` ingest it on first run.
 Direct invocations (what the Make targets wrap):
 
 ```bash
-# HR@5 / MRR (retrieval-only, no LLM)
+# HR@5 / MRR (retrieval-only, no LLM). With no --rerank flag the arm matches
+# whatever the backend reports shipping, which is the funnel a user gets.
 cd evals && uv run --no-sync python run_eval.py --dataset d2l \
   --backend-url http://localhost:7820 --assert-thresholds
 
@@ -67,6 +68,7 @@ cd evals && uv run --no-sync python run_eval.py --dataset d2l \
 # `uvicorn --reload` dev backend; run this against a fresh/restarted dev or a
 # production (`make start`) backend, or the A/B will read as a no-op.
 cd evals && uv run --no-sync python run_eval.py --dataset d2l --rerank
+cd evals && uv run --no-sync python run_eval.py --dataset d2l --no-rerank
 cd evals && uv run --no-sync python run_eval.py --dataset d2l --ablation
 
 # Topic generation quality (backend venv — imports topic_service)

--- a/evals/audit_golden.py
+++ b/evals/audit_golden.py
@@ -272,8 +272,21 @@ def main() -> None:
     for ds in targets:
         path = GOLDEN_DIR / f"{ds}.jsonl"
         if not path.exists():
-            print(f"  {ds:24s}  SKIP (no golden file at {path})")
-            continue
+            if args.all:
+                # Unreachable via --all (the list above filters on existence),
+                # kept so a future change to that filter still says what it did.
+                print(f"  {ds:24s}  SKIP (no golden file at {path})")
+                continue
+            # Named explicitly and absent: an error, never a skip. This printed
+            # SKIP and exited 0 with an empty JSON summary, so scripts/smoke/S212
+            # summed zero "empty" entries out of nothing and reported the dataset
+            # healthy -- for a name (`book_odyssey`) that has never existed.
+            print(
+                f"ERROR: no golden file at {path}. Nothing was audited, which is "
+                f"not the same as auditing clean. Valid datasets: {VALID_DATASETS}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
         if not args.quiet:
             print(f"\nAuditing {ds} ...")
         rows = audit_dataset(

--- a/evals/golden/manifest.json
+++ b/evals/golden/manifest.json
@@ -1,7 +1,6 @@
 {
   "DATA/books/time_machine.txt": "40d844f2-dd14-450a-9b1d-06f7992ad5f6",
   "DATA/books/alice_in_wonderland.txt": "fd13649e-37ef-4994-b438-4c3152e164fd",
-  "DATA/books/the_odyssey.txt": "b42ddf64-b039-447e-9d1d-ecc7891ed3e3",
   "DATA/books/d2l_dive_into_deep_learning.md": "f2176ac9-56a3-4087-ac94-98487412a49e",
   "DATA/notes/ml_notes.txt": "0f173f27-453d-4602-9e3e-b4aae2b7c39f",
   "DATA/conversations/engineering_sync.txt": "629af881-239d-4f30-bfe8-96b644663ca0",
@@ -10,5 +9,6 @@
   "DATA/legal/federalist_papers.txt": "fa6e1ca4-ea86-414e-86dc-cc87637791d3",
   "DATA/plays/hamlet.txt": "02acff68-b6bb-4efa-a5af-d6a8d3d9e465",
   "DATA/study/sutton_barto_rl.pdf": "109f17f3-332a-479b-9d5b-ff5f7c01a2c5",
-  "DATA/daily_thoughts_2026.txt": "d6e6957f-898f-4bca-822e-f9918c830486"
+  "DATA/daily_thoughts_2026.txt": "d6e6957f-898f-4bca-822e-f9918c830486",
+  "DATA/books/the_odyssey.txt": "7909df7e-9e32-4de3-b096-8ab5ef1ae711"
 }

--- a/evals/lib/environment.py
+++ b/evals/lib/environment.py
@@ -53,6 +53,25 @@ def capture(backend_url: str, **run_args: Any) -> dict[str, Any]:
     return env
 
 
+def shipped_rerank(backend_url: str) -> bool | None:
+    """Whether the app itself reranks, or None when the backend cannot say.
+
+    The retrieval arm queries `/search`, whose `rerank` parameter defaults to
+    false, while the answering path resolves `get_rerank_enabled()` (default
+    true). An arm that does not ask therefore measured a funnel the product does
+    not ship -- and recorded a `rerank_model` while doing it. Default the arm to
+    this rather than to the endpoint's default, so measuring the ablation stays
+    possible but has to be asked for.
+    """
+    try:
+        resp = httpx.get(f"{backend_url.rstrip('/')}/evals/environment", timeout=15.0)
+        resp.raise_for_status()
+        value = resp.json().get("rerank_enabled")
+    except (httpx.HTTPError, ValueError):
+        return None
+    return value if isinstance(value, bool) else None
+
+
 def output_stats(backend_url: str) -> dict[str, Any] | None:
     """Repair counters as they stand right now, or None when unreadable.
 

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -195,7 +195,9 @@ DATASET_THRESHOLDS: dict[str, dict[str, float]] = {
     "paper": {"hit_rate_5": 0.80, "mrr": 0.60, "ndcg_10": 0.65},
     "legal": {"hit_rate_5": 0.55, "mrr": 0.40, "ndcg_10": 0.45},
     "play": {"hit_rate_5": 0.70, "mrr": 0.50, "ndcg_10": 0.55},
-    "study": {"hit_rate_5": 0.60, "mrr": 0.35, "ndcg_10": 0.40},
+    # study takes the default mrr/ndcg_10: measured 0.4692/0.5370, its floors land
+    # exactly on the global ones, and restating a default reads as a decision.
+    "study": {"hit_rate_5": 0.60},
 }
 
 

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -44,6 +44,7 @@ from evals.lib.citation_metrics import (  # noqa: E402
 )
 from evals.lib.environment import capture as capture_environment  # noqa: E402
 from evals.lib.environment import output_stats, self_judging, stats_delta  # noqa: E402
+from evals.lib.environment import shipped_rerank  # noqa: E402
 from evals.lib.loader import GoldenValidationError  # noqa: E402
 from evals.lib.loader import load_golden as _lib_load_golden  # noqa: E402
 from evals.lib.manifest import (  # noqa: E402
@@ -157,20 +158,44 @@ THRESHOLDS = {
 # used to, at 0.45/0.30, because 17 of its 40 questions asked about scrape furniture.
 # Regenerated clean 2026-08-12 it measures 0.850/0.703, so it carries the default.
 #
-# Retrieval baselines, measured 2026-08-12 in ONE library state (9 documents),
-# bit-reproducible across re-runs. Compare a change against these, never the floor.
-#   book      HR@5 0.5750  MRR 0.3979  nDCG 0.5074   40 rows,  ~1.6k chunks
-#   paper     HR@5 0.8500  MRR 0.7025  nDCG 0.7461   40 rows,   146 chunks
-#   legal     HR@5 0.5333  MRR 0.3728  nDCG 0.4508   60 rows,  2537 chunks
-#   play      HR@5 0.6500  MRR 0.4406  nDCG 0.5263   60 rows,   394 chunks
-#   study     HR@5 0.5833  MRR 0.4136  nDCG 0.4832   60 rows,  1939 chunks (PDF)
-#   thoughts  HR@5 1.0000  MRR 1.0000  nDCG 1.0000    4 rows,     7 chunks
-# `thoughts` reads 1.000 because top-5 over a 7-chunk document returns most of it.
-# That is a property of the document, not of retrieval, which is why a 4-row
+# Retrieval baselines, measured 2026-08-26 on the SHIPPED funnel (rerank on, which
+# is what `get_rerank_enabled` returns by default), ONE library state -- 50
+# documents / 75537 chunks -- and bit-reproducible across re-runs. Compare a change
+# against these, never the floor.
+#   book      HR@5 0.6750  MRR 0.5396  nDCG 0.6000   40 rows
+#   paper     HR@5 0.9000  MRR 0.7279  nDCG 0.7797   40 rows
+#   legal     HR@5 0.6500  MRR 0.5142  nDCG 0.5686   60 rows
+#   play      HR@5 0.8000  MRR 0.6267  nDCG 0.6906   60 rows
+#   study     HR@5 0.7000  MRR 0.4692  nDCG 0.5370   60 rows (PDF)
+#   d2l       HR@5 0.9200  MRR 0.7170  nDCG 0.7876   (unreranked arm: .8400/.6347/.7184)
+#
+# The 2026-08-12 table these replace was measured with rerank OFF, because
+# `/search` defaults `rerank=false` and the arm never asked -- while `/qa`, which
+# produced the generation metrics in the same run, reranked. One run described two
+# funnels. Isolated on `study` in one library state: HR@5 0.5667 unreranked against
+# 0.7000 shipped. The superseded numbers are NOT comparable to the table above, and
+# the older ones also sat in a 9-document library, so two confounds are stacked.
+#
+# Floors are (weakest measured - 0.10), rounded down to 0.05, per dataset. The
+# subtrahend is headroom for library-state coupling, which is real: study's HR@5
+# moved 0.0166 and its MRR 0.0156 between the 9-document and 50-document states
+# with nothing about the dataset touched. 0.10 is ~6x that. Bracketing the choice:
+# 0.05 would put study's MRR floor at 0.40 against a measured 0.4692, which is
+# inside two library moves; 0.20 would let `paper` fall from 0.90 to 0.70 without
+# firing. Retrieval is deterministic on a fixed corpus, so none of this is sampling
+# noise -- a floor that fires means the corpus or a leg of the funnel changed.
+#
+# `thoughts` reads HR@5 1.0000 because top-5 over a 7-chunk document returns most
+# of it. That is a property of the document, not of retrieval, which is why a 4-row
 # dataset is recorded and never gated (tests/test_golden_integrity.py).
 DATASET_THRESHOLDS: dict[str, dict[str, float]] = {
     "conversation": {"hit_rate_5": 0.55, "mrr": 0.40},
     "notes": {"hit_rate_5": 0.60, "mrr": 0.45},
+    "book": {"hit_rate_5": 0.55, "mrr": 0.40, "ndcg_10": 0.50},
+    "paper": {"hit_rate_5": 0.80, "mrr": 0.60, "ndcg_10": 0.65},
+    "legal": {"hit_rate_5": 0.55, "mrr": 0.40, "ndcg_10": 0.45},
+    "play": {"hit_rate_5": 0.70, "mrr": 0.50, "ndcg_10": 0.55},
+    "study": {"hit_rate_5": 0.60, "mrr": 0.35, "ndcg_10": 0.40},
 }
 
 
@@ -569,7 +594,14 @@ def main() -> None:
         ),
     )
     parser.add_argument(
-        "--rerank", action="store_true", help="Enable cross-encoder reranking."
+        "--rerank",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Cross-encoder reranking. Defaults to what the backend actually "
+            "ships (`rerank_enabled` in /evals/environment), so the arm measures "
+            "the funnel a user gets. Pass --no-rerank to measure the ablation."
+        ),
     )
     parser.add_argument(
         "--rerank-depth",
@@ -667,6 +699,30 @@ def main() -> None:
 
     # Auto-detect /api prefix so the harness works against prod backends too.
     args.backend_url = resolve_backend_base(args.backend_url)
+
+    # Resolve the retrieval arm against the funnel the app ships, not against
+    # `/search`'s parameter default. Unasked, this arm reranked nothing while the
+    # answering path reranked everything, so one run's retrieval and generation
+    # metrics described two different funnels. Measured on `study` 2026-08-26:
+    # HR@5 0.5667 unreranked against 0.7000 shipped, on one corpus.
+    if args.rerank is None:
+        shipped = shipped_rerank(args.backend_url)
+        if shipped is None:
+            print(
+                "ERROR: could not read `rerank_enabled` from the backend, so the "
+                "arm cannot be matched to the shipped funnel. Pass --rerank or "
+                "--no-rerank to state it explicitly.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        args.rerank = shipped
+    else:
+        shipped = shipped_rerank(args.backend_url)
+        if shipped is not None and shipped != args.rerank:
+            print(
+                f"  NOTE: measuring rerank={args.rerank} while the app ships "
+                f"rerank={shipped}. This arm is an ablation, not the product."
+            )
 
     dataset_label = args.dataset or args.dataset_id
     if args.dataset_id:

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -154,9 +154,14 @@ THRESHOLDS = {
 }
 
 # Floors are collapse detectors, not quality bars -- see the `eval-integrity` skill.
-# A dataset appears here only when its floor must differ from the default; `paper`
-# used to, at 0.45/0.30, because 17 of its 40 questions asked about scrape furniture.
-# Regenerated clean 2026-08-12 it measures 0.850/0.703, so it carries the default.
+# A dataset appears here only when its floor must differ from the default. `paper`
+# once carried 0.45/0.30 because 17 of its 40 questions asked about scrape
+# furniture -- the floor had been lowered instead of the data fixed. It carries an
+# override again, in the opposite direction: regenerated clean it measures far
+# above the global bar, against which it could halve before anything fired.
+# `hit_rate_5` and `mrr` are the asserted ones; `ndcg_10` stays report-only
+# everywhere (see THRESHOLDS above), so the values below are the bar the UI draws,
+# not a gate.
 #
 # Retrieval baselines, measured 2026-08-26 on the SHIPPED funnel (rerank on, which
 # is what `get_rerank_enabled` returns by default), ONE library state -- 50
@@ -707,24 +712,22 @@ def main() -> None:
     # answering path reranked everything, so one run's retrieval and generation
     # metrics described two different funnels. Measured on `study` 2026-08-26:
     # HR@5 0.5667 unreranked against 0.7000 shipped, on one corpus.
+    shipped = shipped_rerank(args.backend_url)
     if args.rerank is None:
-        shipped = shipped_rerank(args.backend_url)
         if shipped is None:
             print(
                 "ERROR: could not read `rerank_enabled` from the backend, so the "
-                "arm cannot be matched to the shipped funnel. Pass --rerank or "
-                "--no-rerank to state it explicitly.",
+                "arm cannot be matched to the shipped funnel. Check the backend is "
+                "up, or pass --rerank / --no-rerank to state the arm explicitly.",
                 file=sys.stderr,
             )
             sys.exit(2)
         args.rerank = shipped
-    else:
-        shipped = shipped_rerank(args.backend_url)
-        if shipped is not None and shipped != args.rerank:
-            print(
-                f"  NOTE: measuring rerank={args.rerank} while the app ships "
-                f"rerank={shipped}. This arm is an ablation, not the product."
-            )
+    elif shipped is not None and shipped != args.rerank:
+        print(
+            f"  NOTE: measuring rerank={args.rerank} while the app ships "
+            f"rerank={shipped}. This arm is an ablation, not the product."
+        )
 
     dataset_label = args.dataset or args.dataset_id
     if args.dataset_id:
@@ -817,7 +820,13 @@ def main() -> None:
                     question,
                     doc_id,
                     hyde=args.hyde,
-                    rerank=do_rerank or args.rerank,
+                    # The ARM decides, never `args.rerank`. This read
+                    # `do_rerank or args.rerank` while that default was False,
+                    # which was harmless; once the arm defaults to the shipped
+                    # funnel (rerank on) it silently reranked `vector`, `fts`,
+                    # `graph` and `rrf` too, and printed the flat table under
+                    # their own labels. An ablation states every arm itself.
+                    rerank=do_rerank,
                     rerank_depth=depth,
                     rerank_threshold=args.rerank_threshold,
                     rerank_blend=blend,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.7.9",
+      "version": "0.8.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.7.9",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/diagnose-slow-host.sh
+++ b/scripts/diagnose-slow-host.sh
@@ -22,12 +22,22 @@ git -C "$REPO_ROOT" status --short 2>/dev/null | head -5
 
 echo
 echo "-- is a backend reachable ------------------------------------"
+# Probed with /settings, NOT /health. In public mode (which is what the Docker
+# image runs) the API lives under /api, but /health is deliberately registered at
+# BOTH the root and the prefix for container probes -- so a /health check picks
+# the root, and every real call after it then falls through to the SPA. That is
+# a 200 with an HTML body on GET and a 405 on `POST /qa`, which is how this
+# script previously reported "question failed" against a perfectly healthy
+# backend. The settings router is registered in every mode, so a JSON
+# content-type from it is what actually identifies the API base.
 BASE=""
 for u in "http://localhost:7820" "http://localhost:7820/api" \
          "http://127.0.0.1:7820" "http://127.0.0.1:7820/api"; do
-    code=$(curl -s -o /dev/null -w "%{http_code}" -m 5 "$u/health" 2>/dev/null || true)
-    echo "  $u/health -> ${code:-000}"
-    if [ "$code" = "200" ] && [ -z "$BASE" ]; then BASE="$u"; fi
+    ct=$(curl -s -o /dev/null -w "%{http_code} %{content_type}" -m 5 "$u/settings" 2>/dev/null || true)
+    echo "  $u/settings -> ${ct:-000}"
+    case "$ct" in
+        200\ application/json*) [ -z "$BASE" ] && BASE="$u" ;;
+    esac
 done
 
 if [ -z "$BASE" ]; then
@@ -44,12 +54,43 @@ if [ -z "$BASE" ]; then
 fi
 echo "  using: $BASE"
 
+# Where this backend's own lines can be read from. Under Docker there is no log
+# file on this side of the VM, so `docker logs` is the only source -- and it is
+# also the only source for the slow-host profile there, because
+# /evals/environment belongs to the `full`-mode quality dashboard
+# (surface-manifest.json) while the container runs LUMINARY_MODE=public.
+LOG_FILE=""
+for f in "$HOME/Library/Logs/Luminary/luminary.log" "$REPO_ROOT/backend/luminary.log"; do
+    [ -f "$f" ] && LOG_FILE="$f" && break
+done
+DOCKER_APP=$(docker ps --filter "label=com.docker.compose.service=app" \
+                       --format '{{.Names}}' 2>/dev/null | head -1)
+
+app_logs() {
+    if [ -n "$DOCKER_APP" ]; then
+        docker logs "$DOCKER_APP" 2>&1
+    elif [ -n "$LOG_FILE" ]; then
+        cat "$LOG_FILE"
+    fi
+}
+
+if [ -n "$DOCKER_APP" ]; then
+    echo "  logs:  docker container $DOCKER_APP"
+elif [ -n "$LOG_FILE" ]; then
+    echo "  logs:  $LOG_FILE"
+else
+    echo "  logs:  none found -- the log-derived lines below will be empty"
+fi
+
 echo
 echo "-- slow-host profile -----------------------------------------"
-curl -s -m 30 "$BASE/evals/environment" | python3 -c '
+ENV_JSON=$(mktemp)
+ENV_CODE=$(curl -s -m 30 -o "$ENV_JSON" -w "%{http_code}" "$BASE/evals/environment" 2>/dev/null || true)
+if [ "$ENV_CODE" = "200" ]; then
+    python3 -c '
 import sys, json
 try:
-    d = json.load(sys.stdin)
+    d = json.load(open(sys.argv[1]))
 except Exception:
     print("  /evals/environment did not return JSON")
     raise SystemExit
@@ -78,7 +119,40 @@ elif not slow:
     print("  full budget is correct for this host.")
 else:
     print("  VERDICT: profile ENGAGED (%.1fs probe). Narrow budget in use." % probe)
+' "$ENV_JSON"
+else
+    # Not an error and not a fallback for a broken backend: /evals/environment is
+    # a `full`-mode surface, and the Docker image runs public mode, so under
+    # Docker this endpoint is 404 by design. The same two facts are in the log --
+    # the keep-warm decision line prints the probe and states which way the gate
+    # went -- so the diagnostic reports them from there rather than reporting
+    # nothing on the one topology this branch exists to measure.
+    echo "  /evals/environment -> $ENV_CODE (full-mode surface; public mode does not mount it)"
+    echo "  reading the same facts from the log instead:"
+    app_logs | grep -E "Keep-warm (on|off):" | tail -2 | sed 's/^/    /'
+    app_logs | grep -E "Keep-warm (on|off):" | tail -1 | python3 -c '
+import sys, re
+line = sys.stdin.read()
+if not line.strip():
+    print()
+    print("  VERDICT: no keep-warm line in the log yet. Warm-up has not reached")
+    print("  the probe (wait ~30s and re-run), or the log source is wrong.")
+    raise SystemExit
+m = re.search(r"took ([0-9.]+)s at start-up", line)
+print()
+if "Keep-warm off" in line and m is None:
+    print("  VERDICT: probe UNMEASURED, so the profile CANNOT engage and this")
+    print("  host keeps the full budget. Ollama was likely down at start-up.")
+elif "Keep-warm off" in line:
+    print("  VERDICT: measured %ss at start-up, NOT classified slow, so the" % m.group(1))
+    print("  full budget is correct for this host.")
+else:
+    print("  VERDICT: profile ENGAGED (%ss probe). Narrow budget in use." % m.group(1))
+print("  The resolved budget itself is not logged until a question is answered;")
+print("  it is on the synthesize_node line at the bottom of this report.")
 '
+fi
+rm -f "$ENV_JSON"
 
 echo
 echo "-- ollama ----------------------------------------------------"
@@ -99,26 +173,34 @@ for m in ms:
 
 echo
 echo "-- one real question (this will take as long as it takes) -----"
+# `total` is the number that matters. curl's time_starttransfer is NOT the
+# model's first token here: /qa streams, so the headers come back in ~0.02s
+# whatever the model is doing, and reading that as a latency win would be
+# reading the HTTP layer. The real one is `LLM time-to-first-token` in the log
+# lines below -- 0.019s of headers sat in front of a 30.21s first token on the
+# run this note was written from.
 curl -s -m 900 -X POST "$BASE/qa" \
      -H 'Content-Type: application/json' \
      -d '{"question":"What is this document about?","include_context":true}' \
      -o /dev/null \
-     -w "  time to first byte : %{time_starttransfer}s\n  total              : %{time_total}s\n  http               : %{http_code}\n" \
+     -w "  response headers in : %{time_starttransfer}s\n  total               : %{time_total}s\n  http                : %{http_code}\n" \
      2>/dev/null || echo "  question failed"
 
 echo
 echo "-- what the answer path logged -------------------------------"
-LOGS=""
-for f in "$HOME/Library/Logs/Luminary/luminary.log" "$REPO_ROOT/backend/luminary.log"; do
-    [ -f "$f" ] && LOGS="$f" && break
-done
-if [ -n "$LOGS" ]; then
-    grep -E "Warmup:|synthesize_node:|classify_node|prompt ~" "$LOGS" 2>/dev/null | tail -12 \
-        || echo "  no matching lines in $LOGS"
+# `synthesize_node:` carries the budget that was actually used and how many
+# passages survived it, which is the line that says what the narrow budget cost.
+if [ -z "$DOCKER_APP" ] && [ -z "$LOG_FILE" ]; then
+    echo "  no log source found. Under 'make dev' the lines are in that terminal;"
+    echo "  under Docker, start the app with 'make docker-run-host-ollama' so this"
+    echo "  script can find the container."
 else
-    echo "  no log file found; if running under Docker use:"
-    echo "     docker compose logs app | grep -E 'Warmup:|synthesize_node:|prompt ~' | tail -12"
-    echo "  if running via 'make dev', the lines are in that terminal."
+    matched=$(app_logs | grep -E "Warmup:|synthesize_node:|classify_node|prompt ~|\[perf\]" | tail -16)
+    if [ -n "$matched" ]; then
+        echo "$matched" | sed 's/^/  /'
+    else
+        echo "  no matching lines in the log source above"
+    fi
 fi
 
 echo

--- a/scripts/diagnose-slow-host.sh
+++ b/scripts/diagnose-slow-host.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# One command that answers "why is answering slow on this host".
+#
+# Written because diagnosing it took six round-trips of relayed commands between
+# two machines. Everything needed to tell the causes apart is collected here:
+# which build is running, whether the host measured itself slow at start-up,
+# which context budget that resolved to, and where a real question's time went.
+#
+# Read-only. Starts nothing, changes nothing.
+
+set -uo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "=============================================================="
+echo " Luminary slow-host diagnostic"
+echo "=============================================================="
+
+echo
+echo "-- build under test ------------------------------------------"
+git -C "$REPO_ROOT" log --oneline -1 2>/dev/null || echo "  not a git checkout"
+git -C "$REPO_ROOT" status --short 2>/dev/null | head -5
+
+echo
+echo "-- is a backend reachable ------------------------------------"
+BASE=""
+for u in "http://localhost:7820" "http://localhost:7820/api" \
+         "http://127.0.0.1:7820" "http://127.0.0.1:7820/api"; do
+    code=$(curl -s -o /dev/null -w "%{http_code}" -m 5 "$u/health" 2>/dev/null || true)
+    echo "  $u/health -> ${code:-000}"
+    if [ "$code" = "200" ] && [ -z "$BASE" ]; then BASE="$u"; fi
+done
+
+if [ -z "$BASE" ]; then
+    echo
+    echo "  NO BACKEND REACHABLE. Nothing below can be measured."
+    echo "  Start one, wait ~30s for warm-up, and re-run this script:"
+    echo "     make luminary       # the way a user runs it"
+    echo "     make dev            # backend on :7820 with reload"
+    echo
+    echo "  NOTE: the bundled Luminary.app runs its OWN backend, not this"
+    echo "  checkout. Testing the .app does not test this branch."
+    echo "=============================================================="
+    exit 1
+fi
+echo "  using: $BASE"
+
+echo
+echo "-- slow-host profile -----------------------------------------"
+curl -s -m 30 "$BASE/evals/environment" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print("  /evals/environment did not return JSON")
+    raise SystemExit
+probe = d.get("startup_probe_seconds")
+slow  = d.get("local_inference_slow")
+rows = [
+    ("startup_probe_seconds", probe),
+    ("local_inference_slow", slow),
+    ("qa_context_token_budget", d.get("qa_context_token_budget")),
+    ("budget_reason", d.get("qa_context_budget_reason")),
+    ("chat_model", d.get("chat_model")),
+    ("generation_model", d.get("generation_model")),
+    ("rerank_enabled", d.get("rerank_enabled")),
+    ("backend_version", d.get("backend_version")),
+    ("library", d.get("library")),
+]
+for k, v in rows:
+    print("  %-24s %s" % (k, v))
+print()
+if probe is None:
+    print("  VERDICT: no start-up probe recorded, so the profile CANNOT engage")
+    print("  and this host keeps the full budget. Either warm-up has not")
+    print("  finished (wait 30s and re-run) or it failed.")
+elif not slow:
+    print("  VERDICT: measured %.1fs at start-up, NOT classified slow, so the" % probe)
+    print("  full budget is correct for this host.")
+else:
+    print("  VERDICT: profile ENGAGED (%.1fs probe). Narrow budget in use." % probe)
+'
+
+echo
+echo "-- ollama ----------------------------------------------------"
+curl -s -m 10 "${OLLAMA_URL:-http://localhost:11434}/api/ps" | python3 -c '
+import sys, json
+try:
+    ms = json.load(sys.stdin).get("models", [])
+except Exception:
+    print("  ollama not reachable")
+    raise SystemExit
+if not ms:
+    print("  no model resident -- the next question pays a load")
+for m in ms:
+    vram = m.get("size_vram", 0) / 1e9
+    tail = "  (CPU-only: size_vram 0)" if vram < 0.1 else ""
+    print("  %s  vram=%.1fGB%s" % (m.get("name"), vram, tail))
+'
+
+echo
+echo "-- one real question (this will take as long as it takes) -----"
+curl -s -m 900 -X POST "$BASE/qa" \
+     -H 'Content-Type: application/json' \
+     -d '{"question":"What is this document about?","include_context":true}' \
+     -o /dev/null \
+     -w "  time to first byte : %{time_starttransfer}s\n  total              : %{time_total}s\n  http               : %{http_code}\n" \
+     2>/dev/null || echo "  question failed"
+
+echo
+echo "-- what the answer path logged -------------------------------"
+LOGS=""
+for f in "$HOME/Library/Logs/Luminary/luminary.log" "$REPO_ROOT/backend/luminary.log"; do
+    [ -f "$f" ] && LOGS="$f" && break
+done
+if [ -n "$LOGS" ]; then
+    grep -E "Warmup:|synthesize_node:|classify_node|prompt ~" "$LOGS" 2>/dev/null | tail -12 \
+        || echo "  no matching lines in $LOGS"
+else
+    echo "  no log file found; if running under Docker use:"
+    echo "     docker compose logs app | grep -E 'Warmup:|synthesize_node:|prompt ~' | tail -12"
+    echo "  if running via 'make dev', the lines are in that terminal."
+fi
+
+echo
+echo "=============================================================="
+echo " Paste everything above."
+echo "=============================================================="

--- a/scripts/smoke/S110.sh
+++ b/scripts/smoke/S110.sh
@@ -17,10 +17,17 @@ if [ -z "$DOC_ID" ]; then
 fi
 echo "Using document: ${DOC_ID}"
 
+# Unique per run. A fixed section id made this script pass once and fail on every
+# later run against the same database -- the upsert had already counted the first
+# visit, so "first visit -> view_count=1" read 3 and reported a product failure
+# that was the script's own leftover state. A fresh id measures the increment
+# itself, which is what the script is named for.
+SECTION_ID="smoke-section-s110-$(date +%s)-$$"
+
 echo "S110 [2/4]: POST /reading/progress (first visit) -> view_count=1..."
 RESP=$(curl -sf -X POST "${BASE}/reading/progress" \
   -H "Content-Type: application/json" \
-  -d "{\"document_id\":\"${DOC_ID}\",\"section_id\":\"smoke-section-s110\"}")
+  -d "{\"document_id\":\"${DOC_ID}\",\"section_id\":\"${SECTION_ID}\"}")
 echo "$RESP" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
@@ -31,7 +38,7 @@ echo "PASS: first POST returns view_count=1"
 echo "S110 [3/4]: POST /reading/progress (second visit) -> view_count=2..."
 RESP2=$(curl -sf -X POST "${BASE}/reading/progress" \
   -H "Content-Type: application/json" \
-  -d "{\"document_id\":\"${DOC_ID}\",\"section_id\":\"smoke-section-s110\"}")
+  -d "{\"document_id\":\"${DOC_ID}\",\"section_id\":\"${SECTION_ID}\"}")
 echo "$RESP2" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)

--- a/scripts/smoke/S212.sh
+++ b/scripts/smoke/S212.sh
@@ -31,7 +31,7 @@ trap 'rm -f "${AUDIT_OUT}"' EXIT
 
 cd "${EVALS_DIR}"
 
-for ds in book_time_machine book_alice book_odyssey; do
+for ds in book_time_machine book_alice odyssey; do
   if uv run python audit_golden.py --dataset "${ds}" --backend-url "${BASE}" --quiet > "${AUDIT_OUT}" 2>&1; then
     :
   else
@@ -49,13 +49,18 @@ if "JSON summary:" not in out:
     print(-1); sys.exit(0)
 blob = out.split("JSON summary:", 1)[1].strip()
 data = json.loads(blob)
+# An empty summary is "nothing was audited", which summed to zero empties and
+# read as healthy. It is how `book_odyssey` -- a dataset with no golden file --
+# passed this check for as long as the name has been wrong.
+if not data:
+    print(-1); sys.exit(0)
 empties = sum(d.get("empty", 0) for d in data)
 print(empties)
 PY
 )
 
   if [ "${EMPTY}" = "-1" ]; then
-    echo "FAIL: could not parse audit output for ${ds}"
+    echo "FAIL: audit of ${ds} reported nothing to score (missing golden, or unparseable output)"
     cat "${AUDIT_OUT}"
     exit 1
   fi

--- a/scripts/smoke/S78.sh
+++ b/scripts/smoke/S78.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Smoke test for S78: strategy nodes — summary_lookup, graph_traversal, comparative, search.
-# POST /qa twice with different question types; both must return HTTP 200 within 30 seconds.
+# POST /qa twice with different question types; both must return HTTP 200 with a done event.
 # Requires the backend to be running on localhost:7820.
 
 set -euo pipefail
@@ -66,5 +66,5 @@ qa_check "factual (search_node)" "Who is Achilles?"
 qa_check "summary (summary_node)" "Summarize this document"
 
 echo ""
-echo "PASS: All S78 /qa calls returned HTTP 200 within 30 seconds"
+echo "PASS: All S78 /qa calls returned HTTP 200 with a done event"
 exit 0

--- a/scripts/smoke/S79.sh
+++ b/scripts/smoke/S79.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Smoke test for S79: pure context packer integrated into synthesize_node.
-# POST /qa with a book-style question; assert HTTP 200, done event, response < 15s.
+# POST /qa with a book-style question; assert HTTP 200 and a done event.
 # Requires the backend to be running on localhost:7820.
 
 set -euo pipefail
@@ -11,7 +11,13 @@ TMP_FILE="/tmp/s79_qa.txt"
 echo "POSTing question to /qa ..."
 START_TIME=$(date +%s)
 
-HTTP_CODE=$(curl -s --max-time 15 -o "$TMP_FILE" -w "%{http_code}" \
+# 180s, and the same reason S78 already carries: this bound exists to catch a
+# hang or a stream that never reaches its done event, NOT to grade the host. The
+# 15s it used to carry was a wall-clock assertion about a small library -- an
+# all-scope question over 57 documents measures 28.6s and 32.6s here with the
+# model resident, and minutes on a cold load, so 15s failed on library size and
+# said "the packer is broken".
+HTTP_CODE=$(curl -s --max-time 180 -o "$TMP_FILE" -w "%{http_code}" \
   -X POST "${BASE}/qa" \
   -H "Content-Type: application/json" \
   -d '{"question": "What happens in book 1?", "document_ids": [], "scope": "all"}')
@@ -22,11 +28,6 @@ ELAPSED=$((END_TIME - START_TIME))
 if [ "$HTTP_CODE" != "200" ]; then
   echo "FAIL: POST /qa returned ${HTTP_CODE} (expected 200)"
   cat "$TMP_FILE"
-  exit 1
-fi
-
-if [ "$ELAPSED" -ge 15 ]; then
-  echo "FAIL: POST /qa took ${ELAPSED}s (expected < 15s)"
   exit 1
 fi
 

--- a/scripts/smoke/S80.sh
+++ b/scripts/smoke/S80.sh
@@ -15,7 +15,12 @@ qa_check() {
   local tmp_file="/tmp/s80_qa_${RANDOM}.txt"
 
   echo "Testing $label ..."
-  HTTP_CODE=$(curl -s --max-time 30 -o "$tmp_file" -w "%{http_code}" \
+  # 180s for the reason S78 and S79 carry: a bound on a local generation is a
+  # hang detector, not a grade for the host. The four questions below measure
+  # 10.0s / 10.7s / 11.0s / 19.2s alone on this library with the model resident,
+  # and they all exceeded the old 30s when the machine was also running `make
+  # ci` -- so 30s was measuring what else the host was doing.
+  HTTP_CODE=$(curl -s --max-time 180 -o "$tmp_file" -w "%{http_code}" \
     -X POST "${BASE}/qa" \
     -H "Content-Type: application/json" \
     -d "{\"question\": \"${question}\", \"document_ids\": [], \"scope\": \"${scope}\"}")

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "luminary-desktop"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminary-desktop"
-version = "0.7.9"
+version = "0.8.0"
 description = "Luminary"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminary",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "identifier": "sh.luminary.app",
   "build": {
     "frontendDist": "boot"


### PR DESCRIPTION
Released as **v0.8.0** (tag pushed; source tarball published, macOS DMG building).

## What this branch does

Answering on a host that measures local inference expensive now uses a narrower
prompt and skips the LLM call that confirms an intent the heuristic already
chose — both off the same start-up measurement, never a platform check. Docker
users can move inference onto the host with `make docker-run-host-ollama`, and
`scripts/diagnose-slow-host.sh` says in one command why a host is slow.

On the eval side, the retrieval arm now measures the funnel the app ships:
`/search` defaults `rerank=false` while the answering path resolves
`get_rerank_enabled()`, so one run's retrieval and generation metrics used to
describe two different funnels. Retrieval baselines were re-measured on the
shipped funnel and per-dataset floors derived from them.

## Review fixes on top

- **Every ablation arm reranked.** `rerank=do_rerank or args.rerank` was inert
  while `--rerank` defaulted False; defaulting it to the shipped funnel turned
  the `or` on, so `vector`/`fts`/`graph`/`rrf` all reranked under their own
  labels. The arm now decides, and the test pins `shipped_rerank` True.
- **The slow-host routing cost was priced across two models.** The recorded
  0.9655 → 0.8276 subtracted `qwen2.5:14b-instruct` from the shipped
  `qwen3.5:4b`. Re-measured on the shipped model: 0.8966 → 0.8276, two of 29
  rows.
- **Two `synthesize_node` log lines disagreed about the budget** on exactly the
  hosts the profile exists for.
- **Four smoke checks measured the harness**, not the product — including S212
  auditing a dataset with no golden file and reporting it healthy.

## Verification

- `make ci` green locally (3297 passed) and on GitHub for this commit.
- `make smoke` — 176 passed, 0 failed.
- `make eval` — all five datasets reproduce the committed baselines to four
  decimals, on a library that had grown 50 → 57 documents.
- `make eval-intent` — `intents` 1.0000 both arms; adversarial 0.8276 / 0.8966.

## Known, not fixed here

- `QA_CONTEXT_TOKEN_BUDGET_SLOW_HOST` ships with its generation-quality cost
  unmeasured; `config.py` says so at the constant.
- `make docker-run-host-ollama` needs `extra_hosts: host-gateway` to work on
  Linux. The target and its README section are Mac-scoped.
- `tests/test_note_search.py::test_fts_sync_on_delete` flaked once on GitHub. It
  passes here and on this commit's run, but the mechanism behind it is real:
  `delete_note_vector` swallows every exception and the vector arm of note
  search has no liveness join, so a transient delete failure leaves a deleted
  note searchable. Follow-up, not a release blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)