### PR TITLE
release: 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.0] - 2026-08-28
+## [0.8.2] - 2026-08-28
 
 ### Added
 - **The Blog & Thoughts panel lists what you have not published yet.** It showed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "luminary-backend"
-version = "0.9.0"
+version = "0.8.2"
 description = "Luminary — local-first personal knowledge and learning assistant"
 requires-python = ">=3.13"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1669,7 +1669,7 @@ wheels = [
 
 [[package]]
 name = "luminary-backend"
-version = "0.9.0"
+version = "0.8.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.9.0",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.9.0",
+      "version": "0.8.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "luminary-desktop"
-version = "0.9.0"
+version = "0.8.2"
 dependencies = [
  "chrono",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminary-desktop"
-version = "0.9.0"
+version = "0.8.2"
 description = "Luminary"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminary",
-  "version": "0.9.0",
+  "version": "0.8.2",
   "identifier": "sh.luminary.app",
   "build": {
     "frontendDist": "boot"


### PR DESCRIPTION
Patch on the current minor. (An earlier attempt tagged this work 0.9.0 on
changelog convention; that tag and release were deleted — 0 downloads, DMG build
cancelled — and the version number is the user's call, not the convention's.)

## What is in it

Since v0.8.0, via #78, #80, #81, #82, #83 and #85:

- Blog & Thoughts panel lists notes you have not published yet
- `make docker-stop` / `make docker-down`
- Deleted notes could keep coming back from note search — fixed
- Public builds no longer ship code for features they cannot run, with a CI gate
- Four Docker lifecycle fixes (stop killed browsers, SIGKILL on shutdown, stale
  toolchain, `command not found` when Docker was merely not started)

## README

- Says plainly that all-in-Docker is too slow to ingest a real book, and names
  the two ways out — host Ollama, or a hosted model. Reported from a real attempt
  at a SQL book.
- Documents stopping the stack, and that a stale toolchain is refused up front.

## Verification

| check | result |
|---|---|
| `make ci` | green — 3309 passed, bundle check OK |
| `make smoke` | 177 passed, 0 failed |
| Linux arm64 + amd64 (ubuntu:24.04, git-archive snapshot) | scripts parse, shellcheck clean, `uv sync --no-default-groups` resolves, public-mode import OK on both |
| Windows | repo's pwsh gate under real PowerShell 7.4.6 — `install.ps1` and the generated `start.ps1` parse; unchanged since v0.8.0 |
| Docker image | 3.39 GB; container boots, `/api/settings` 200 in 20s, full-mode routers 404, shipped bundle contains 0 of 3 full-mode strings across 282 chunks (control present in 9) |

## Known, not fixed

- `scripts/smoke/S171.sh` failed in two of three full-suite runs with
  `POST /notes` → 500, passed in the third and standalone. Not reproducible on
  demand; graph contention and the preceding scripts were ruled out. Pre-existing.
- macOS DMG not built locally; the release workflow builds and notarizes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)