### PR TITLE
fix(build): keep full-mode code out of public bundles; feat(blog): list unpublished drafts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -680,6 +680,7 @@ endif
 	python3 scripts/check_public_surface_calls.py
 	bash scripts/check_powershell.sh
 	cd frontend && npm run build
+	python3 scripts/check_public_bundle_excludes_full.py
 	cd frontend && npx tsc -b --noEmit
 	cd frontend && npm run lint
 	# The frontend suite was never wired into a gate: 59 files of pure-logic

--- a/backend/app/repos/note_repo.py
+++ b/backend/app/repos/note_repo.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.models import (
     CollectionMemberModel,
+    CollectionModel,
     NoteLinkModel,
     NoteModel,
     NoteSourceModel,
@@ -109,6 +110,30 @@ class NoteRepo:
         await self.session.commit()
 
     # -- collection / source membership reads ------------------------------
+
+    async def in_collection_named(self, name: str) -> list[NoteModel]:
+        """Notes in the collection with this NAME, case-insensitively.
+
+        Matched by name rather than id because that is what the publishing
+        surfaces key off: collections carry no category field, so "is this a
+        blog note" is answered by belonging to a collection called "BLOG" --
+        the same rule the note card's chip uses in the frontend. Name is not
+        unique, so every collection sharing it contributes.
+        """
+        stmt = (
+            select(NoteModel)
+            .join(
+                CollectionMemberModel,
+                (CollectionMemberModel.member_id == NoteModel.id)
+                & (CollectionMemberModel.member_type == "note"),
+            )
+            .join(CollectionModel, CollectionModel.id == CollectionMemberModel.collection_id)
+            .where(func.lower(CollectionModel.name) == name.lower())
+            .order_by(NoteModel.updated_at.desc())
+            .distinct()
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
 
     async def collection_ids_for(self, note_id: str) -> list[str]:
         result = await self.session.execute(

--- a/backend/app/routers/blog.py
+++ b/backend/app/routers/blog.py
@@ -22,6 +22,7 @@ from app.schemas.blog import (
     BlogConfigResponse,
     BlogDraftRequest,
     BlogDraftResponse,
+    BlogDraftSummary,
     BlogLivePreviewCleanupRequest,
     BlogLivePreviewRequest,
     BlogLivePreviewResponse,
@@ -97,9 +98,9 @@ def _within(path: Path, root: Path) -> bool:
 
 
 def _fallback_title(content: str) -> str:
-    first = next((ln.strip() for ln in content.splitlines() if ln.strip()), "")
-    first = re.sub(r"^#+\s*", "", first)
-    return first[:60] or "Untitled"
+    # One derivation, in the service: GET /blog/drafts decides "already published"
+    # by slugging this title, so a second copy here would let the two disagree.
+    return blog_service.fallback_title(content)
 
 
 @router.get("/config", response_model=BlogConfigResponse)
@@ -279,6 +280,30 @@ def _post_path(slug: str, kind: str) -> tuple[Path, Path, str]:
 
 def _post_url(slug: str, kind: str) -> str:
     return f"{get_settings().LUMINARY_BLOG_URL_BASE}/{kind}/{slug}/"
+
+
+@router.get("/drafts", response_model=list[BlogDraftSummary])
+async def list_drafts(
+    kind: str = "blog",
+    repo: NoteRepo = Depends(get_note_repo),
+) -> list[BlogDraftSummary]:
+    """Notes in the `kind` collection that have no post on the site yet.
+
+    The publish entry point is a chip on the note card, so a note written for the
+    site is only findable by remembering which note it was. This is the other
+    half of the management panel, which until now listed published posts and so
+    could never show the thing you were about to publish.
+    """
+    _check_kind(kind)
+    notes = await repo.in_collection_named(kind)
+    rows = [
+        (n.id, n.title, n.content, n.updated_at.isoformat() if n.updated_at else None)
+        for n in notes
+    ]
+    return [
+        BlogDraftSummary(**d)
+        for d in blog_service.unpublished_notes(rows, _content_dir(kind))
+    ]
 
 
 @router.get("/posts", response_model=list[BlogPostSummary])

--- a/backend/app/schemas/blog.py
+++ b/backend/app/schemas/blog.py
@@ -115,6 +115,20 @@ class BlogPostSummary(BaseModel):
     url: str
 
 
+class BlogDraftSummary(BaseModel):
+    """A note that is eligible to publish but has no post on the site yet.
+
+    `slug` is what publishing WOULD use, derived the same way `POST /blog/draft`
+    derives it, so the two cannot disagree about whether a note is already out.
+    """
+
+    note_id: str
+    title: str
+    slug: str
+    excerpt: str
+    updated_at: str | None = None
+
+
 class BlogPostDetail(BlogPostSummary):
     hero_image: str | None = None
     body: str

--- a/backend/app/services/blog_service.py
+++ b/backend/app/services/blog_service.py
@@ -56,6 +56,47 @@ def slugify(text: str) -> str:
     return slug or "untitled"
 
 
+def fallback_title(content: str) -> str:
+    """Title for a note that has none: its first non-blank line, heading marks off.
+
+    Lives here rather than in the router because the drafts listing and the draft
+    endpoint must derive the SAME title -- a note whose title differs between
+    them would slug differently and so look unpublished forever.
+    """
+    first = next((ln.strip() for ln in (content or "").splitlines() if ln.strip()), "")
+    first = re.sub(r"^#+\s*", "", first)
+    return first[:60] or "Untitled"
+
+
+def unpublished_notes(
+    notes: list[tuple[str, str | None, str, str | None]], content_dir: Path
+) -> list[dict]:
+    """(note_id, title, content, updated_at) tuples that have no post on the site.
+
+    "Published" is decided by slug, the same key `publish` writes under, so a
+    note republished under an edited title correctly reappears here -- the old
+    post still exists but this note no longer maps onto it.
+    """
+    published = existing_slugs(content_dir)
+    out: list[dict] = []
+    for note_id, title, content, updated_at in notes:
+        resolved = (title or fallback_title(content)).strip()
+        slug = slugify(resolved)
+        if slug in published:
+            continue
+        excerpt = " ".join((content or "").split())[:160]
+        out.append(
+            {
+                "note_id": note_id,
+                "title": resolved,
+                "slug": slug,
+                "excerpt": excerpt,
+                "updated_at": updated_at,
+            }
+        )
+    return out
+
+
 def format_pub_date(when: date | datetime) -> str:
     # Matches the site's existing posts, e.g. "Jun 15 2026". %-d is non-portable,
     # so strip a leading zero from the day manually.

--- a/backend/tests/test_blog.py
+++ b/backend/tests/test_blog.py
@@ -441,3 +441,91 @@ def test_suggest_description_keeps_note_content_local(client, monkeypatch):
     resp = client.post("/blog/suggest-description", json={"note_id": note_id})
     assert resp.status_code == 200
     assert seen["background"] is True
+
+
+# -- GET /blog/drafts -------------------------------------------------------
+#
+# The management panel listed published posts only, so the one thing you were
+# about to publish was the one thing it could not show. These cover the two
+# halves that make the listing mean something: membership decides what is
+# eligible, and the slug decides what has already gone out.
+
+
+def _collect(client, note_id: str, name: str) -> None:
+    """Put a note in a collection with this name, creating it if needed."""
+    tree = client.get("/collections/tree").json()
+    existing = {c["name"].lower(): c["id"] for c in tree}
+    cid = existing.get(name.lower()) or client.post(
+        "/collections", json={"name": name}
+    ).json()["id"]
+    client.post(
+        f"/collections/{cid}/members",
+        json={"member_ids": [note_id], "member_type": "note"},
+    )
+
+
+def test_drafts_lists_a_collected_note_that_is_not_published_yet(client, blog_repo):
+    note_id = client.post(
+        "/notes", json={"content": "# Unshipped Idea\n\nbody text", "tags": []}
+    ).json()["id"]
+    _collect(client, note_id, "BLOG")
+
+    drafts = client.get("/blog/drafts").json()
+    mine = [d for d in drafts if d["note_id"] == note_id]
+    assert len(mine) == 1
+    assert mine[0]["title"] == "Unshipped Idea"
+    assert mine[0]["slug"] == "unshipped-idea"
+    assert "body text" in mine[0]["excerpt"]
+
+
+def test_a_note_outside_the_collection_is_not_a_draft(client, blog_repo):
+    """Membership is the eligibility rule, matching the note card's chip."""
+    note_id = client.post(
+        "/notes", json={"content": "# Private Musing\n\nnot for the site", "tags": ["blog"]}
+    ).json()["id"]
+
+    drafts = client.get("/blog/drafts").json()
+    assert all(d["note_id"] != note_id for d in drafts)
+
+
+def test_publishing_a_draft_removes_it_from_the_list(client, blog_repo):
+    """The whole point: the list has to empty out as you ship."""
+    note_id = client.post(
+        "/notes", json={"content": "# Ship Me\n\nbody", "tags": []}
+    ).json()["id"]
+    _collect(client, note_id, "BLOG")
+    assert any(d["note_id"] == note_id for d in client.get("/blog/drafts").json())
+
+    draft = client.post("/blog/draft", json={"note_id": note_id}).json()
+    client.post(
+        "/blog/publish",
+        json={
+            "note_id": note_id,
+            "slug": draft["slug"],
+            "title": draft["title"],
+            "description": "d",
+            "pub_date": draft["pub_date"],
+            "markdown": draft["markdown"],
+            "overwrite": False,
+        },
+    )
+
+    assert all(d["note_id"] != note_id for d in client.get("/blog/drafts").json())
+
+
+def test_drafts_are_isolated_per_kind(client, blog_repo):
+    """A BLOG note is not a thoughts draft; `kind` selects both the collection
+    and the content directory it is checked against."""
+    (blog_repo / "src/content/thoughts").mkdir(parents=True, exist_ok=True)
+    note_id = client.post(
+        "/notes", json={"content": "# Blog Only\n\nbody", "tags": []}
+    ).json()["id"]
+    _collect(client, note_id, "BLOG")
+
+    assert any(d["note_id"] == note_id for d in client.get("/blog/drafts").json())
+    thoughts = client.get("/blog/drafts", params={"kind": "thoughts"}).json()
+    assert all(d["note_id"] != note_id for d in thoughts)
+
+
+def test_drafts_rejects_an_unknown_kind(client, blog_repo):
+    assert client.get("/blog/drafts", params={"kind": "wat"}).status_code == 422

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,6 @@ import { LLMModeBadge, SettingsDrawer } from "./components/SettingsDrawer"
 import { StreakXPWidget } from "./components/StreakXPWidget"
 import { SearchDialog } from "./components/SearchDialog"
 import { StudyLauncher } from "./components/StudyLauncher"
-import { FocusTimerPill } from "./components/FocusTimerPill"
 import { Skeleton } from "./components/ui/skeleton"
 import { useReviewNotification } from "./hooks/useReviewNotification"
 import { IngestionTrackerProvider } from "./hooks/IngestionTrackerProvider"
@@ -44,6 +43,25 @@ const Learning = lazy(() => import("@/pages/Learning"))
 const Notes = lazy(() => import("@/pages/Notes"))
 const Study = lazy(() => import("@/pages/Study"))
 const Viz = lazy(() => import("@/pages/Viz"))
+
+// Full-mode only, and folded at BUILD time rather than hidden at runtime.
+// `isSurfaceVisible("pomodoro")` decides what renders; it does not decide what
+// is compiled in, so a static import shipped lib/focusApi and its /pomodoro/*
+// calls to every public user. LUMINARY_MODE is a vite `define`, so in a public
+// build this ternary folds to null and the dynamic import is dropped entirely.
+// scripts/check_public_bundle_excludes_full.py fails the build if it comes back.
+// Compared against `import.meta.env.VITE_LUMINARY_MODE`, NOT the exported
+// LUMINARY_MODE constant. vite `define` substitutes the env expression
+// textually before parsing, so this folds to `"public" === "full"` -> false and
+// Rollup drops the branch with its dynamic import. LUMINARY_MODE is the return
+// value of resolveMode(), which Rollup cannot constant-fold -- using it here
+// emits a separate chunk that still ships. Measured both ways.
+const FocusTimerPill =
+  import.meta.env.VITE_LUMINARY_MODE === "full"
+    ? lazy(() =>
+        import("./components/FocusTimerPill").then((m) => ({ default: m.FocusTimerPill })),
+      )
+    : null
 const Quality = lazy(() => import("@/pages/Quality"))
 const Progress = lazy(() => import("@/pages/Progress"))
 const Admin = lazy(() => import("@/pages/Admin"))
@@ -568,9 +586,11 @@ function AppShell() {
           </div>
         )}
         {/* Focus timer pill (app-wide) -- full-mode surface, only when pomodoro is visible */}
-        {pomodoroVisible && (
+        {pomodoroVisible && FocusTimerPill && (
           <div className="flex items-center justify-end gap-2 px-4 pt-3">
-            <FocusTimerPill />
+            <Suspense fallback={null}>
+              <FocusTimerPill />
+            </Suspense>
           </div>
         )}
         <Routes>

--- a/frontend/src/components/blog/BlogsPanel.tsx
+++ b/frontend/src/components/blog/BlogsPanel.tsx
@@ -1,25 +1,29 @@
 /**
- * BlogsPanel — lists the published posts in the site repo (GET /blog/posts).
+ * BlogsPanel — drafts you have not published yet (GET /blog/drafts), then the
+ * published posts in the site repo (GET /blog/posts).
  * Each post can be opened for editing (BlogEditDialog) or deleted in place
  * (both commit locally; the user pushes). Shown in the Notes page "Blogs" view.
  */
 
 import { useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { ExternalLink, Loader2, Pencil, Trash2 } from "lucide-react"
+import { ExternalLink, Loader2, Pencil, Send, Trash2 } from "lucide-react"
 import { toast } from "sonner"
 
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   deleteBlogPost,
   getBlogConfig,
+  listBlogDrafts,
   listBlogPosts,
   KIND_PLURAL,
   KIND_SINGULAR,
   type BlogKind,
   type BlogPostSummary,
 } from "@/lib/blogApi"
+import { getNote } from "@/lib/notesApi"
 import { BlogEditDialog } from "./BlogEditDialog"
+import { BlogPublishDialog } from "./BlogPublishDialog"
 import { PushBlogButton } from "./PushBlogButton"
 
 const KINDS: BlogKind[] = ["blog", "thoughts"]
@@ -36,6 +40,7 @@ export function BlogsPanel() {
   const [kind, setKind] = useState<BlogKind>("blog")
   const [editing, setEditing] = useState<string | null>(null)
   const [confirming, setConfirming] = useState<string | null>(null)
+  const [publishing, setPublishing] = useState<string | null>(null)
 
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ["blog-posts", kind],
@@ -50,11 +55,30 @@ export function BlogsPanel() {
   })
   const unconfigured = !!config && (!config.is_git_repo || !config.content_dir_exists)
 
+  // Notes in the matching collection with nothing on the site yet. Listed here
+  // because the publish action otherwise lives only on the note card, so the
+  // panel named for a collection could not show the thing you came to publish.
+  const { data: drafts } = useQuery({
+    queryKey: ["blog-drafts", kind],
+    queryFn: () => listBlogDrafts(kind),
+  })
+  const draftRows = drafts ?? []
+
+  // The publish dialog renders mermaid from the note's FULL markdown; the row's
+  // excerpt is truncated, so passing that would quietly drop diagrams. Fetch the
+  // note and hold the dialog back until it is here.
+  const { data: publishingNote } = useQuery({
+    queryKey: ["note", publishing],
+    queryFn: () => getNote(publishing as string),
+    enabled: !!publishing,
+  })
+
   const deleteMut = useMutation({
     mutationFn: (slug: string) => deleteBlogPost(slug, kind),
     onSuccess: (_res, slug) => {
       setConfirming(null)
       void qc.invalidateQueries({ queryKey: ["blog-posts"] })
+      void qc.invalidateQueries({ queryKey: ["blog-drafts"] })
       void qc.invalidateQueries({ queryKey: ["blog-config"] })
       toast.success(`Deleted ${slug} (committed locally)`)
     },
@@ -207,7 +231,53 @@ export function BlogsPanel() {
         </div>
       </div>
 
+      {draftRows.length > 0 && (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Drafts — in {KIND_PLURAL[kind]}, not published yet
+          </h2>
+          <ul className="flex flex-col gap-1.5">
+            {draftRows.map((d) => (
+              <li
+                key={d.note_id}
+                className="flex items-center gap-3 rounded-lg border border-dashed border-border px-3 py-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-foreground">{d.title}</p>
+                  <p className="truncate text-xs text-muted-foreground">{d.excerpt}</p>
+                </div>
+                <code className="hidden shrink-0 truncate rounded bg-muted/50 px-2 py-0.5 text-[11px] text-muted-foreground sm:block">
+                  {d.slug}.md
+                </code>
+                <button
+                  onClick={() => setPublishing(d.note_id)}
+                  className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary hover:bg-primary/20"
+                >
+                  <Send size={12} />
+                  Publish
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
       {content}
+
+      {publishing && publishingNote && (
+        <BlogPublishDialog
+          open={!!publishing}
+          kind={kind}
+          noteId={publishing}
+          noteContent={publishingNote.content}
+          onClose={() => {
+            setPublishing(null)
+            void qc.invalidateQueries({ queryKey: ["blog-drafts"] })
+            void qc.invalidateQueries({ queryKey: ["blog-posts"] })
+            void qc.invalidateQueries({ queryKey: ["blog-config"] })
+          }}
+        />
+      )}
 
       {editing && (
         <BlogEditDialog
@@ -217,6 +287,7 @@ export function BlogsPanel() {
           onClose={() => setEditing(null)}
           onChanged={() => {
             void qc.invalidateQueries({ queryKey: ["blog-posts"] })
+      void qc.invalidateQueries({ queryKey: ["blog-drafts"] })
             void qc.invalidateQueries({ queryKey: ["blog-config"] })
           }}
         />

--- a/frontend/src/components/reader/DocumentReader.tsx
+++ b/frontend/src/components/reader/DocumentReader.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { ArrowLeft, ChevronLeft, ChevronRight, GitCompareArrows, Highlighter, MessageSquare, PanelRightClose, PanelRightOpen, RefreshCw, Search, Sparkles, StickyNote, Target, Trash2, X } from "lucide-react"
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import React, { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { useBackNavigation } from "@/hooks/useBackNavigation"
 import { toast } from "sonner"
@@ -18,10 +18,30 @@ import { useAppStore } from "@/store"
 
 import { ChapterGoalsPanel } from "./ChapterGoalsPanel"
 import { DocumentFlashcardDialog } from "./DocumentFlashcardDialog"
-import { LUMINARY_MODE, isSurfaceVisible } from "@/lib/surfaceManifest"
+import { isSurfaceVisible } from "@/lib/surfaceManifest"
+
+// Full-mode only, folded at BUILD time. FEYNMAN_VISIBLE below gates rendering,
+// which hid the button but still compiled the dialog and its /feynman/* calls
+// into the public Learning chunk. LUMINARY_MODE is a vite `define`, so a public
+// build folds this to null and drops the dynamic import.
+// Compared against `import.meta.env.VITE_LUMINARY_MODE`, NOT the exported
+// LUMINARY_MODE constant. vite `define` substitutes the env expression
+// textually before parsing, so this folds to `"public" === "full"` -> false and
+// Rollup drops the branch with its dynamic import. LUMINARY_MODE is the return
+// value of resolveMode(), which Rollup cannot constant-fold -- using it here
+// emits a separate chunk that still ships. Measured both ways.
+const loadLastPracticed =
+  import.meta.env.VITE_LUMINARY_MODE === "full"
+    ? (documentId: string) =>
+        import("./feynmanSessions").then((m) => m.lastPracticedBySection(documentId))
+    : null
+
+const FeynmanDialog =
+  import.meta.env.VITE_LUMINARY_MODE === "full"
+    ? lazy(() => import("./FeynmanDialog").then((m) => ({ default: m.FeynmanDialog })))
+    : null
 
 import { EPUBViewer } from "./EPUBViewer"
-import { FeynmanDialog } from "./FeynmanDialog"
 import { prefetchFeynmanSummary } from "./feynmanSummaryCache"
 import { COLOR_CLASSES } from "./highlightColors"
 import { readerLandingTab } from "./hooks/readerLandingTab"
@@ -649,23 +669,9 @@ function DocumentReaderBase({ documentId, onBack, initialSectionId, initialChunk
   // Powers the "last practiced" badge in the section list.
   const { data: lastPracticedBySection } = useQuery<Map<string, string>>({
     queryKey: ["feynman-sessions-by-section", documentId],
-    queryFn: async () => {
-      try {
-        const sessions = await apiGet<
-          Array<{ section_id: string | null; created_at: string }>
-        >("/feynman/sessions", { document_id: documentId })
-        const byId = new Map<string, string>()
-        // Sessions are returned in created_at desc; first hit per section wins.
-        for (const s of sessions) {
-          if (!s.section_id) continue
-          if (!byId.has(s.section_id)) byId.set(s.section_id, s.created_at)
-        }
-        return byId
-      } catch {
-        return new Map<string, string>()
-      }
-    },
-    enabled: LUMINARY_MODE === "full",
+    queryFn: () =>
+      loadLastPracticed ? loadLastPracticed(documentId) : new Map<string, string>(),
+    enabled: !!loadLastPracticed,
     staleTime: 30_000,
   })
 
@@ -1567,7 +1573,8 @@ function DocumentReaderBase({ documentId, onBack, initialSectionId, initialChunk
       )}
 
       {/* Feynman dialog */}
-      {feynmanSection && (
+      {feynmanSection && FeynmanDialog && (
+        <Suspense fallback={null}>
         <FeynmanDialog
           documentId={documentId}
           sectionId={feynmanSection}
@@ -1583,6 +1590,7 @@ function DocumentReaderBase({ documentId, onBack, initialSectionId, initialChunk
             }
           }}
         />
+        </Suspense>
       )}
 
       {/* Flashcard generation dialog — scoped to selected text context */}

--- a/frontend/src/components/reader/feynmanSessions.ts
+++ b/frontend/src/components/reader/feynmanSessions.ts
@@ -1,0 +1,25 @@
+// Feynman session lookups, split out of DocumentReader so a public build can
+// drop them. `feynman` is a full-mode surface; the query in DocumentReader was
+// already `enabled: LUMINARY_MODE === "full"` and so never ran for a public
+// user, but the "/feynman/sessions" call still compiled into the Learning
+// chunk. Behind a folded dynamic import this module is not emitted at all.
+import { apiGet } from "@/lib/apiClient"
+
+/** section_id -> ISO timestamp of that section's most recent Feynman session. */
+export async function lastPracticedBySection(documentId: string): Promise<Map<string, string>> {
+  try {
+    const sessions = await apiGet<Array<{ section_id: string | null; created_at: string }>>(
+      "/feynman/sessions",
+      { document_id: documentId },
+    )
+    const byId = new Map<string, string>()
+    // Sessions are returned in created_at desc; first hit per section wins.
+    for (const s of sessions) {
+      if (!s.section_id) continue
+      if (!byId.has(s.section_id)) byId.set(s.section_id, s.created_at)
+    }
+    return byId
+  } catch {
+    return new Map<string, string>()
+  }
+}

--- a/frontend/src/lib/blogApi.ts
+++ b/frontend/src/lib/blogApi.ts
@@ -121,6 +121,19 @@ export const blogLivePreviewCleanup = (slug: string, kind: BlogKind = "blog"): P
 
 // -- published-post management --------------------------------------------
 
+/** A collected note with no post on the site yet -- what you are about to publish. */
+export interface BlogDraftSummary {
+  note_id: string
+  title: string
+  /** The slug publishing WOULD use; how "already published" is decided. */
+  slug: string
+  excerpt: string
+  updated_at?: string | null
+}
+
+export const listBlogDrafts = (kind: BlogKind = "blog"): Promise<BlogDraftSummary[]> =>
+  apiGet<BlogDraftSummary[]>(`/blog/drafts${q(kind)}`)
+
 export interface BlogPostSummary {
   slug: string
   title: string

--- a/frontend/src/pages/Notes.tsx
+++ b/frontend/src/pages/Notes.tsx
@@ -6,7 +6,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { ArrowLeft, BookOpen, Download, Feather, FileText, Loader2, Network, Newspaper, Pencil, Plus, Tag, Trash2, Wand2, X } from "lucide-react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { useBackNavigation } from "@/hooks/useBackNavigation"
 import { NEW_NOTE_ROUTE_ID } from "@/lib/noteAutosave"
@@ -18,10 +18,33 @@ import { GapDetectDialog } from "@/components/GapDetectDialog"
 import { OrganizationPlanDialog, type NamingViolation } from "@/components/OrganizationPlanDialog"
 import { GenerateFlashcardsDialog } from "@/components/GenerateFlashcardsDialog"
 import { QuickNoteComposer } from "@/components/notes/QuickNoteComposer"
-import { BlogPublishDialog } from "@/components/blog/BlogPublishDialog"
-import { BlogsPanel } from "@/components/blog/BlogsPanel"
 import type { BlogKind } from "@/lib/blogApi"
 import { isSurfaceVisible } from "@/lib/surfaceManifest"
+
+// Full-mode only, folded at BUILD time. `isSurfaceVisible("blog")` below decides
+// what renders; it does not decide what is compiled in, so a static import put
+// the whole publish dialog and lib/blogApi into the public Notes chunk. In a
+// public build LUMINARY_MODE folds this to null and the dynamic import is
+// dropped. Guarded by scripts/check_public_bundle_excludes_full.py.
+// Compared against `import.meta.env.VITE_LUMINARY_MODE`, NOT the exported
+// LUMINARY_MODE constant. vite `define` substitutes the env expression
+// textually before parsing, so this folds to `"public" === "full"` -> false and
+// Rollup drops the branch with its dynamic import. LUMINARY_MODE is the return
+// value of resolveMode(), which Rollup cannot constant-fold -- using it here
+// emits a separate chunk that still ships. Measured both ways.
+const BlogsPanel =
+  import.meta.env.VITE_LUMINARY_MODE === "full"
+    ? lazy(() => import("@/components/blog/BlogsPanel").then((m) => ({ default: m.BlogsPanel })))
+    : null
+
+const BlogPublishDialog =
+  import.meta.env.VITE_LUMINARY_MODE === "full"
+    ? lazy(() =>
+        import("@/components/blog/BlogPublishDialog").then((m) => ({
+          default: m.BlogPublishDialog,
+        })),
+      )
+    : null
 import { useDebounce } from "@/hooks/useDebounce"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
@@ -668,7 +691,8 @@ function NoteCard({ note, onEdit, onDeleted }: NoteCardProps) {
         </div>
       )}
 
-      {publishKind && (
+      {publishKind && BlogPublishDialog && (
+        <Suspense fallback={null}>
         <BlogPublishDialog
           open={!!publishKind}
           kind={publishKind}
@@ -676,6 +700,7 @@ function NoteCard({ note, onEdit, onDeleted }: NoteCardProps) {
           noteId={note.id}
           noteContent={note.content}
         />
+        </Suspense>
       )}
     </div>
   )
@@ -917,8 +942,12 @@ export default function NotesPage() {
         navigate={navigate}
       />
     )
-  } else if (filter.type === "blogs") {
-    panelContent = <BlogsPanel />
+  } else if (filter.type === "blogs" && BlogsPanel) {
+    panelContent = (
+      <Suspense fallback={null}>
+        <BlogsPanel />
+      </Suspense>
+    )
   } else if (isSearchMode) {
     if (searchLoading) {
       panelContent = (

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -139,6 +139,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/blog/drafts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Drafts
+         * @description Notes in the `kind` collection that have no post on the site yet.
+         *
+         *     The publish entry point is a chip on the note card, so a note written for the
+         *     site is only findable by remembering which note it was. This is the other
+         *     half of the management panel, which until now listed published posts and so
+         *     could never show the thing you were about to publish.
+         */
+        get: operations["list_drafts_blog_drafts_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/blog/posts": {
         parameters: {
             query?: never;
@@ -4342,10 +4367,18 @@ export interface paths {
          * Classify Only
          * @description Classify the chat route without executing retrieval/LLM graph nodes.
          *
-         *     The heuristic alone is not what production routes on: `chat_graph` sends
-         *     anything below 0.7 to the LLM, and the catch-all sits at 0.5. Measuring this
-         *     endpoint without `llm_fallback` therefore measures a path no user takes on
-         *     its own -- it is the floor, not the routing.
+         *     The heuristic alone is not what production routes on -- on a quick host.
+         *     `chat_graph` sends anything below 0.7 to the LLM there, and the catch-all
+         *     sits at 0.5, so measuring this endpoint without `llm_fallback` measures the
+         *     floor rather than the routing. On a host the start-up probe measured slow the
+         *     two converge: `should_use_llm_fallback` drops that call, and the heuristic
+         *     alone IS what the user gets.
+         *
+         *     This parameter is deliberately NOT gated on the host the way the graph is.
+         *     An eval has to be able to measure both arms on whatever machine it runs on;
+         *     gating it here would have made the slow-host arm unmeasurable on exactly the
+         *     hosts the gate exists for, and the 0.9655 -> 0.8276 figure that quantifies
+         *     its cost came from asking for both arms on such a machine.
          */
         post: operations["classify_only_qa_classify_only_post"];
         delete?: never;
@@ -6429,6 +6462,25 @@ export interface components {
             /** Collision */
             collision: boolean;
         };
+        /**
+         * BlogDraftSummary
+         * @description A note that is eligible to publish but has no post on the site yet.
+         *
+         *     `slug` is what publishing WOULD use, derived the same way `POST /blog/draft`
+         *     derives it, so the two cannot disagree about whether a note is already out.
+         */
+        BlogDraftSummary: {
+            /** Note Id */
+            note_id: string;
+            /** Title */
+            title: string;
+            /** Slug */
+            slug: string;
+            /** Excerpt */
+            excerpt: string;
+            /** Updated At */
+            updated_at?: string | null;
+        };
         /** BlogLivePreviewCleanupRequest */
         BlogLivePreviewCleanupRequest: {
             /** Slug */
@@ -7535,6 +7587,28 @@ export interface components {
             rerank_depth: number;
             /** Rerank Blend Alpha */
             rerank_blend_alpha: number | null;
+            /**
+             * Rerank Enabled
+             * @default true
+             */
+            rerank_enabled: boolean;
+            /** Startup Probe Seconds */
+            startup_probe_seconds?: number | null;
+            /**
+             * Local Inference Slow
+             * @default false
+             */
+            local_inference_slow: boolean;
+            /**
+             * Qa Context Token Budget
+             * @default 0
+             */
+            qa_context_token_budget: number;
+            /**
+             * Qa Context Budget Reason
+             * @default unknown
+             */
+            qa_context_budget_reason: string;
             /** Query Spell Correct */
             query_spell_correct: boolean;
             /** Llm Mode */
@@ -11255,6 +11329,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BlogPublishResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_drafts_blog_drafts_get: {
+        parameters: {
+            query?: {
+                kind?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlogDraftSummary"][];
                 };
             };
             /** @description Validation Error */

--- a/scripts/check_public_bundle_excludes_full.py
+++ b/scripts/check_public_bundle_excludes_full.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Assert the built public bundle contains no full-mode surface's code.
+
+`surface-manifest.json` mode gating is a RUNTIME array filter
+(`visibleSurfaces()` in frontend/src/lib/surfaceManifest.ts). It decides what
+renders; it does not decide what is compiled in. A full-mode component that a
+public-mode page imports statically therefore ships to every user, inert but
+present -- the UI entry point is hidden and the router 404s, so nothing looks
+wrong from outside.
+
+Measured 2026-08-27 on a public build: `blog` rode into the Notes chunk via
+`import { BlogPublishDialog }` in pages/Notes.tsx, and `feynman` into the
+Learning chunk via `import { FeynmanDialog }` in components/reader/
+DocumentReader.tsx. Both files already guarded rendering with
+`isSurfaceVisible(...)`, which is exactly why it went unnoticed.
+
+Routed full-mode pages (admin, monitoring, quality) were already clean: they are
+reached through `lazy(() => import(...))` behind manifest-driven routing, so
+nothing references them in a public build.
+
+The probe is derived from the manifest rather than hand-listed: for every
+full-only router, look for its URL prefix as a string literal in the emitted
+JavaScript. A public bundle has no reason to contain "/blog/" -- if it does,
+that surface's client code was compiled in.
+
+Run AFTER `npm run build` (which defaults to public mode). Wired into `make ci`.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+MANIFEST = REPO / "surface-manifest.json"
+ROUTERS = REPO / "backend" / "app" / "routers"
+DIST = REPO / "frontend" / "dist" / "assets"
+
+_MODE_ORDER = {"public": 0, "full": 1}
+ALWAYS_MOUNTED = {"settings", "setup"}
+
+
+def enabled_routers(data: dict, mode: str) -> set[str]:
+    rank = _MODE_ORDER[mode]
+    out = set(ALWAYS_MOUNTED)
+    for s in data["surfaces"]:
+        if _MODE_ORDER[s["mode"]] <= rank:
+            out.update((s.get("backend") or {}).get("routers", []))
+    return out
+
+
+def router_prefixes() -> dict[str, str]:
+    pat = re.compile(r"""APIRouter\((?:[^)]*?)prefix\s*=\s*["']([^"']+)["']""", re.S)
+    out: dict[str, str] = {}
+    for f in sorted(ROUTERS.glob("*.py")):
+        if f.stem == "__init__":
+            continue
+        m = pat.search(f.read_text())
+        if m:
+            out[f.stem] = m.group(1)
+    return out
+
+
+def main() -> int:
+    if not DIST.is_dir():
+        print(
+            f"ERROR: no build at {DIST}. Run `npm run build` in frontend/ first -- "
+            "this check reads the emitted bundle, not the source.",
+            file=sys.stderr,
+        )
+        return 2
+
+    data = json.loads(MANIFEST.read_text())
+    full_only = enabled_routers(data, "full") - enabled_routers(data, "public")
+    prefixes = router_prefixes()
+
+    chunks = sorted(DIST.glob("*.js"))
+    if not chunks:
+        print(f"ERROR: {DIST} holds no .js chunks; nothing was scanned.", file=sys.stderr)
+        return 2
+    blobs = {p.name: p.read_text(errors="ignore") for p in chunks}
+
+    errors: list[str] = []
+    checked = 0
+    for router in sorted(full_only):
+        prefix = prefixes.get(router)
+        if not prefix:
+            continue
+        # Anchored on a non-path boundary. The manifest is itself bundled and
+        # lists component paths like "components/blog/BlogPublishDialog", so a
+        # bare "/blog/" substring matches that embedded JSON and reports a leak
+        # that is not one -- while skipping any probe the manifest contains
+        # (the first attempt) silently drops `blog`, which is a real leak. An
+        # API path literal is preceded by a quote; a component path by a word
+        # character. Discriminate on that.
+        probe = re.compile(r"(?<![\w/])" + re.escape(prefix) + r"/")
+        checked += 1
+        hits = sorted(name for name, body in blobs.items() if probe.search(body))
+        if hits:
+            errors.append(
+                f"  full-mode surface `{router}`: {prefix + '/'!r} found in {', '.join(hits)}"
+            )
+
+    if errors:
+        print("Public bundle contains full-mode code:", file=sys.stderr)
+        print("\n".join(errors), file=sys.stderr)
+        print(
+            "\nA runtime `isSurfaceVisible()` guard hides the UI but still compiles the\n"
+            "component in. Import it so the mode folds at build time instead:\n"
+            '  const Dlg = LUMINARY_MODE === "full"\n'
+            '    ? lazy(() => import("@/components/..."))\n'
+            "    : null\n"
+            "`LUMINARY_MODE` is a vite `define`, so the false branch and its dynamic\n"
+            "import are dropped from a public build entirely.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"public bundle check OK ({checked} full-only routers probed, {len(chunks)} chunks)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/S244.sh
+++ b/scripts/smoke/S244.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# S244 smoke: GET /blog/drafts lists collected-but-unpublished notes.
+#
+# `blog` is a full-mode surface, so this is a no-op against a public build --
+# the route is not mounted there and the script says so rather than failing.
+set -euo pipefail
+
+BASE="http://localhost:7820"
+
+CT=$(curl -s -o /dev/null -w "%{content_type}" -m 10 "${BASE}/blog/config" || true)
+case "$CT" in
+  application/json*) ;;
+  *)
+    echo "SKIP: S244 -- /blog is not mounted (public mode); nothing to check"
+    exit 0
+    ;;
+esac
+
+for kind in blog thoughts; do
+  BODY=$(curl -sf -m 30 "${BASE}/blog/drafts?kind=${kind}")
+  echo "$BODY" | python3 -c "
+import sys, json
+rows = json.load(sys.stdin)
+assert isinstance(rows, list), f'expected a list, got {type(rows).__name__}'
+for r in rows:
+    for f in ('note_id', 'title', 'slug', 'excerpt'):
+        assert f in r, f'draft row missing {f}: {r}'
+    assert r['slug'], 'slug must be non-empty -- it is the published-or-not key'
+print(f'  ${kind}: {len(rows)} draft(s)')
+" || { echo "FAIL: S244 -- /blog/drafts?kind=${kind} shape wrong"; exit 1; }
+done
+
+# A draft must never duplicate something already on the site: the two listings
+# are keyed on the same slug, so an overlap means the filter stopped working.
+python3 - "$BASE" <<'PY' || exit 1
+import json, sys, urllib.request
+
+base = sys.argv[1]
+def get(path):
+    with urllib.request.urlopen(f"{base}{path}", timeout=30) as r:
+        return json.load(r)
+
+for kind in ("blog", "thoughts"):
+    drafts = {d["slug"] for d in get(f"/blog/drafts?kind={kind}")}
+    posts = {p["slug"] for p in get(f"/blog/posts?kind={kind}")}
+    overlap = drafts & posts
+    assert not overlap, f"{kind}: slug in BOTH drafts and posts: {sorted(overlap)}"
+print("  drafts and published posts are disjoint")
+PY
+
+CODE=$(curl -s -o /dev/null -w "%{http_code}" -m 10 "${BASE}/blog/drafts?kind=wat")
+[ "$CODE" = "422" ] || { echo "FAIL: S244 -- bad kind returned ${CODE}, expected 422"; exit 1; }
+
+echo "PASS: S244 -- /blog/drafts lists unpublished collected notes, disjoint from posts"


### PR DESCRIPTION
Two related changes to the blog/full-mode surfaces, both needed before the next release.

## 1. Public bundles shipped full-mode code

`visibleSurfaces()` is a runtime array filter — it decides what renders, not what
is compiled in. A full-mode component imported statically by a public-mode page
therefore shipped to every user: `blog` in the Notes chunk, `feynman` in
Learning, `pomodoro` in index. All three already guarded rendering with
`isSurfaceVisible()`, which is why nobody noticed.

Each now loads through a dynamic import behind
`import.meta.env.VITE_LUMINARY_MODE === "full"`. That exact expression is
load-bearing: `define` substitutes it textually so Rollup folds the branch and
drops the import. Comparing the exported `LUMINARY_MODE` constant does **not**
fold — it is a function return — and emits a chunk that still ships. Both were
measured.

`scripts/check_public_bundle_excludes_full.py` is the gate, wired into `make ci`
after the frontend build. It derives probes from the manifest rather than a
hand-list: for every full-only router, its URL prefix must not appear in the
emitted bundle.

## 2. The Blog & Thoughts panel could not show what you came to publish

It listed posts already on the site, so a note written for the site was findable
only by remembering which note it was — the publish action lived solely on a chip
on the note card.

`GET /blog/drafts?kind=` returns notes in the matching collection with no post
under their slug; the panel renders them above the published list with a Publish
button. "Already published" is decided by slug through
`blog_service.fallback_title`, the same derivation `POST /blog/draft` uses — the
router's private copy now delegates to it, so the two cannot disagree and leave a
note looking unpublished for ever.

## Verification

- `make ci` green — 3307 passed, bundle check OK (8 full-only routers, 282 chunks).
- The bundle check fails on the old bundle naming all three surfaces, passes on
  the new one; a full build still contains all three.
- `S244` green against a live backend: 4 blog / 3 thoughts drafts, disjoint from
  published posts.
- `test_publishing_a_draft_removes_it_from_the_list` asserts present-then-absent
  in one run.

**Not verified:** the Drafts panel was checked by endpoint output and typecheck,
not rendered in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)