### PR TITLE
release: 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-28
+
 ### Added
+- **The Blog & Thoughts panel lists what you have not published yet.** It showed
+  posts already on your site, so the note you opened it to publish was the one
+  thing it could not show.
 - **`make docker-stop` and `make docker-down`.** There was no way to bring the
   compose stack down; `down` never passes `--volumes`, so the library survives.
 
@@ -27,6 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The docker targets failed with `command not found` when Docker was merely
   not started.** Docker Desktop installs its CLI symlinks only on first
   successful run, so "not on PATH" was never evidence it was missing.
+- **A deleted note could keep coming back from note search.** Keyword search
+  joins the notes table so it could never serve one; semantic search read the
+  vector index directly and had no such join, so a delete that failed silently
+  left the note findable for good.
+- **Public builds shipped code for features they cannot run.** Mode gating hid
+  the buttons but still compiled the components in; a build check now keeps them
+  out.
 
 ## [0.8.0] - 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ will fetch it for you.
 **Simplest: everything in Docker**
 
 No Homebrew, no host Ollama. One command, and the model is pulled for you into
-a Docker volume on first run:
+a Docker volume on first run. Good for trying Luminary; slow for real ingestion
+— see [Running under Docker](#running-under-docker):
 
 ```bash
 git clone https://github.com/nupsea/luminary.git
@@ -305,6 +306,20 @@ but will swap under load.** Ingestion is the peak; answering questions afterward
 sits around 6.5 GB.
 
 ### Running under Docker
+
+> **Run the model outside the container.** Docker on a Mac is CPU-only — no GPU
+> passes through — and the container is already sharing that CPU with the
+> embedder, reranker and entity model. Ingesting a full technical book this way
+> takes a long time and there is no setting that fixes it. Two ways out, either
+> of which moves generation off the VM entirely:
+>
+> - **`make docker-run-host-ollama`** — Ollama on your Mac, app in Docker.
+> - **A hosted model** — set `LITELLM_DEFAULT_MODEL` and its API key in `.env`
+>   beside the compose file, or in Settings. See
+>   [Choosing a model](#choosing-a-model).
+>
+> The all-in-Docker path is the simplest way to *try* Luminary, not the way to
+> run a library through it.
 
 Docker Desktop is a Linux VM. **Every number above is that VM's allowance, not
 your machine's** — it gets a fraction of the host, often half, so a 16 GB Mac

--- a/README.md
+++ b/README.md
@@ -327,6 +327,14 @@ model configuration: ollama/qwen3.5:4b needs 8GB and this machine has 7GB -- it 
 which takes the memory and speed rows off the table. macOS only — on Linux the
 container needs `extra_hosts: host-gateway` to reach the host.
 
+**Stopping.** `make docker-stop` leaves the containers in place for a fast
+restart; `make docker-down` also removes them and the network. Neither touches
+your library — no target here ever passes `--volumes`.
+
+**A stale Docker toolchain is refused up front** rather than hanging mid-build:
+compose needs buildx 0.17.0+, and compose 2.0.0-beta.4 creates a container it
+never starts. Stopping still works whatever the version.
+
 Reclaim disk with `docker builder prune -af` (build cache) and
 `docker image prune -af` (unused images). **Never add `--volumes`** — that
 deletes `luminary-data`, which is your library.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "luminary-backend"
-version = "0.8.0"
+version = "0.9.0"
 description = "Luminary — local-first personal knowledge and learning assistant"
 requires-python = ">=3.13"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1669,7 +1669,7 @@ wheels = [
 
 [[package]]
 name = "luminary-backend"
-version = "0.8.0"
+version = "0.9.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "luminary-desktop"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminary-desktop"
-version = "0.8.0"
+version = "0.9.0"
 description = "Luminary"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminary",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "identifier": "sh.luminary.app",
   "build": {
     "frontendDist": "boot"


### PR DESCRIPTION
Minor, not patch: this carries an `### Added` (the Blog & Thoughts drafts list),
which by convention here has only ever appeared at a minor version.

## What is in it

Since v0.8.0, via #78, #80, #81, #82 and #83:

- Blog & Thoughts panel lists notes you have not published yet
- `make docker-stop` / `make docker-down`
- Deleted notes could keep coming back from note search — fixed
- Public builds no longer ship code for features they cannot run, with a CI gate
- Four Docker lifecycle fixes (stop killed browsers, SIGKILL on shutdown, stale
  toolchain, `command not found` when Docker was merely not started)

## README

- Says plainly that all-in-Docker is too slow to ingest a real book, and names
  the two ways out (host Ollama, or a hosted model). Reported from a real attempt.
- Documents stopping the stack, and that a stale toolchain is refused up front.

## Verification

| check | result |
|---|---|
| `make ci` | green — 3309 passed, bundle check OK |
| `make smoke` | **177 passed, 0 failed** |
| Linux arm64 (ubuntu:24.04, git-archive snapshot) | scripts parse, shellcheck clean, `uv sync --no-default-groups` resolves, public-mode import OK |
| Linux amd64 (`--platform linux/amd64`, confirmed `x86_64`) | same, green |
| Windows | repo's own pwsh gate under real PowerShell 7.4.6: `check_powershell.ps1`, `install.ps1`, generated `start.ps1` all parse. `install.ps1` unchanged since v0.8.0 |
| Docker image | builds at 3.39 GB; container boots, `/api/settings` 200 in 20s, full-mode routers correctly 404, and the shipped bundle contains **0** of 3 full-mode strings across 282 chunks (control string present in 9) |

## Known, not fixed

- `scripts/smoke/S171.sh` (note-to-note links) failed in two of three full-suite
  runs with `POST /notes` → 500, and passed in the third plus standalone and in
  sequence. Not reproducible on demand — graph contention and the preceding
  scripts were both ruled out. Pre-existing; the note-create path is unchanged
  by this release. Worth an issue.
- macOS DMG not built locally; the release workflow builds and notarizes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)