### PR TITLE
fix(docker): gate buildx too, and stop guessing the shutdown ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`make stop` and `make clean` killed browsers instead of the app.** Both
   matched every socket on the port rather than the listener, so a tab left open
   on Luminary was SIGTERMed then SIGKILLed while the app kept running.
-- **Stopping the container SIGKILLed it about half the time.** A full shutdown
-  takes ~10.8s against `docker stop`'s 10s default, so exit 137 or 0 was a coin
-  toss; the timeout is now 30s and a forced kill can no longer strand the Kuzu
-  lock on a healthy stop.
-- **A pre-release `docker compose` now fails in under a second instead of
-  hanging.** 2.0.0-beta.4 creates the container and never starts it, attached or
-  detached; the run targets refuse it, while stop and down still work.
+- **Stopping the container SIGKILLed it about half the time.** Shutdown is
+  variable — 10.8s settled, over 30s if it lands while a model is loading — and
+  Docker's 10s default cut it off, risking a stranded Kuzu lock. Every stop
+  ceiling is now 90s; `-t` returns as soon as the process exits, so a normal stop
+  is no slower.
+- **A stale Docker build toolchain now fails in under a second instead of
+  hanging or dying mid-build.** compose 2.0.0-beta.4 creates the container and
+  never starts it, attached or detached; buildx below 0.17.0 is refused outright
+  by a current compose. Both are checked up front, while stop and down keep
+  working regardless.
 - **The docker targets failed with `command not found` when Docker was merely
   not started.** Docker Desktop installs its CLI symlinks only on first
   successful run, so "not on PATH" was never evidence it was missing.

--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,12 @@ require-docker:
 		     echo "Every compose target here uses v2, not the docker-compose binary."; \
 		     echo "Upgrade Docker Desktop, or: brew install docker-compose"; exit 1; }
 
+# The build toolchain: compose AND buildx. Both live in the Docker Desktop
+# bundle, so a stale Desktop fails here in two different places, one at a time --
+# a current compose still refuses to build against buildx 0.5.1 with "compose
+# build requires buildx 0.17.0 or later", arriving only after the Ollama probes
+# have printed and the build has started.
+#
 # A pre-release compose is not a supported configuration here, and this is a
 # separate gate from require-docker on purpose: it blocks the RUN targets only.
 # Stopping and tearing down must keep working on a broken compose -- refusing to
@@ -249,6 +255,19 @@ require-compose-release: require-docker
 				exit 1; \
 			fi ;; \
 	esac
+	@bx="$$(docker buildx version 2>/dev/null | sed -n 's/.*v\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' | head -1)"; \
+	[ -n "$$bx" ] || { echo "docker buildx is missing; compose needs it to build."; \
+	                   echo "   brew install docker-buildx"; exit 1; }; \
+	maj=$${bx%%.*}; min=$${bx#*.}; \
+	if [ "$$maj" -eq 0 ] && [ "$$min" -lt 17 ]; then \
+		echo "docker buildx $$bx is too old -- compose build needs 0.17.0 or later."; \
+		echo "Docker Desktop bundles buildx, so an old Desktop fails here even with"; \
+		echo "a current compose. Upgrade Docker Desktop, or override just this plugin:"; \
+		echo "   brew install docker-buildx"; \
+		echo "   mkdir -p ~/.docker/cli-plugins"; \
+		echo "   ln -sfn $$(brew --prefix 2>/dev/null || echo /usr/local)/opt/docker-buildx/bin/docker-buildx ~/.docker/cli-plugins/docker-buildx"; \
+		exit 1; \
+	fi
 
 docker-build: require-docker
 	docker build --build-arg WITH_MEDIA=$(WITH_MEDIA) -t luminary:latest .
@@ -305,11 +324,12 @@ docker-run-host-ollama: require-compose-release
 # There was no way to bring the stack down. `make stop` frees the port -- and now
 # stops the container serving it -- but nothing removed the container and network
 # compose creates, so a re-run met a half-existing stack. Both use -t 30 for the
-# same measured reason as every other stop in this repo: a full shutdown takes
-# ~10.8s and the 10s default SIGKILLed it at random.
+# same reason as every other stop here: shutdown is variable (10.8s settled, over
+# 30s during a model load) and both the 10s default and a 30s ceiling SIGKILLed
+# healthy shutdowns. -t is a ceiling, not a wait.
 docker-stop: require-docker
 	@echo "Stopping the Luminary compose stack (containers kept for a fast restart)..."
-	@docker compose --profile ai stop -t 30
+	@docker compose --profile ai stop -t 90
 	@echo "Stopped. 'make docker-down' also removes the containers and network."
 
 # down removes containers and the network. It NEVER takes --volumes: that deletes
@@ -317,7 +337,7 @@ docker-stop: require-docker
 # allowed to do that silently. Do not add it.
 docker-down: require-docker
 	@echo "Stopping and removing Luminary containers and network..."
-	@docker compose --profile ai down -t 30
+	@docker compose --profile ai down -t 90
 	@echo "Done. Your library volume is untouched:"
 	@docker volume ls --filter name=luminary --format '  {{.Name}}' 2>/dev/null || true
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,29 @@ Everything below is the Docker path. Apple Silicon Macs use the native path abov
 1. [Docker Desktop](https://www.docker.com/products/docker-desktop/), running —
    check its memory and disk against
    [Running under Docker](#running-under-docker) before the first build.
+   **Keep it current.** The compose targets need a stable `docker compose` (v2 or
+   later, not a pre-release) and **buildx 0.17.0 or later**, both of which ship
+   inside the Docker Desktop bundle. `make docker-run…` checks each and refuses
+   with the fix rather than hanging. Verify with:
+
+   ```bash
+   docker compose version   # must not say alpha/beta/rc
+   docker buildx version    # must be >= v0.17.0
+   ```
+
+   On a Docker Desktop too old to upgrade in place, you can override just these
+   two plugins — the CLI prefers `~/.docker/cli-plugins` over the app bundle:
+
+   ```bash
+   brew install docker-compose docker-buildx
+   mkdir -p ~/.docker/cli-plugins
+   ln -sfn "$(brew --prefix)/opt/docker-compose/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
+   ln -sfn "$(brew --prefix)/opt/docker-buildx/bin/docker-buildx"   ~/.docker/cli-plugins/docker-buildx
+   ```
+
+   A 2021 Docker Desktop failed twice this way — its compose created the
+   container and never started it, and its buildx was refused by a current
+   compose — while its daemon was fine. Upgrading Desktop fixes both at once.
 2. [Homebrew](https://brew.sh), then `brew install ollama` — only for the
    recommended path; the all-in-Docker path needs nothing but Docker.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,13 @@ services:
       - "127.0.0.1:7820:7820"
     volumes:
       - luminary-data:/data
-    # A full shutdown takes ~10.8s: the FastAPI lifespan finishes fast, then the
-    # process drains an unawaited LiteLLM coroutine before the interpreter exits.
-    # Compose's default grace is 10s, so Ctrl-C here landed on either side of the
-    # boundary at random -- exit 0 on one run, SIGKILL (137) on the next, with the
-    # Kuzu lock left held. Do not lower this below the measured number.
-    stop_grace_period: 30s
+    # A ceiling, not a wait: compose stops as soon as the process exits. Shutdown
+    # is variable -- 10.8s settled, 17s during warmup, over 30s when it lands
+    # while a model is loading, because the process blocks on an uncancellable
+    # model load after the lifespan has already finished. Compose's 10s default
+    # and a first attempt at 30s both SIGKILLed healthy shutdowns (exit 137),
+    # which risks leaving the Kuzu lock held. Do not lower this.
+    stop_grace_period: 90s
     environment:
       - LUMINARY_MODE=public
       - DATA_DIR=/data

--- a/scripts/cli/luminary
+++ b/scripts/cli/luminary
@@ -48,7 +48,7 @@ _free_port() {
                             --format '{{.ID}}' 2>/dev/null | head -1)"
                     if [ -n "$cid" ]; then
                         _info "Stopping Luminary container $cid (graceful)."
-                        docker stop -t 30 "$cid" >/dev/null 2>&1 || true
+                        docker stop -t 90 "$cid" >/dev/null 2>&1 || true
                         return 0
                     fi
                 fi
@@ -70,7 +70,7 @@ _free_port() {
 
     pids="$(lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true)"
     [ -n "$pids" ] || return 0
-    _warn "Still listening after 30s; SIGKILL. This can leave the Kuzu lock held."
+    _warn "Still listening after 90s; SIGKILL. This can leave the Kuzu lock held."
     for pid in $pids; do kill -9 "$pid" 2>/dev/null || true; done
 }
 

--- a/scripts/free_port.sh
+++ b/scripts/free_port.sh
@@ -27,15 +27,21 @@
 # enrichment worker and cancels in-flight ingestion, and it is what leaves the
 # Kuzu lock held against the next launch.
 #
-# The 30s grace is measured, not guessed. A full stop of the app container takes
-# ~10.8s: the FastAPI lifespan itself finishes in well under a second, then the
-# process sits in loop.run_until_complete cleaning up an unawaited LiteLLM
-# coroutine (`BaseLLMHTTPHandler.async_completion`) before the interpreter exits.
-# That is just over `docker stop`'s 10s default, so the default produced exit 137
-# on one run and exit 0 on the next -- a SIGKILLed shutdown, at random, on the
-# path users take every day. Both the container timeout and the native grace are
-# set here so neither can drift back under the real number. A shorter value does
-# not make stop faster: free_port returns the moment the port is released.
+# The 90s grace is a CEILING, not a wait: `docker stop -t N` and the poll below
+# both return the moment the process exits, so a large N costs nothing on a
+# normal stop and only bounds a pathological one.
+#
+# It has to be this large because shutdown time is VARIABLE, which is the part
+# that bit us. Measured on one machine: 10.8s on a settled container, 17s during
+# warmup, and over 30s when the stop landed while GLiNER was loading. The FastAPI
+# lifespan itself always finishes fast -- the logs reach "Application shutdown
+# complete" every time -- but the process then blocks in shutdown_model_executor()
+# on an in-flight model load, which cannot be cancelled, before the interpreter
+# exits. Docker's and compose's 10s defaults, and a first attempt at 30s, both
+# SIGKILLed healthy shutdowns; exit 137 risks leaving the Kuzu lock held.
+#
+# Do not tune this down to make a stop "feel" faster. It will not, and the only
+# thing a lower ceiling buys is a forced kill during warmup.
 
 _fp_listeners() { lsof -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null || true; }
 
@@ -62,7 +68,7 @@ _fp_stop_container() {
         *luminary*|*Luminary*)
             printf '  :%s is served by container %s — docker stop (graceful)\n' \
                 "$_fpc_port" "$(printf '%s' "$_fpc_row" | awk '{print $2}')"
-            docker stop -t "${FREE_PORT_GRACE:-30}" "$_fpc_id" >/dev/null 2>&1 && return 0
+            docker stop -t "${FREE_PORT_GRACE:-90}" "$_fpc_id" >/dev/null 2>&1 && return 0
             return 1 ;;
         *)
             printf '  :%s is published by a NON-Luminary container (%s) — left alone.\n' \
@@ -74,7 +80,7 @@ _fp_stop_container() {
 # free_port PORT [GRACE_SECONDS]
 free_port() {
     _fp_port="$1"
-    _fp_grace="${2:-${FREE_PORT_GRACE:-30}}"
+    _fp_grace="${2:-${FREE_PORT_GRACE:-90}}"
     _fp_pids="$(_fp_listeners "$_fp_port")"
 
     if [ -z "$_fp_pids" ]; then

--- a/scripts/luminary.sh
+++ b/scripts/luminary.sh
@@ -104,9 +104,10 @@ FRONTEND_PIPE_PID=$!
 _stop() {
     if [[ -n "$DOCKER_CONTAINER" ]]; then
         _info "Stopping Docker container ($DOCKER_CONTAINER)..."
-        # -t 30, not the 10s default: a full stop takes ~10.8s, so the default
-        # SIGKILLed a healthy shutdown on roughly half of Ctrl-C exits.
-        docker stop -t 30 "$DOCKER_CONTAINER" 2>/dev/null || true
+        # -t 90, a ceiling not a wait. Shutdown is variable (10.8s settled, over
+        # 30s if it lands during a model load); 10s and 30s both SIGKILLed
+        # healthy shutdowns. See scripts/free_port.sh.
+        docker stop -t 90 "$DOCKER_CONTAINER" 2>/dev/null || true
     fi
     kill "$BACKEND_PIPE_PID" "$FRONTEND_PIPE_PID" 2>/dev/null || true
     wait "$BACKEND_PIPE_PID" "$FRONTEND_PIPE_PID" 2>/dev/null || true


### PR DESCRIPTION
Two corrections, both found by actually running the Docker path on a stale Docker Desktop rather than reasoning about it.

## buildx is now gated alongside compose

After upgrading compose past the broken beta, the run failed again:

```
[+] up 0/1
 ⠋ Image luminary-app Building
compose build requires buildx 0.17.0 or later
```

buildx 0.5.1 (2021) against a current compose. Both plugins ship inside the Docker Desktop bundle, so a stale Desktop fails **twice, one at a time** — and this one surfaced only after the Ollama probes had printed and the build had started.

`require-compose-release` now checks buildx `>= 0.17.0` and a missing buildx, each with the fix. Verified with stubs: `v0.5.1` refused, missing refused, `v0.36.1` silent.

## The 30s stop ceiling was measured on the wrong sample

I set 30s from timing a settled container at 10.8s. That was too narrow. Shutdown is **variable**:

| When the stop lands | Duration | Result at 30s |
|---|---|---|
| settled container | 10.8s | exit 0 |
| during warmup | 17s | exit 0 |
| while GLiNER is loading | > 30s | **exit 137** |

The lifespan always completes — `Application shutdown complete` is in the log every time, including the killed run. The process then blocks in `shutdown_model_executor()` on an in-flight model load that cannot be cancelled. So a 30s ceiling SIGKILLed a *healthy* shutdown, which is exactly the case that risks stranding the Kuzu lock.

All ceilings go to **90s** — `free_port.sh`, `cli/luminary`, `luminary.sh`'s trap, compose's `stop_grace_period`, and `docker-stop`/`docker-down`. `-t` is a **ceiling, not a wait**: it returns the moment the process exits, so a normal stop is no slower. Re-measured after the change: **12s, exit 0**, stopping mid-warmup.

## Docs

README's Docker prerequisite now states both version floors, how to check them, and the plugin-override recipe for a Desktop too old to upgrade in place (the CLI prefers `~/.docker/cli-plugins` over the app bundle). CHANGELOG entries corrected — the previous one claimed 30s and a fixed 10.8s shutdown.

## Verified end to end

With compose 5.5.0 + buildx 0.36.1 against the 2021 daemon (API 1.41), the full path finally works on this machine:

- `make docker-run-host-ollama` → image built, **container started** (the beta never did), `Ollama reachable at http://host.docker.internal:11434`
- `GET /api/health` → `{"status":"ok","version":"0.8.0"}`, `GET /` → 200
- `make stop` mid-warmup → 12s, **exit 0**
- `make docker-stop` → exit 0; `make docker-down` → container + network removed, **both library volumes intact**

## Not verified

The daemon itself is still 20.10.7 / API 1.41. It works for this path, but it is not a configuration anyone should ship on; upgrading Docker Desktop replaces all three at once. `make ci` still cannot run locally (pre-existing `Dockerfile.ci` build context) — CI is the gate.