### PR TITLE
feat(docker): docker-stop/docker-down, and refuse a compose that cannot run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`make docker-stop` and `make docker-down`.** There was no way to bring the
+  compose stack down; `down` never passes `--volumes`, so the library survives.
+
 ### Fixed
 - **`make stop` and `make clean` killed browsers instead of the app.** Both
   matched every socket on the port rather than the listener, so a tab left open
@@ -14,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   takes ~10.8s against `docker stop`'s 10s default, so exit 137 or 0 was a coin
   toss; the timeout is now 30s and a forced kill can no longer strand the Kuzu
   lock on a healthy stop.
+- **A pre-release `docker compose` now fails in under a second instead of
+  hanging.** 2.0.0-beta.4 creates the container and never starts it, attached or
+  detached; the run targets refuse it, while stop and down still work.
 - **The docker targets failed with `command not found` when Docker was merely
   not started.** Docker Desktop installs its CLI symlinks only on first
   successful run, so "not on PATH" was never evidence it was missing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ Prose versions in this repo have drifted before.
 | `make db-revision m="…"` | generate an Alembic revision (never raw `alembic revision` — see I-23) |
 | `make db-migrate` | apply migrations to the dev database |
 | `make regen-api-types` | regenerate `frontend/src/types/api.ts` from the OpenAPI schema |
-| `make clean` | kill anything on :7820, :5173, :5174 |
+| `make clean` | free :7820, :5173, :5174 — listeners only, SIGTERM first |
+| `make docker-stop` / `docker-down` | stop the compose stack / also remove containers + network (never volumes) |
 
 Ports: backend **7820**, frontend **5173**. Dev database: `<repo>/.luminary/luminary.db`.
 The bundled desktop app uses `~/Library/Application Support/sh.luminary.app/` instead.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: require-docker docker-run-host-ollama dev ci backend frontend build start stop lint test test-full test-concurrent test-perf test-e2e test-book-e2e test-book-content test-books-all test-v2 eval eval-intent eval-ingest eval-gen eval-variance prompt-dump eval-models eval-matrix eval-summary eval-routing eval-flashcards golden-flashcards eval-all eval-d2l eval-d2l-rerank eval-d2l-gen eval-topics golden-d2l golden-paper golden-legal golden-play golden-study golden-thoughts logs smoke luminary clean regen-api-types verify-router install release docker-build docker-run stage stage-payload stage-python stage-ollama verify-stage check-stage desktop-dev desktop-app desktop-adhoc desktop-test
+.PHONY: require-docker require-compose-release docker-stop docker-down docker-run-host-ollama dev ci backend frontend build start stop lint test test-full test-concurrent test-perf test-e2e test-book-e2e test-book-content test-books-all test-v2 eval eval-intent eval-ingest eval-gen eval-variance prompt-dump eval-models eval-matrix eval-summary eval-routing eval-flashcards golden-flashcards eval-all eval-d2l eval-d2l-rerank eval-d2l-gen eval-topics golden-d2l golden-paper golden-legal golden-play golden-study golden-thoughts logs smoke luminary clean regen-api-types verify-router install release docker-build docker-run stage stage-payload stage-python stage-ollama verify-stage check-stage desktop-dev desktop-app desktop-adhoc desktop-test
 
 # Where the dev backend listens; `make dev` starts it here.
 BACKEND_URL ?= http://localhost:7820
@@ -220,6 +220,36 @@ require-docker:
 		     echo "Every compose target here uses v2, not the docker-compose binary."; \
 		     echo "Upgrade Docker Desktop, or: brew install docker-compose"; exit 1; }
 
+# A pre-release compose is not a supported configuration here, and this is a
+# separate gate from require-docker on purpose: it blocks the RUN targets only.
+# Stopping and tearing down must keep working on a broken compose -- refusing to
+# let someone shut the stack down because their compose is old is the wrong
+# failure.
+#
+# 2.0.0-beta.4 creates the container and then never starts it, in BOTH attached
+# and detached mode, so `make docker-run` parks at "Container luminary_app_1
+# Created" and hangs indefinitely -- measured at 6min attached and 3min20s with
+# -d before being killed, container still in Created both times. The same beta
+# also refused to select any service until --profile ai was passed explicitly
+# (see docker-run-host-ollama). Two independent breakages in one version is
+# enough to stop guessing.
+require-compose-release: require-docker
+	@v="$$(docker compose version --short 2>/dev/null)"; \
+	case "$$v" in \
+		*alpha*|*beta*|*rc*) \
+			if [ "$(ALLOW_PRERELEASE_COMPOSE)" = "1" ]; then \
+				echo "warning: docker compose $$v is a pre-release; ALLOW_PRERELEASE_COMPOSE=1 set."; \
+			else \
+				echo "docker compose $$v is a pre-release, and this one does not work:"; \
+				echo "it creates the container and never starts it, so the run hangs"; \
+				echo "with nothing to show for it."; \
+				echo "Upgrade Docker Desktop (Settings -> Software updates), or:"; \
+				echo "   brew install docker-compose"; \
+				echo "To run anyway: make $(MAKECMDGOALS) ALLOW_PRERELEASE_COMPOSE=1"; \
+				exit 1; \
+			fi ;; \
+	esac
+
 docker-build: require-docker
 	docker build --build-arg WITH_MEDIA=$(WITH_MEDIA) -t luminary:latest .
 
@@ -228,7 +258,7 @@ docker-build: require-docker
 # shell that exports OLLAMA_URL for `make dev` -- 127.0.0.1, the loopback of the
 # machine, not of the container -- would otherwise reach in here and point the
 # container at itself.
-docker-run: require-docker
+docker-run: require-compose-release
 	OLLAMA_URL=http://ollama:11434 docker compose --profile ai up --build
 
 # Same stack, but inference runs on the HOST instead of in the compose network.
@@ -249,7 +279,7 @@ docker-run: require-docker
 # a selectable service at all; naming it and passing --no-deps is what leaves the
 # ollama sidecars out. Do not drop --no-deps to "simplify" this -- the ollama
 # container comes back and takes the VM's CPU with it, which is the whole point.
-docker-run-host-ollama: require-docker
+docker-run-host-ollama: require-compose-release
 	@command -v ollama >/dev/null || { echo "Install Ollama first: https://ollama.com/download"; exit 1; }
 	@curl -sf http://localhost:11434/api/tags >/dev/null \
 		|| { echo "Ollama is not answering on :11434. Start it with:"; \
@@ -271,6 +301,25 @@ docker-run-host-ollama: require-docker
 	@echo "Using host Ollama at :11434 (no ollama container)."
 	OLLAMA_URL=http://host.docker.internal:11434 \
 		docker compose --profile ai up --build --no-deps app
+
+# There was no way to bring the stack down. `make stop` frees the port -- and now
+# stops the container serving it -- but nothing removed the container and network
+# compose creates, so a re-run met a half-existing stack. Both use -t 30 for the
+# same measured reason as every other stop in this repo: a full shutdown takes
+# ~10.8s and the 10s default SIGKILLed it at random.
+docker-stop: require-docker
+	@echo "Stopping the Luminary compose stack (containers kept for a fast restart)..."
+	@docker compose --profile ai stop -t 30
+	@echo "Stopped. 'make docker-down' also removes the containers and network."
+
+# down removes containers and the network. It NEVER takes --volumes: that deletes
+# luminary-data, which is the user's library, and no target in this file is
+# allowed to do that silently. Do not add it.
+docker-down: require-docker
+	@echo "Stopping and removing Luminary containers and network..."
+	@docker compose --profile ai down -t 30
+	@echo "Done. Your library volume is untouched:"
+	@docker volume ls --filter name=luminary --format '  {{.Name}}' 2>/dev/null || true
 
 stop:
 	@echo "Stopping Luminary on :$(LUMINARY_PORT)..."

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ frontend/src/
 | `make install` | One-time setup (uv, Node, Ollama, models, build) |
 | `make start` | Public-mode server on :7820 |
 | `make luminary` | Backend + frontend in full mode (:7820 + :5173) |
-| `make stop` | Stop all Luminary processes |
+| `make stop` | Stop Luminary on :7820, gracefully (also stops the container when it serves the port) |
 | `make test` | Backend unit + integration tests |
 | `make lint` | Ruff + tsc + eslint + manifest checks |
 | `make ci` | **The gate.** Lint, layer check, tests, build, tsc, eslint, vitest |
@@ -536,6 +536,8 @@ frontend/src/
 | `make db-migrate` | Apply pending migrations (the server also does this on boot) |
 | `make db-revision m="..."` | Generate a migration after changing `models.py` |
 | `make docker-run` | Run via Docker Compose (with Ollama sidecar) |
+| `make docker-stop` | Stop the compose stack, containers kept for a fast restart |
+| `make docker-down` | Stop and remove containers and network; **volumes, i.e. your library, are kept** |
 
 **Evaluation harness.** Retrieval is scored with HR@5 / MRR / nDCG@10;
 faithfulness uses a dedicated NLI model (Vectara HHEM-2.1-Open) rather than an


### PR DESCRIPTION
Follow-up to #80. Two gaps in the Docker workflow, both hit while testing that PR.

## There was no way to bring the stack down

`make stop` frees the port — and since #80, stops the container serving it — but nothing removed the container and network compose creates, so a re-run met a half-existing stack. No `docker compose down` existed anywhere in the repo.

- `make docker-stop` — stops the stack, keeps containers for a fast restart
- `make docker-down` — also removes containers and the network

Both use `-t 30`, matching the measured ~10.8s shutdown from #80. **`down` never passes `--volumes`** — that would delete `luminary-data`, which is the user's library. There's a comment saying so next to it.

## A pre-release compose now fails fast instead of hanging

`docker compose` 2.0.0-beta.4 creates the container and then never starts it — **attached and detached both**, parked at `Container luminary_app_1  Created` through 6min and 3min20s respectively before I killed it. The same version already required an explicit `--profile ai` to select any service at all, which `docker-run-host-ollama` documents. Two independent breakages in one version.

The run targets now refuse it in **0.8s** with the upgrade path, instead of hanging with nothing to show.

The gate is deliberately **separate from `require-docker`**: it blocks the run targets only, so `docker-stop` and `docker-down` keep working on a broken compose. Refusing to let someone shut their stack down because their compose is old is the wrong failure. `ALLOW_PRERELEASE_COMPOSE=1` overrides.

## Verified on the broken beta

| Path | Result |
|---|---|
| `make docker-run` / `docker-run-host-ollama` | refused in 0.8s, names the target in the override hint |
| `make docker-stop` | stopped the container compose left in `Created` |
| `make docker-down` | removed container + network |
| library volumes after `down` | `luminary_luminary-data` and `luminary_ollama-models` both intact |
| `ALLOW_PRERELEASE_COMPOSE=1` | warns, exits 0 |
| stubbed compose 2.29.7 | silent, exits 0 |

Also: `make clean`'s description in CLAUDE.md said "kill anything on :7820, :5173, :5174", which stopped being true in #80 — corrected to "listeners only, SIGTERM first".

## Not verified

The happy path — an actual `docker compose up` completing — cannot be exercised here; this machine's only compose is the broken beta. That path is unchanged by this PR apart from the new prerequisite. `make ci` still cannot run locally (pre-existing, `Dockerfile.ci` build context); CI is the gate.