### PR TITLE
fix(notes): a deleted note could keep coming back from search

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,24 +157,20 @@ build needs 20+. Verified end to end on a clean `ubuntu:24.04` container (arm64)
 <details>
 <summary><b>Windows — Docker, or native</b></summary>
 
-Docker (needs [Docker Desktop](https://www.docker.com/products/docker-desktop/) running):
+Docker (needs [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+running — check [Running under Docker](#running-under-docker) first):
 
 ```powershell
 docker compose --profile ai up --build
 ```
 
-Audio, video and YouTube ingestion are **off** in that image — they need ffmpeg
-and a transcriber, which are GPL and never travel inside anything Luminary
-distributes. The image is built on your machine, so you can opt in. PowerShell
-has no inline `VAR=value` form, so set it first:
+Audio, video and YouTube ingestion are **off** in that image; PowerShell has no
+inline `VAR=value` form, so opt in by setting it first:
 
 ```powershell
 $env:WITH_MEDIA=1
 docker compose --profile ai up --build
 ```
-
-That adds about 850 MB. Installing ffmpeg on Windows itself does nothing for the
-Docker path — the backend is a Linux container and cannot see your `PATH`.
 
 Native, for a proxy or VPN that blocks Docker. In a normal PowerShell window (no admin):
 
@@ -183,10 +179,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; .\scripts\install.ps1   # one-
 .\start.ps1                                                              # each time after
 ```
 
-Open http://localhost:7820 when the log settles. First start downloads models —
-the launcher prints `Luminary is ready` only when it truly is.
-
-The native install covers everything except audio and video. For those, install
+Open http://localhost:7820 when the log settles. The native install covers everything except audio and video. For those, install
 ffmpeg and leave it on `PATH` (`winget install Gyan.FFmpeg`), then add **Speech
 to text** from Settings — Luminary fetches that one itself.
 </details>
@@ -199,19 +192,18 @@ Everything below is the Docker path. Apple Silicon Macs use the native path abov
 
 **Install first**
 
-1. [Docker Desktop](https://www.docker.com/products/docker-desktop/) — running,
-   with at least **10 GB free** in its disk image (see
-   [How much memory it actually needs](#how-much-memory-it-actually-needs)).
+1. [Docker Desktop](https://www.docker.com/products/docker-desktop/), running —
+   check its memory and disk against
+   [Running under Docker](#running-under-docker) before the first build.
 2. [Homebrew](https://brew.sh), then `brew install ollama` — only for the
    recommended path; the all-in-Docker path needs nothing but Docker.
 
 **Recommended: inference on the host, app in Docker**
 
-Docker Desktop on a Mac is a Linux VM with a capped CPU and memory allowance,
-and the app container is already running the embedder, reranker and entity
-model inside it. Putting Ollama there too makes them compete. Running Ollama on
-the host gives it the whole machine, and is the only latency change measured so
-far that costs nothing in answer quality.
+The container is already running the embedder, reranker and entity model inside
+Docker's Linux VM; putting Ollama there too makes them compete for one capped
+CPU allowance. On the host it gets the whole machine, and it is the only latency
+change measured so far that costs nothing in answer quality.
 
 ```bash
 # terminal 1 — Ollama must listen beyond loopback, or the container cannot
@@ -256,22 +248,16 @@ One command, one paste: which build is running, whether this host measured
 itself slow at start-up, which context budget that resolved to, and where a
 real question's seconds went. It starts nothing and changes nothing.
 
-Expect single-digit tokens per second either way — Docker on any Mac is
-CPU-only, no GPU passes through. On an Intel i7-8850H with host Ollama,
-`qwen3.5:4b` decodes at ~6 tok/s, so answer length is what you feel most.
+Expect single-digit tokens per second either way (see
+[Running under Docker](#running-under-docker)). On an Intel i7-8850H with host
+Ollama, `qwen3.5:4b` decodes at ~6 tok/s, so answer length is what you feel most.
 
-Audio, video and YouTube ingestion are **off** in this image. They need ffmpeg
-and a transcriber, which are GPL and so are never part of anything Luminary
-distributes. The image is built on your machine, so you can opt in:
-
-```bash
-WITH_MEDIA=1 docker compose --profile ai up --build
-```
-
-That installs ffmpeg from Debian plus the download and transcription packages,
-by your own action, and adds about 850 MB to the image. Installing ffmpeg on
-the Mac itself does nothing here -- the backend is a Linux container and cannot
-see the host's PATH.
+Audio, video and YouTube ingestion are **off** in this image — ffmpeg and a
+transcriber are GPL, so they never travel inside anything Luminary distributes.
+The image is built on your machine, so you can opt in with
+`WITH_MEDIA=1 docker compose --profile ai up --build` (+850 MB). Installing
+ffmpeg on the Mac itself does nothing: the backend is a Linux container and
+cannot see the host's `PATH`.
 </details>
 
 > First launch is slow because it downloads ML models. Every launcher polls the
@@ -295,29 +281,34 @@ Measured, not estimated — every figure below was read off a running instance.
 but will swap under load.** Ingestion is the peak; answering questions afterwards
 sits around 6.5 GB.
 
-**Docker users: this is the VM's memory, not your machine's.** Docker Desktop
-gives its Linux VM a fraction of the host — often half — so a 16 GB Mac presents
-as roughly 7.7 GB and lands under the floor. Raise it in **Settings → Resources →
-Memory**. Luminary reads the VM, not the Mac, and says so at startup:
+### Running under Docker
+
+Docker Desktop is a Linux VM. **Every number above is that VM's allowance, not
+your machine's** — it gets a fraction of the host, often half, so a 16 GB Mac
+presents as roughly 7.7 GB and lands under the floor. Luminary reads the VM and
+says so at startup:
 
 ```
 model configuration: ollama/qwen3.5:4b needs 8GB and this machine has 7GB -- it will swap under load
 ```
 
-**Docker also needs disk, and more than people expect.** The image is 3.4 GB, or
-4.2 GB with `WITH_MEDIA=1`, and the model blob is another 3.4 GB — so budget
-**10 GB free** in Docker Desktop's disk image before the first build, or `apt`
-fails partway through with `You don't have enough free space in
-/var/cache/apt/archives/`. Reclaim it with `docker builder prune -af` (build
-cache only) and `docker image prune -af` (unused images), or raise the slider in
-**Settings → Resources → Disk image size**. Do not pass `--volumes` to a prune:
-that deletes `luminary-data`, which is your library.
+| | |
+|---|---|
+| **Memory** | Raise it in **Settings → Resources → Memory** |
+| **Disk** | **10 GB free** before the first build, or `apt` fails partway through: a 3.4 GB image (4.2 with `WITH_MEDIA=1`) plus a 3.4 GB model blob |
+| **GPU** | None passes through on any Mac, so generation runs at a few tokens per second whatever the memory |
+| **Model** | Pulled into a Docker volume on first run by the `--profile ai` sidecar |
+| **Secrets** | A container has no OS keyring, so a cloud API key saved in Settings is stored in the database as plain text — readable by anyone who can read the `luminary-data` volume. Put it in `.env` beside the compose file instead |
 
-Docker on any Mac is CPU-only — no GPU passes through — so generation runs at a
-few tokens per second whatever the memory. On an Intel Mac especially, prefer
-more RAM and expect ingestion to take minutes. The memory above is for the
-all-in-Docker path; `make docker-run-host-ollama` moves the model's share of it
-out of the VM and onto the host.
+`make docker-run-host-ollama` runs the model on your Mac instead of in the VM,
+which takes the memory and speed rows off the table. macOS only — on Linux the
+container needs `extra_hosts: host-gateway` to reach the host.
+
+Reclaim disk with `docker builder prune -af` (build cache) and
+`docker image prune -af` (unused images). **Never add `--volumes`** — that
+deletes `luminary-data`, which is your library.
+
+### Runtime bounds
 
 Two runtime bounds ship set, because Ollama's own defaults are not sized for a
 laptop: the model stays resident for 30 minutes rather than Ollama's 5, and
@@ -367,8 +358,8 @@ abandoned.
 
 If Ollama is not running or no model is pulled, only the LLM features (chat,
 teach-back, flashcards) pause — reading, search and review keep working. Fix it
-with `ollama serve` and `ollama pull qwen3.5:4b`. Docker users: the `--profile ai`
-sidecar does this on first start.
+with `ollama serve` and `ollama pull qwen3.5:4b` (under Docker the `--profile ai`
+sidecar does it on first start).
 
 Luminary sizes its models from your machine's RAM, and `make install` pulls what
 that band needs.
@@ -418,12 +409,9 @@ which model, and any warnings.
 **Cloud models.** An id is `provider/name`. A local model needs no key; a hosted
 one does. You can also add the key in Settings.
 
-Where that key is stored depends on the install. A native install puts it in
-your OS keychain. **A container has no OS keyring, so Docker installs fall back
-to storing the key in the SQLite database in plain text** — readable by anyone
-who can read the `luminary-data` volume. If that matters to you, pass the key
-as an environment variable instead of saving it in Settings, and remember that
-`docker compose` reads a `.env` file beside the compose file.
+A native install puts that key in your OS keychain. A container has none, so
+Docker installs store it in the database as plain text — pass it as an
+environment variable instead (see [Running under Docker](#running-under-docker)).
 
 ```bash
 LITELLM_DEFAULT_MODEL=openai/gpt-4o

--- a/backend/app/services/note_search.py
+++ b/backend/app/services/note_search.py
@@ -3,9 +3,10 @@
 import json
 import logging
 
-from sqlalchemy import text
+from sqlalchemy import select, text
 
 from app.database import get_session_factory
+from app.models import NoteModel
 from app.services.fts_query import sanitize_fts_query as _sanitize_fts_query
 from app.types import NoteSearchResult
 
@@ -13,6 +14,25 @@ logger = logging.getLogger(__name__)
 
 RRF_K = 60
 _NOTE_SEARCH_K = 20  # per-arm candidate count before RRF
+
+# Minimum cosine similarity for the semantic arm to return a note at all.
+# `table.search(...).limit(k)` is a nearest-neighbour query with no floor, so in
+# a library smaller than k it returns EVERY note however unrelated -- which is
+# why a "search for the old term, expect a miss" test could never pass without
+# one. Measured with BAAI/bge-small-en-v1.5, the two cases that bracket it:
+#
+#   0.5004  "photosynthesis chloroplast" vs a note reading "baroque fugue
+#           counterpoint harpsichord sonata" -- unrelated, must be dropped
+#   0.7516  "feline that disappears" vs "Cheshire Cat can vanish leaving only
+#           its grin" -- a hit with ZERO words in common, which is the entire
+#           reason this arm exists and must be kept
+#
+# Every keep-case measured lands in 0.7516-0.9140 and every drop-case in
+# 0.4186-0.5004, so 0.62 sits in a 0.25-wide gap with ~0.12 either side.
+# Do NOT replace this with a literal-term check on the content: that was the
+# previous behaviour and it dropped the 0.7516 case, which is the one the arm
+# is for.
+NOTE_SEMANTIC_MIN_SIMILARITY = 0.62
 
 
 def _rrf_merge(
@@ -111,21 +131,86 @@ class NoteSearchService:
                 return []
             vector = get_embedding_service().encode([query])[0]
             rows = table.search(vector).metric("cosine").limit(k).to_list()
-            return [
-                NoteSearchResult(
-                    note_id=row["note_id"],
-                    content=row["content"],
-                    tags=[],
-                    group_name=None,
-                    document_id=row["document_id"] or None,
-                    score=1.0 - float(row.get("_distance", 0.0)),
-                    source="vector",
+            # LanceDB's cosine `_distance` is 1 - cosine_similarity, verified
+            # against a manual dot product, so this score IS the similarity.
+            results = []
+            for row in rows:
+                similarity = 1.0 - float(row.get("_distance", 0.0))
+                if similarity < NOTE_SEMANTIC_MIN_SIMILARITY:
+                    continue
+                results.append(
+                    NoteSearchResult(
+                        note_id=row["note_id"],
+                        content=row["content"],
+                        tags=[],
+                        group_name=None,
+                        document_id=row["document_id"] or None,
+                        score=similarity,
+                        source="vector",
+                    )
                 )
-                for row in rows
-            ]
+            return results
         except Exception as exc:
             logger.warning("semantic_search failed: %s", exc)
             return []
+
+    async def _drop_deleted(self, results: list[NoteSearchResult]) -> list[NoteSearchResult]:
+        """Keep only results whose note still exists, with the note's own fields.
+
+        The FTS arm gets this free -- its SQL joins notes_fts against notes, so a
+        stale index row can never surface. The vector arm reads LanceDB directly
+        and had no equivalent, so anything left in that table was returned as a
+        live note: `delete_note_vector` swallows its exceptions (deliberately --
+        a vector-store hiccup must not fail a user's delete), and a swallowed
+        failure therefore kept serving a note the user had deleted.
+
+        This is the join the vector arm was missing. A ghost row is now invisible
+        whatever put it there, which is also what makes the swallow above safe.
+
+        Hydrating rather than only filtering, because the vector table's copy of
+        content goes stale on an edit and it carries no tags or group at all --
+        so a note found by the semantic arm used to come back with tags=[].
+        """
+        if not results:
+            return []
+        ids = [r.note_id for r in results]
+        # ORM `in_`, not a built IN list: the placeholders would be ours rather
+        # than the caller's, but a string-built WHERE is the shape this repo is
+        # trying to be rid of and ruff S608 says so.
+        stmt = select(
+            NoteModel.id,
+            NoteModel.content,
+            NoteModel.tags,
+            NoteModel.group_name,
+            NoteModel.document_id,
+        ).where(NoteModel.id.in_(ids))
+        async with get_session_factory()() as session:
+            rows = (await session.execute(stmt)).all()
+
+        live = {row[0]: row for row in rows}
+        out: list[NoteSearchResult] = []
+        for r in results:
+            row = live.get(r.note_id)
+            if row is None:
+                logger.debug("note search: dropping deleted note_id=%s", r.note_id)
+                continue
+            _, content, raw_tags, group_name, document_id = row
+            try:
+                tags = json.loads(raw_tags) if isinstance(raw_tags, str) else (raw_tags or [])
+            except Exception:
+                tags = []
+            out.append(
+                NoteSearchResult(
+                    note_id=r.note_id,
+                    content=content,
+                    tags=tags,
+                    group_name=group_name,
+                    document_id=document_id or None,
+                    score=r.score,
+                    source=r.source,
+                )
+            )
+        return out
 
     async def search(self, query: str, k: int = 10) -> list[NoteSearchResult]:
         """Hybrid search: FTS5 + semantic, fused via RRF."""
@@ -134,44 +219,20 @@ class NoteSearchService:
         fts_results = await self.fts_search(query, k=_NOTE_SEARCH_K)
         vector_results = self.semantic_search(query, _NOTE_SEARCH_K)
 
+        # Before the merge, so a deleted note cannot take a slot in the top k.
+        # The FTS arm needs no such pass -- it joins notes in SQL already.
+        vector_results = await self._drop_deleted(vector_results)
+
         merged = _rrf_merge(fts_results, vector_results, k=k)
 
-        # Post-filter to ensure content actually contains search terms if it
-        # came from a stale FTS index (secondary safety for CI flakiness).
-        # We only do this for FTS-only results or if we want extra rigor.
-        # Actually, let's just trust FTS if it's fresh, but here we'll verify
-        # that if it's a "miss" in the test, it's because the content changed.
-
-        # Refined strategy: The test fails because FTS returns a hit for old terms.
-        # If we check the CURRENT content of the notes in the merged list, we can
-        # drop those that no longer match the query terms.
-
-        safe_query = _sanitize_fts_query(query).lower()
-        query_terms = set(safe_query.split())
-
-        final_results = []
-        for r in merged:
-            content_lower = r.content.lower()
-            # Verify that the result actually contains at least one of the query terms.
-            # This handles both stale FTS entries and overly-broad semantic matches.
-            if any(term in content_lower for term in query_terms):
-                final_results.append(r)
-            else:
-                logger.debug(
-                    "Dropping unrelated search result note_id=%s source=%s",
-                    r.note_id,
-                    r.source,
-                )
-
         logger.debug(
-            "note search q=%r fts=%d vector=%d merged=%d final=%d",
+            "note search q=%r fts=%d vector=%d merged=%d",
             query[:50],
             len(fts_results),
             len(vector_results),
             len(merged),
-            len(final_results),
         )
-        return final_results[:k]
+        return merged
 
 
 _note_search_service: NoteSearchService | None = None

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -140,7 +140,15 @@ class LanceDBService:
             except Exception as exc:
                 logger.warning("Could not inspect note_vectors_v2 schema: %s", exc)
             return tbl
-        return self._db.create_table(NOTE_TABLE_NAME, schema=NOTE_SCHEMA)
+        try:
+            return self._db.create_table(NOTE_TABLE_NAME, schema=NOTE_SCHEMA)
+        except ValueError:
+            # list_tables() then create_table() is check-then-act, and two
+            # concurrent callers both pass the check. Reachable without any test
+            # harness: `POST /notes` schedules its embedding as a background
+            # task, so creating two notes in quick succession on a fresh install
+            # races here and one of them raises "Table already exists".
+            return self._db.open_table(NOTE_TABLE_NAME)
 
     def upsert_note_vector(
         self, note_id: str, document_id: str | None, content: str, vector: list[float]
@@ -162,13 +170,24 @@ class LanceDBService:
         logger.debug("Upserted note vector note_id=%s", note_id)
 
     def delete_note_vector(self, note_id: str) -> None:
-        """Delete the vector for the given note_id."""
+        """Delete the vector for the given note_id.
+
+        Non-fatal on purpose: a vector-store hiccup must not fail the user's
+        `DELETE /notes/{id}`, which has already removed the note itself. What
+        makes that safe is `NoteSearchService._drop_deleted` -- the semantic arm
+        resolves every hit against `notes`, so a row this call failed to remove
+        is invisible rather than served as a live note. Before that join existed,
+        one swallowed exception here kept a deleted note searchable forever.
+
+        Logged with the traceback, not just a message: a silent counter of
+        "deletes that did not happen" is how the ghost went unnoticed.
+        """
         try:
             table = self._get_or_create_note_table()
             table.delete(f"note_id = '{note_id}'")
             logger.debug("Deleted note vector note_id=%s", note_id)
-        except Exception as exc:
-            logger.warning("delete_note_vector failed for note_id=%s: %s", note_id, exc)
+        except Exception:
+            logger.exception("delete_note_vector failed for note_id=%s", note_id)
 
     def _get_image_table(self) -> Any:
         self._connect()

--- a/backend/tests/test_note_search.py
+++ b/backend/tests/test_note_search.py
@@ -203,3 +203,110 @@ def test_alice_note_search_slow(all_books_ingested):
         results = resp.json()["results"]
         top3_ids = [r["note_id"] for r in results[:3]]
         assert note_id in top3_ids, f"Note not in top-3: {[r['note_id'] for r in results]}"
+
+
+# A ghost vector is a row in the LanceDB note table whose note no longer exists
+# in `notes`. `delete_note_vector` swallows its exceptions by design, so one is
+# reachable in production whenever the vector store hiccups during a delete --
+# which is why these tests inject one directly instead of hoping a delete fails.
+
+
+def _embed_now(note_id: str, content: str) -> None:
+    """Write the note's vector without waiting on the background task.
+
+    `POST /notes` schedules `embed_and_store_note` with `asyncio.create_task`, so
+    the vector's existence is not ordered against the next request. Tests that
+    need the semantic arm specifically -- ones whose query shares no word with
+    the note, so the FTS arm cannot answer -- would otherwise race the scheduler.
+    Same service the background task calls, just awaited here.
+    """
+    from app.services.embedder import get_embedding_service
+    from app.services.vector_store import get_lancedb_service
+
+    vector = get_embedding_service().encode([content])[0]
+    get_lancedb_service().upsert_note_vector(note_id, None, content, vector)
+
+
+def _inject_ghost_vector(content: str) -> str:
+    """Put a vector in the note table for a note_id that has no `notes` row."""
+    import uuid as _uuid
+
+    from app.services.embedder import get_embedding_service
+    from app.services.vector_store import get_lancedb_service
+
+    ghost_id = f"ghost-{_uuid.uuid4()}"
+    vector = get_embedding_service().encode([content])[0]
+    get_lancedb_service().upsert_note_vector(ghost_id, None, content, vector)
+    return ghost_id
+
+
+def test_a_deleted_note_cannot_come_back_through_the_semantic_arm(client):
+    """The defect this file's delete test only caught by luck.
+
+    The FTS arm joins `notes_fts` against `notes`, so it can never serve a
+    deleted note. The semantic arm read LanceDB directly and had no such join,
+    so anything left in that table was returned as a live note.
+    """
+    content = "Luminiferous ether hypothesis and the Michelson Morley experiment"
+    ghost_id = _inject_ghost_vector(content)
+
+    resp = client.get("/notes/search", params={"q": "Luminiferous ether"})
+    assert resp.status_code == 200
+    assert ghost_id not in [r["note_id"] for r in resp.json()["results"]]
+
+
+def test_the_semantic_arm_still_matches_without_a_word_in_common(client):
+    """The floor must not become the literal-term filter it replaced.
+
+    "feline that disappears" shares no word with the note and scores 0.7516, so
+    a check for query terms in the content -- the previous behaviour -- dropped
+    exactly the hit the semantic arm exists to produce.
+    """
+    content = "Cheshire Cat can vanish leaving only its grin"
+    create = client.post("/notes", json={"content": content, "tags": []})
+    assert create.status_code == 201
+    note_id = create.json()["id"]
+    _embed_now(note_id, content)
+
+    resp = client.get("/notes/search", params={"q": "feline that disappears"})
+    assert resp.status_code == 200
+    assert note_id in [r["note_id"] for r in resp.json()["results"]]
+
+
+def test_an_unrelated_note_is_below_the_similarity_floor(client):
+    """`limit(k)` has no floor, so in a library smaller than k the semantic arm
+    returns every note however unrelated. 0.5004 is the measured similarity of
+    this pair and it must not clear NOTE_SEMANTIC_MIN_SIMILARITY."""
+    create = client.post(
+        "/notes", json={"content": "baroque fugue counterpoint harpsichord sonata", "tags": []}
+    )
+    assert create.status_code == 201
+    note_id = create.json()["id"]
+
+    resp = client.get("/notes/search", params={"q": "photosynthesis chloroplast"})
+    assert resp.status_code == 200
+    assert note_id not in [r["note_id"] for r in resp.json()["results"]]
+
+
+def test_the_floor_sits_between_the_two_cases_that_set_it():
+    """Bracketing, so a future tweak has to move one of these to justify itself."""
+    from app.services.note_search import NOTE_SEMANTIC_MIN_SIMILARITY
+
+    assert 0.5004 < NOTE_SEMANTIC_MIN_SIMILARITY < 0.7516
+
+
+def test_a_semantic_hit_carries_the_notes_own_tags(client):
+    """The vector arm reported tags=[] and group_name=None for every hit,
+    because it read them from the vector table, which stores neither."""
+    create = client.post(
+        "/notes",
+        json={"content": "Cheshire Cat can vanish leaving only its grin", "tags": ["wonderland"]},
+    )
+    assert create.status_code == 201
+    note_id = create.json()["id"]
+    _embed_now(note_id, "Cheshire Cat can vanish leaving only its grin")
+
+    resp = client.get("/notes/search", params={"q": "feline that disappears"})
+    assert resp.status_code == 200
+    hit = next(r for r in resp.json()["results"] if r["note_id"] == note_id)
+    assert hit["tags"] == ["wonderland"]


### PR DESCRIPTION
Follow-up to #77, which flagged this but shipped 0.8.0 without it.

## The defect

`NoteSearchService.fts_search` joins `notes_fts` against `notes`, so a stale FTS
row can never surface. `semantic_search` read LanceDB directly with **no such
join**, and `VectorStore.delete_note_vector` swallows every exception — so one
swallowed failure during `DELETE /notes/{id}` left the note searchable forever,
served to the reader as a live note. Content the user deleted, still returned.

This is what `tests/test_note_search.py::test_fts_sync_on_delete` was flaking on.

## What was already there

`search()` carried a post-filter keeping only results whose content contained a
literal query term, under comments written as they were being reasoned out
("Actually, let's just trust FTS if it's fresh…", "The test fails because FTS
returns a hit for old terms"). It did two bad things:

- **It never fixed this.** A deleted note's stored content still contains the
  query terms, which is why the test kept flaking.
- **It defeated the arm it guarded.** `"feline that disappears"` scores 0.7516
  against `"Cheshire Cat can vanish leaving only its grin"` and was dropped for
  sharing no word with the query — the exact case a semantic arm exists for.

## The fix

`_drop_deleted` resolves every semantic hit against `notes` before the RRF
merge: no row, no result. It also hydrates content/tags/group from the note,
because the vector table's copy goes stale on an edit and stores no tags at all
— semantic hits used to come back with `tags=[]`.

The post-filter is replaced by the bound it should have been. The real problem
it was groping at is that `table.search(...).limit(k)` has no floor, so a
library smaller than `k` returns every note however unrelated. Measured with
BAAI/bge-small-en-v1.5:

| band | range |
|---|---|
| keep | 0.7516 – 0.9140 |
| drop | 0.4186 – 0.5004 |
| `NOTE_SEMANTIC_MIN_SIMILARITY` | **0.62**, in a 0.25-wide gap |

Both bracketing cases are recorded at the constant and pinned by a test.
`1 - _distance` was checked against a manual dot product before thresholding on
it.

Also fixed: `_get_or_create_note_table` was check-then-act, so two notes created
in quick succession on a fresh install could both pass the existence check and
one would raise `Table already exists`. Reachable in production — `POST /notes`
embeds in a background task.

## Verification

- `make ci` green, **3302 passed** (+5).
- Both new checks **fail on the old code** and pass on the new.
- Real app: a ghost injected into the live dev LanceDB is invisible to
  `/notes/search`; real notes still return, now with their tags. Probe removed.
- All 30 note-related smoke scripts pass.

## Also in this PR

`docs(readme)`: the Docker caveats were re-explained in six places — "Docker
Desktop is a Linux VM, so this number is the VM's" three times over. One
`Running under Docker` table now carries memory, disk, GPU, model and secrets;
every other mention is a clause and a link. Net −61/+49 lines. Adds the Linux
`extra_hosts: host-gateway` caveat, since the host-Ollama path does not work
there as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)