### PR TITLE
fix: stop targets killed browsers and Docker, not the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`make stop` and `make clean` killed browsers instead of the app.** Both
+  matched every socket on the port rather than the listener, so a tab left open
+  on Luminary was SIGTERMed then SIGKILLed while the app kept running.
+- **Stopping the container SIGKILLed it about half the time.** A full shutdown
+  takes ~10.8s against `docker stop`'s 10s default, so exit 137 or 0 was a coin
+  toss; the timeout is now 30s and a forced kill can no longer strand the Kuzu
+  lock on a healthy stop.
+- **The docker targets failed with `command not found` when Docker was merely
+  not started.** Docker Desktop installs its CLI symlinks only on first
+  successful run, so "not on PATH" was never evidence it was missing.
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docker-run-host-ollama dev ci backend frontend build start stop lint test test-full test-concurrent test-perf test-e2e test-book-e2e test-book-content test-books-all test-v2 eval eval-intent eval-ingest eval-gen eval-variance prompt-dump eval-models eval-matrix eval-summary eval-routing eval-flashcards golden-flashcards eval-all eval-d2l eval-d2l-rerank eval-d2l-gen eval-topics golden-d2l golden-paper golden-legal golden-play golden-study golden-thoughts logs smoke luminary clean regen-api-types verify-router install release docker-build docker-run stage stage-payload stage-python stage-ollama verify-stage check-stage desktop-dev desktop-app desktop-adhoc desktop-test
+.PHONY: require-docker docker-run-host-ollama dev ci backend frontend build start stop lint test test-full test-concurrent test-perf test-e2e test-book-e2e test-book-content test-books-all test-v2 eval eval-intent eval-ingest eval-gen eval-variance prompt-dump eval-models eval-matrix eval-summary eval-routing eval-flashcards golden-flashcards eval-all eval-d2l eval-d2l-rerank eval-d2l-gen eval-topics golden-d2l golden-paper golden-legal golden-play golden-study golden-thoughts logs smoke luminary clean regen-api-types verify-router install release docker-build docker-run stage stage-payload stage-python stage-ollama verify-stage check-stage desktop-dev desktop-app desktop-adhoc desktop-test
 
 # Where the dev backend listens; `make dev` starts it here.
 BACKEND_URL ?= http://localhost:7820
@@ -150,7 +150,80 @@ release:
 # silently ignored on exactly one of the two documented ways to build.
 WITH_MEDIA ?= 0
 
-docker-build:
+# Every docker target below fails the same way on a machine without a working
+# daemon, and the bare failure is unhelpful: `docker: command not found` with a
+# make Error 127, arriving AFTER this file has printed "Using host Ollama at
+# :11434" -- which reads like the run started. Check the three things separately,
+# because they fail independently: the CLI, the daemon, and the compose v2
+# subcommand (every compose target here uses `docker compose`, not
+# `docker-compose`). They run in that order for the reasons noted at each.
+#
+# Only the ABSENT cases are fatal. A daemon that is merely stopped is a state
+# this target can fix, so it starts Docker Desktop (or colima) and waits, rather
+# than making you run one command and re-run make. DOCKER_AUTOSTART=0 opts out --
+# set it where a build should never launch a GUI app. The wait has to be generous
+# and it has to end: Docker Desktop cold-starts a Linux VM, and a version too old
+# for the host macOS hangs instead of failing, which is what the timeout catches.
+DOCKER_AUTOSTART ?= 1
+DOCKER_WAIT_SECS ?= 120
+
+# Docker Desktop installs /usr/local/bin/docker and its compose plugin the FIRST
+# TIME IT SUCCESSFULLY RUNS, through a privileged helper. Until that happens
+# `docker` is not on PATH at all even though Docker is installed -- the failure
+# reads as "not installed" when it is really "never started", which is a
+# different fix. Fall back to the CLI inside the app bundle so this target can
+# start Desktop instead of telling you to install what you already have.
+# Appended, not prepended: a properly linked docker always wins over the bundle.
+DOCKER_APP_BIN := /Applications/Docker.app/Contents/Resources/bin
+ifneq ($(wildcard $(DOCKER_APP_BIN)/docker),)
+export PATH := $(PATH):$(DOCKER_APP_BIN)
+endif
+require-docker:
+	@command -v docker >/dev/null 2>&1 \
+		|| { echo "No docker CLI found -- not on PATH, and no Docker.app to fall"; \
+		     echo "back to. Install Docker Desktop:"; \
+		     echo "   https://www.docker.com/products/docker-desktop/"; \
+		     echo "or a lighter daemon:"; \
+		     echo "   brew install colima docker docker-compose && colima start"; exit 1; }
+	@docker info >/dev/null 2>&1 && exit 0; \
+	if [ "$(DOCKER_AUTOSTART)" != "1" ]; then \
+		echo "docker is installed but the daemon is not answering, and"; \
+		echo "DOCKER_AUTOSTART=0. Start it yourself, then retry."; exit 1; \
+	fi; \
+	if [ "$$(uname -s)" = "Darwin" ] && [ -d /Applications/Docker.app ]; then \
+		starter="Docker Desktop"; \
+		open -g -a Docker \
+			|| { echo "Could not launch Docker Desktop."; exit 1; }; \
+	elif command -v colima >/dev/null 2>&1; then \
+		starter="colima"; \
+		colima start || { echo "'colima start' failed."; exit 1; }; \
+	else \
+		echo "docker is installed but the daemon is not answering, and there"; \
+		echo "is nothing here to start it (no Docker.app, no colima)."; \
+		echo "Start your daemon and retry -- on Linux:"; \
+		echo "   sudo systemctl start docker"; exit 1; \
+	fi; \
+	printf "Daemon down; started %s, waiting up to %ss" "$$starter" "$(DOCKER_WAIT_SECS)"; \
+	i=0; \
+	while [ $$i -lt $(DOCKER_WAIT_SECS) ]; do \
+		if docker info >/dev/null 2>&1; then echo " -- up."; exit 0; fi; \
+		printf "."; sleep 2; i=$$((i+2)); \
+	done; \
+	echo ""; \
+	echo "$$starter did not come up within $(DOCKER_WAIT_SECS)s."; \
+	echo "It may be too old for this macOS, or wedged. Check it with:"; \
+	echo "   docker info"; exit 1
+# Compose is checked LAST, not alongside the CLI: starting Desktop is what
+# installs the v2 plugin, so a machine that has never run it fails this check for
+# a reason the step above already fixed.
+	@docker compose version >/dev/null 2>&1 \
+		|| { echo "The docker daemon is up, but this CLI has no 'docker compose'"; \
+		     echo "(v2) subcommand:"; \
+		     echo "   $$(docker --version 2>&1)"; \
+		     echo "Every compose target here uses v2, not the docker-compose binary."; \
+		     echo "Upgrade Docker Desktop, or: brew install docker-compose"; exit 1; }
+
+docker-build: require-docker
 	docker build --build-arg WITH_MEDIA=$(WITH_MEDIA) -t luminary:latest .
 
 # OLLAMA_URL pinned, not left to the ambient environment. The compose file now
@@ -158,7 +231,7 @@ docker-build:
 # shell that exports OLLAMA_URL for `make dev` -- 127.0.0.1, the loopback of the
 # machine, not of the container -- would otherwise reach in here and point the
 # container at itself.
-docker-run:
+docker-run: require-docker
 	OLLAMA_URL=http://ollama:11434 docker compose --profile ai up --build
 
 # Same stack, but inference runs on the HOST instead of in the compose network.
@@ -179,7 +252,7 @@ docker-run:
 # a selectable service at all; naming it and passing --no-deps is what leaves the
 # ollama sidecars out. Do not drop --no-deps to "simplify" this -- the ollama
 # container comes back and takes the VM's CPU with it, which is the whole point.
-docker-run-host-ollama:
+docker-run-host-ollama: require-docker
 	@command -v ollama >/dev/null || { echo "Install Ollama first: https://ollama.com/download"; exit 1; }
 	@curl -sf http://localhost:11434/api/tags >/dev/null \
 		|| { echo "Ollama is not answering on :11434. Start it with:"; \
@@ -540,6 +613,7 @@ ci:
 	@echo "Running CI checks..."
 ifeq ($(shell uname -s)-$(shell uname -m),Darwin-x86_64)
 	@echo "Intel Mac detected: running backend CI in Docker (lancedb has no x86_64 macOS wheel)..."
+	@$(MAKE) --no-print-directory require-docker
 	docker build -q -t luminary-ci -f backend/Dockerfile.ci backend/
 	docker run --rm luminary-ci
 else

--- a/Makefile
+++ b/Makefile
@@ -25,15 +25,12 @@ w = warn_if_configuration_exceeds_host(); \
 print('  (.env + registry defaults; a model chosen in Settings is stored in the'); \
 print('   database and only shows at GET /settings/models on a running server)')"
 
+# Was: `lsof -ti :$$port` then an immediate `kill -9`. That query matches
+# clients as well as listeners, so it force-killed browser tabs pointed at the
+# app, and -9 skips the shutdown that releases the Kuzu lock. See free_port.sh.
 clean:
 	@echo "Stopping processes on Luminary ports (7820, 5173, 5174)..."
-	@for port in 7820 5173 5174; do \
-		pid=$$(lsof -ti :$$port 2>/dev/null); \
-		if [ -n "$$pid" ]; then \
-			echo "  killing PID $$pid on :$$port"; \
-			kill -9 $$pid; \
-		fi; \
-	done
+	@sh scripts/free_port.sh 7820 5173 5174
 	@echo "Done."
 
 dev:
@@ -276,23 +273,8 @@ docker-run-host-ollama: require-docker
 		docker compose --profile ai up --build --no-deps app
 
 stop:
-	@pids=$$(lsof -ti :$(LUMINARY_PORT) 2>/dev/null); \
-	if [ -z "$$pids" ]; then \
-		echo "No Luminary app running on :$(LUMINARY_PORT)."; \
-	else \
-		echo "Gracefully stopping Luminary on :$(LUMINARY_PORT) (SIGTERM to $$pids)..."; \
-		kill $$pids 2>/dev/null || true; \
-		for i in 1 2 3 4 5 6 7 8 9 10; do \
-			sleep 0.5; \
-			pids=$$(lsof -ti :$(LUMINARY_PORT) 2>/dev/null); \
-			[ -z "$$pids" ] && break; \
-		done; \
-		if [ -n "$$pids" ]; then \
-			echo "  still alive after 5s; sending SIGKILL to $$pids"; \
-			kill -9 $$pids 2>/dev/null || true; \
-		fi; \
-		echo "Stopped."; \
-	fi
+	@echo "Stopping Luminary on :$(LUMINARY_PORT)..."
+	@sh scripts/free_port.sh $(LUMINARY_PORT)
 
 # The frontend typecheck needs `tsc -b`: tsconfig.json is solution-style
 # ("files": []), so a bare `tsc --noEmit` resolves zero files and always passes.

--- a/backend/tests/test_free_port.py
+++ b/backend/tests/test_free_port.py
@@ -1,0 +1,127 @@
+"""Freeing a port must stop the listener and nothing else.
+
+`lsof -ti :PORT` matches every socket on the port, clients included. A browser
+tab left open on http://127.0.0.1:7820 holds a CLOSE_WAIT socket and was
+returned by that query, so `make stop` SIGTERMed -- then SIGKILLed five seconds
+later -- the user's browser, while the app it was asked to stop kept running.
+Observed with Brave at PID 718. scripts/free_port.sh filters -sTCP:LISTEN.
+
+Real processes on a real port, as in test_graph_lock.py: a mocked lsof would
+only prove the mock still matches the mock.
+"""
+
+import shutil
+import socket
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+FREE_PORT_SH = Path(__file__).resolve().parents[2] / "scripts" / "free_port.sh"
+
+# Two structural skips, both real rather than defensive: the local Intel-Mac CI
+# path builds its image from backend/ alone (Dockerfile.ci), so scripts/ is not
+# in that context. GitHub CI runs `make ci` on ubuntu-latest against the whole
+# checkout, which is where this test actually gates.
+pytestmark = [
+    pytest.mark.skipif(shutil.which("lsof") is None, reason="free_port.sh needs lsof"),
+    pytest.mark.skipif(
+        not FREE_PORT_SH.exists(),
+        reason=f"{FREE_PORT_SH} not in this build context (backend-only CI image)",
+    ),
+]
+
+
+def _free_tcp_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _spawn(src: str) -> subprocess.Popen:
+    return subprocess.Popen([sys.executable, "-c", textwrap.dedent(src)])
+
+
+def _wait_until(predicate, timeout=10.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.1)
+    return False
+
+
+@pytest.fixture
+def listener_and_client():
+    """A listener on a port, and a separate process holding a connection to it."""
+    port = _free_tcp_port()
+    listener = _spawn(f"""
+        import socket, time
+        s = socket.socket()
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("127.0.0.1", {port}))
+        s.listen(5)
+        while True:
+            try:
+                s.accept()
+            except OSError:
+                time.sleep(0.1)
+    """)
+    assert _wait_until(
+        lambda: _can_connect(port)
+    ), "listener never came up"
+
+    client = _spawn(f"""
+        import socket, time
+        s = socket.create_connection(("127.0.0.1", {port}))
+        time.sleep(120)
+    """)
+    time.sleep(1.0)
+    assert client.poll() is None, "client died before the test began"
+
+    yield port, listener, client
+
+    for proc in (listener, client):
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=10)
+
+
+def _can_connect(port: int) -> bool:
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.25):
+            return True
+    except OSError:
+        return False
+
+
+def test_frees_the_listener_and_spares_the_client(listener_and_client):
+    port, listener, client = listener_and_client
+
+    subprocess.run(
+        ["sh", str(FREE_PORT_SH), str(port)], check=True, timeout=60,
+        capture_output=True, text=True,
+    )
+
+    assert listener.poll() is not None, "the listener holding the port was not stopped"
+    assert client.poll() is None, (
+        "the client was killed -- free_port.sh matched a non-LISTEN socket, "
+        "which is the browser-killing bug this test exists to prevent"
+    )
+
+
+def test_reports_a_free_port_without_signalling_anything(listener_and_client):
+    """A port nobody listens on is a no-op, not an error."""
+    port, _listener, client = listener_and_client
+    unused = _free_tcp_port()
+
+    result = subprocess.run(
+        ["sh", str(FREE_PORT_SH), str(unused)], check=True, timeout=60,
+        capture_output=True, text=True,
+    )
+
+    assert "nothing listening" in result.stdout
+    assert client.poll() is None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
       - "127.0.0.1:7820:7820"
     volumes:
       - luminary-data:/data
+    # A full shutdown takes ~10.8s: the FastAPI lifespan finishes fast, then the
+    # process drains an unawaited LiteLLM coroutine before the interpreter exits.
+    # Compose's default grace is 10s, so Ctrl-C here landed on either side of the
+    # boundary at random -- exit 0 on one run, SIGKILL (137) on the next, with the
+    # Kuzu lock left held. Do not lower this below the measured number.
+    stop_grace_period: 30s
     environment:
       - LUMINARY_MODE=public
       - DATA_DIR=/data

--- a/scripts/cli/luminary
+++ b/scripts/cli/luminary
@@ -24,14 +24,54 @@ _healthy() { curl -sf --max-time 2 "http://127.0.0.1:$PORT/health" >/dev/null 2>
 
 # start.sh has no port-clearing, so a stale listener turns into a raw uvicorn
 # bind error. Clear it before handing the port back to launchd.
+#
+# Deliberately duplicated from scripts/free_port.sh: bootstrap.sh installs THIS
+# FILE ALONE into the bin directory, so it cannot source a sibling. Keep the two
+# in step. Both rules matter here as much as there -- `lsof -ti :PORT` returns
+# clients too (a browser tab on the app sits in CLOSE_WAIT and was being
+# SIGKILLed), and under Docker the listener is com.docker.backend, which must
+# never be signalled to free a port.
+_fp_cmd() { ps -p "$1" -o comm= 2>/dev/null | head -1; }
+
 _free_port() {
-    local pids
-    pids="$(lsof -ti :"$PORT" 2>/dev/null || true)"
-    if [ -n "$pids" ]; then
-        _warn "Port $PORT was held by PID(s) $pids — releasing."
-        kill -9 $pids 2>/dev/null || true
-        sleep 1
-    fi
+    local pids pid
+    pids="$(lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true)"
+    [ -n "$pids" ] || return 0
+
+    for pid in $pids; do
+        case "$(_fp_cmd "$pid")" in
+            *com.docker.backend*|*docker-proxy*|*vpnkit*)
+                _warn "Port $PORT is published by Docker, not a local process."
+                if command -v docker >/dev/null 2>&1; then
+                    local cid
+                    cid="$(docker ps --filter "publish=$PORT" --filter "name=luminary" \
+                            --format '{{.ID}}' 2>/dev/null | head -1)"
+                    if [ -n "$cid" ]; then
+                        _info "Stopping Luminary container $cid (graceful)."
+                        docker stop -t 30 "$cid" >/dev/null 2>&1 || true
+                        return 0
+                    fi
+                fi
+                _die "Refusing to signal $(_fp_cmd "$pid") — that would stop Docker itself. Check: docker ps --filter publish=$PORT"
+                ;;
+        esac
+    done
+
+    _warn "Port $PORT was held by PID(s) $pids — stopping (SIGTERM)."
+    for pid in $pids; do kill "$pid" 2>/dev/null || true; done
+
+    # 30s, not 5: a full stop takes ~10.8s (lifespan is fast, then the loop
+    # drains an unawaited LiteLLM coroutine). 5s SIGKILLed a healthy shutdown.
+    local waited=0
+    while [ "$waited" -lt 30 ]; do
+        sleep 1; waited=$((waited + 1))
+        [ -z "$(lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true)" ] && return 0
+    done
+
+    pids="$(lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true)"
+    [ -n "$pids" ] || return 0
+    _warn "Still listening after 30s; SIGKILL. This can leave the Kuzu lock held."
+    for pid in $pids; do kill -9 "$pid" 2>/dev/null || true; done
 }
 
 _wait_ready() {

--- a/scripts/free_port.sh
+++ b/scripts/free_port.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env sh
+# Free a TCP port held by Luminary, for `make stop`, `make clean` and luminary.sh.
+#
+# Sourced for its free_port() function, or run directly:  sh scripts/free_port.sh 7820
+#
+# Two rules, each from real damage:
+#
+# 1. LISTENERS ONLY. `lsof -ti :PORT` matches every socket on the port, clients
+#    included. A browser tab left on http://127.0.0.1:7820 holds a CLOSE_WAIT
+#    socket and is returned by that query, so the old `make stop` would SIGTERM
+#    -- then SIGKILL five seconds later -- the user's browser, while the app it
+#    was asked to stop kept running. Observed with Brave at PID 718.
+#    `-sTCP:LISTEN` is the fix, and the Ollama probe in the Makefile already
+#    used it; stop and clean simply did not.
+#
+# 2. NEVER KILL THE PORT PROXY. With the app in Docker the host listener is
+#    com.docker.backend, not uvicorn. Signalling it takes down Docker Desktop
+#    for every project on the machine and leaves the container running, so the
+#    app's own shutdown never happens. Stop the container instead -- that
+#    delivers SIGTERM to PID 1, which is what runs the FastAPI lifespan.
+#
+# Killing whatever holds a resource is a pattern this repo has already paid for
+# once: boot used to lsof the Kuzu graph file and SIGTERM the holder, which
+# could only ever hit a live process mid-write. See backend/tests/test_graph_lock.py.
+#
+# SIGTERM first, always. SIGKILL cannot run the lifespan that stops the
+# enrichment worker and cancels in-flight ingestion, and it is what leaves the
+# Kuzu lock held against the next launch.
+#
+# The 30s grace is measured, not guessed. A full stop of the app container takes
+# ~10.8s: the FastAPI lifespan itself finishes in well under a second, then the
+# process sits in loop.run_until_complete cleaning up an unawaited LiteLLM
+# coroutine (`BaseLLMHTTPHandler.async_completion`) before the interpreter exits.
+# That is just over `docker stop`'s 10s default, so the default produced exit 137
+# on one run and exit 0 on the next -- a SIGKILLed shutdown, at random, on the
+# path users take every day. Both the container timeout and the native grace are
+# set here so neither can drift back under the real number. A shorter value does
+# not make stop faster: free_port returns the moment the port is released.
+
+_fp_listeners() { lsof -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null || true; }
+
+_fp_cmd() { ps -p "$1" -o comm= 2>/dev/null | head -1; }
+
+# Is this PID a port forwarder rather than the app itself?
+_fp_is_proxy() {
+    case "$(_fp_cmd "$1")" in
+        *com.docker.backend*|*docker-proxy*|*vpnkit*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Stop the Luminary container publishing $1. Returns 0 stopped, 1 none found,
+# 2 found but not ours (never stop a stranger's container to free a port).
+_fp_stop_container() {
+    _fpc_port="$1"
+    command -v docker >/dev/null 2>&1 || return 1
+    _fpc_row="$(docker ps --filter "publish=$_fpc_port" \
+        --format '{{.ID}} {{.Names}} {{.Image}}' 2>/dev/null | head -1)"
+    [ -n "$_fpc_row" ] || return 1
+    _fpc_id="$(printf '%s' "$_fpc_row" | awk '{print $1}')"
+    case "$_fpc_row" in
+        *luminary*|*Luminary*)
+            printf '  :%s is served by container %s — docker stop (graceful)\n' \
+                "$_fpc_port" "$(printf '%s' "$_fpc_row" | awk '{print $2}')"
+            docker stop -t "${FREE_PORT_GRACE:-30}" "$_fpc_id" >/dev/null 2>&1 && return 0
+            return 1 ;;
+        *)
+            printf '  :%s is published by a NON-Luminary container (%s) — left alone.\n' \
+                "$_fpc_port" "$(printf '%s' "$_fpc_row" | awk '{print $2}')"
+            return 2 ;;
+    esac
+}
+
+# free_port PORT [GRACE_SECONDS]
+free_port() {
+    _fp_port="$1"
+    _fp_grace="${2:-${FREE_PORT_GRACE:-30}}"
+    _fp_pids="$(_fp_listeners "$_fp_port")"
+
+    if [ -z "$_fp_pids" ]; then
+        printf '  :%s — nothing listening.\n' "$_fp_port"
+        return 0
+    fi
+
+    for _fp_pid in $_fp_pids; do
+        if _fp_is_proxy "$_fp_pid"; then
+            _fp_stop_container "$_fp_port"
+            case $? in
+                0) return 0 ;;
+                2) return 1 ;;
+                *)
+                    printf '  :%s is held by %s (a port proxy) but no Luminary\n' \
+                        "$_fp_port" "$(_fp_cmd "$_fp_pid")"
+                    printf '     container publishes it. Refusing to signal it — that would\n'
+                    printf '     stop Docker itself. Check: docker ps --filter publish=%s\n' "$_fp_port"
+                    return 1 ;;
+            esac
+        fi
+    done
+
+    printf '  :%s — SIGTERM to %s\n' "$_fp_port" "$(echo "$_fp_pids" | tr '\n' ' ')"
+    for _fp_pid in $_fp_pids; do kill "$_fp_pid" 2>/dev/null || true; done
+
+    _fp_waited=0
+    while [ "$_fp_waited" -lt "$_fp_grace" ]; do
+        sleep 1
+        _fp_waited=$((_fp_waited + 1))
+        [ -z "$(_fp_listeners "$_fp_port")" ] && {
+            printf '  :%s — stopped cleanly after %ss.\n' "$_fp_port" "$_fp_waited"
+            return 0
+        }
+    done
+
+    _fp_pids="$(_fp_listeners "$_fp_port")"
+    [ -z "$_fp_pids" ] && return 0
+    printf '  :%s — still listening after %ss; SIGKILL to %s\n' \
+        "$_fp_port" "$_fp_grace" "$(echo "$_fp_pids" | tr '\n' ' ')"
+    printf '     (a forced kill can leave the Kuzu lock held; next start may report it)\n'
+    for _fp_pid in $_fp_pids; do kill -9 "$_fp_pid" 2>/dev/null || true; done
+    return 0
+}
+
+# Direct invocation: free every port given as an argument.
+if [ "${0##*/}" = "free_port.sh" ] && [ "$#" -gt 0 ]; then
+    for _fp_arg in "$@"; do free_port "$_fp_arg"; done
+fi

--- a/scripts/luminary.sh
+++ b/scripts/luminary.sh
@@ -46,19 +46,13 @@ fi
 # ---------------------------------------------------------------------------
 # Clear stale processes on required ports (graceful restart support)
 # ---------------------------------------------------------------------------
-_free_port() {
-    local port="$1"
-    local pid
-    pid=$(lsof -ti :"$port" 2>/dev/null)
-    if [ -n "$pid" ]; then
-        _info "Port $port in use by PID $pid — stopping it..."
-        kill "$pid" 2>/dev/null || true
-        # Give it a moment to release; force-kill if it lingers
-        sleep 1
-        pid=$(lsof -ti :"$port" 2>/dev/null)
-        [ -n "$pid" ] && kill -9 "$pid" 2>/dev/null || true
-    fi
-}
+# Listener-only, Docker-aware, SIGTERM-first. The previous version matched any
+# socket on the port -- including a browser tab in CLOSE_WAIT -- and force-killed
+# it after one second. See scripts/free_port.sh for the two incidents.
+# shellcheck source=scripts/free_port.sh
+. "$(dirname "${BASH_SOURCE[0]}")/free_port.sh"
+
+_free_port() { free_port "$1"; }
 _free_port "$BACKEND_PORT"
 _free_port 5173
 _free_port 5174
@@ -110,7 +104,9 @@ FRONTEND_PIPE_PID=$!
 _stop() {
     if [[ -n "$DOCKER_CONTAINER" ]]; then
         _info "Stopping Docker container ($DOCKER_CONTAINER)..."
-        docker stop "$DOCKER_CONTAINER" 2>/dev/null || true
+        # -t 30, not the 10s default: a full stop takes ~10.8s, so the default
+        # SIGKILLed a healthy shutdown on roughly half of Ctrl-C exits.
+        docker stop -t 30 "$DOCKER_CONTAINER" 2>/dev/null || true
     fi
     kill "$BACKEND_PIPE_PID" "$FRONTEND_PIPE_PID" 2>/dev/null || true
     wait "$BACKEND_PIPE_PID" "$FRONTEND_PIPE_PID" 2>/dev/null || true


### PR DESCRIPTION
Two defects in the stop/clean path, plus the Docker preflight that surfaced them. Both stop bugs are on paths users hit every day.

## Killing the wrong process

`make stop` and `make clean` selected PIDs with `lsof -ti :PORT`, which matches **every socket on the port, clients included**. Observed live on `:7820`:

```
Brave\x20   718  TCP 127.0.0.1:61409->127.0.0.1:7820 (CLOSE_WAIT)
com.docke 42642  TCP 127.0.0.1:7820 (LISTEN)
```

So `make stop` would SIGTERM — then SIGKILL 5s later — the user's **browser** and **Docker Desktop's backend**, while the app it was asked to stop kept running. `make clean` went straight to `kill -9`.

Selection is now `-sTCP:LISTEN`; a published port resolves to its container and is stopped gracefully; a container that isn't ours is left alone. This is the same "lsof the resource and signal whatever holds it" pattern the Kuzu boot path already dropped — see `backend/tests/test_graph_lock.py`.

## A 10s timeout against a 10.8s shutdown

Measured, not guessed: the FastAPI lifespan finishes fast, then the process drains an unawaited LiteLLM coroutine (`BaseLLMHTTPHandler.async_completion`) before the interpreter exits. Docker's and Compose's 10s defaults sat just under that, so a clean stop returned **exit 0 or exit 137 at random** — a SIGKILLed shutdown that can strand the Kuzu lock. Both observed. Now 30s in `free_port.sh`, `cli/luminary`, `luminary.sh`'s trap, and `stop_grace_period` in compose.

## Docker preflight

`docker: command not found` → make Error 127, printed *after* `Using host Ollama at :11434`, which reads like the run started. Docker Desktop installs `/usr/local/bin/docker` and its compose plugin only on first successful run, so "not on PATH" was never evidence Docker was missing. The preflight falls back to the CLI in the app bundle, starts the daemon, waits, and only then checks compose v2 — checking it earlier fails on a condition starting the daemon fixes.

## Verified

- All six `free_port` branches fired: no listener; native SIGTERM; SIGKILL escalation; **client spared**; Luminary container → `docker stop`; stranger's container → untouched.
- `backend/tests/test_free_port.py` **fails on the old query** (`assert -15 is None` — SIGTERM to the client) and passes on the fix.
- 60 existing tests covering the changed files pass (compose schema, compose memory profile, launchers, memory profile, prompt spec).
- ruff, layer_linter, boundary_checker, manifest schema/coverage/public-surface: green.
- `make stop` against a live container now returns exit 0 deterministically.

## Not verified

- Full `pytest` did not run locally: `make ci`'s Intel-Mac branch is **pre-existing broken** (161 collection errors, all `/surface-manifest.json` — `Dockerfile.ci` builds from the `backend/` context so a repo-root file read at import time can never be present). This diff touches nothing under `backend/app`. **CI here is the gate.**
- `test_free_port.py` skips in that local image for the same context reason; it runs on ubuntu-latest.
- `check_powershell` skipped locally (no `pwsh`).
- Frontend gate not run — no frontend file in the diff.

`VERSION` is still `0.8.0` and these sit under `[Unreleased]`; they need a bump before tagging.