### PR TITLE
feat(evals): note search had no eval; now it has one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,6 +417,14 @@ eval-intent:
 	uv run --project $(CURDIR)/backend python evals/run_intent_eval.py \
 		--dataset intents_adversarial --backend-url $(BACKEND_URL) --llm-fallback
 
+# Note search: does /notes/search find the note, and only the note. No golden --
+# queries are derived from whatever notes the machine has, so the numbers are
+# corpus-coupled and comparable only against your own previous run.
+eval-notes:
+	@echo "Note search eval (backend must be running)..."
+	uv run --project $(CURDIR)/backend python evals/run_note_search_eval.py \
+		--backend-url $(BACKEND_URL) --assert-thresholds
+
 # Ingestion fidelity: how much of each source document survives into chunks.
 # Deterministic, LLM-free, no backend needed -- it reads the dev database directly.
 # Retrieval scores what was indexed and cannot report what never arrived, so this

--- a/docs/eval-coverage.md
+++ b/docs/eval-coverage.md
@@ -179,6 +179,40 @@ to guess when it cannot read it; `--no-rerank` measures the ablation and says so
 and floors recorded before 2026-08-26 are the unreranked funnel and are not comparable to later
 ones.
 
+## Note search
+
+`make eval-notes` (`evals/run_note_search_eval.py`). Note search had no eval at all until
+2026-08-28, which mattered because it is the surface 0.8.2 changed most — a liveness join
+against `notes` and a cosine floor on the semantic arm both alter what comes back.
+
+**It carries no golden, deliberately.** The corpus is the user's own notes, so a committed
+golden would measure one machine's library and nothing else. Queries are derived from whatever
+notes exist. The cost is that the recall numbers are corpus-coupled: compare a change against
+your own previous run on an unchanged library, never against the floor.
+
+| metric | measured 2026-08-28 | gate | what it catches |
+|---|---|---|---|
+| `self_recall_1` | 0.9000 | floor 0.70 | the funnel stops finding a note by its own words |
+| `self_recall_5` | 1.0000 | **none** | saturated — a self-query is answerable by the keyword arm alone |
+| `ghost_rate` | 0.0000 | ceiling 0.0 | deleted content being served; the only real invariant here |
+| `vector_share` | 0.7563 | floor 0.20 | the semantic arm going silent |
+| `noise_rejection` | 1.0000 | floor 0.75 | the similarity floor missing, so everything matches everything |
+
+Measured against a 125-note library, 40 sampled at seed 42, 119 result slots; bit-reproducible
+across re-runs.
+
+**`self_recall_5` is reported and not gated.** It saturates: the query is a phrase from the
+note's own body, so the keyword arm answers it without the semantic arm doing anything. Quote it
+only when it drops.
+
+**`vector_share` is the one that earns its place.** Raise `NOTE_SEMANTIC_MIN_SIMILARITY` too far
+and the semantic arm stops contributing while every other metric here stays green — the keyword
+arm alone still answers a self-query. That failure is invisible without this number.
+
+**Still not measured:** paraphrase recall. Nothing here scores a query that shares no words with
+the note it should find, which is the case the semantic arm exists for; the floor is bracketed by
+two measured cases (0.5004 drop, 0.7516 keep) but that justifies a threshold, not a quality bar.
+
 **Check the stage before attributing a change.** A retrieval regression can come from ingestion;
 a generation regression can come from retrieval. `eval-ingest` first, then `eval`, then
 `eval-gen` — in that order, because each is the ceiling on the next.

--- a/evals/run_note_search_eval.py
+++ b/evals/run_note_search_eval.py
@@ -1,0 +1,244 @@
+"""Note search eval: does /notes/search find the note, and only the note.
+
+Note search had no eval at all until 2026-08-28, which mattered because it is the
+surface that changed most in 0.8.2 -- a liveness join against `notes` and a
+cosine floor on the semantic arm, both of which alter what comes back.
+
+**This eval has no committed golden, by design.** The corpus is the user's own
+notes; a golden written against one machine's library measures nothing on
+another. Queries are derived from whatever notes exist, so the eval runs
+anywhere. The cost is that `self_recall_*` is corpus-dependent and its floor is a
+collapse detector only -- compare a change against your own previous run on an
+unchanged library, never against the floor (see docs/eval-coverage.md).
+
+Metrics, reported separately because they move independently:
+
+  self_recall_1   the note ranks FIRST for a phrase taken from its own body
+  self_recall_5   ... or anywhere in the top 5. SATURATES at 1.0000 on a healthy
+                  library and is NOT gated: a query built from the note's own
+                  words is answerable by the keyword arm alone, so this is a
+                  floor with no headroom, quotable only when it drops.
+  ghost_rate      results whose note no longer exists in `notes`. The keyword arm
+                  joins that table so it cannot produce one; the semantic arm
+                  reads LanceDB directly and did, for any note whose vector
+                  delete failed. Must be 0.0 on every corpus -- the one metric
+                  here that is a real invariant rather than a corpus property.
+  vector_share    fraction of result slots contributed by the semantic arm.
+                  The collapse detector for NOTE_SEMANTIC_MIN_SIMILARITY: set it
+                  too high and the arm goes silent while every other number here
+                  stays green, because the keyword arm alone still answers a
+                  self-query.
+  noise_rejection fraction of deliberately alien queries returning nothing.
+                  Before the floor existed, `limit(k)` had no distance bound, so
+                  in a library smaller than k EVERY query returned the k nearest
+                  notes however unrelated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from evals.lib.environment import capture as capture_environment  # noqa: E402
+from evals.lib.scoring_history import append_history  # noqa: E402
+
+# Floors are collapse detectors, not quality bars.
+#
+# Baselines measured 2026-08-28 by THIS script against a 125-note library
+# (40 sampled, seed 42; 119 result slots), bit-reproducible across re-runs:
+#   self_recall_1   0.9000      self_recall_5   1.0000
+#   ghost_rate      0.0000      vector_share    0.7563
+#   noise_rejection 1.0000
+# They are corpus-coupled: these hold for THIS library and are not portable.
+# Compare a change against your own previous run, never against the floor.
+#
+# ghost_rate is 0.0 exactly and stays there: a non-zero value means deleted
+# content is being served, which is never acceptable on any corpus.
+#
+# self_recall_1's floor is 0.70 against a measured 0.9250 -- the subtrahend is
+# headroom for corpus variation, since a library of short or near-duplicate notes
+# legitimately scores lower. Bracketing it: 0.90 would fail on a library only
+# slightly noisier than this one, and 0.50 would not notice the keyword arm dying.
+#
+# vector_share's floor is 0.20 against a measured 0.7563. It exists to catch the
+# similarity floor being raised until the semantic arm stops contributing; that
+# failure leaves every other metric green.
+# Split by direction rather than inferred per key: ghost_rate is a CEILING and
+# the rest are FLOORS, and a single dict made the comparison implicit -- the first
+# version of this file got the operator wrong for exactly that reason.
+FLOORS = {
+    "self_recall_1": 0.70,
+    "vector_share": 0.20,
+    "noise_rejection": 0.75,
+}
+CEILINGS = {
+    "ghost_rate": 0.0,
+}
+
+# Deliberately alien to any learning library: domain-specific and mundane. Not
+# nonsense strings -- those are trivially far from everything in embedding space,
+# which would make the metric pass without the floor doing any work.
+NOISE_QUERIES = [
+    "quarterly VAT reconciliation for a Belgian subsidiary",
+    "how to descale a Gaggia espresso machine",
+    "flight LH440 checked baggage allowance",
+    "sourdough starter hydration ratio by weight",
+    "replacing the timing belt on a 2011 Ford Focus",
+]
+
+_STOP = frozenset([
+    "the", "a", "an", "and", "or", "but", "of", "to", "in", "for", "with", "that", "this",
+    "it", "is", "are", "was", "were", "be", "as", "at", "by", "from", "on", "not", "you",
+    "your", "we", "our", "they", "their", "he", "she", "his", "her", "its", "if", "then",
+    "than", "so", "what", "which", "who", "when", "where", "how", "can", "will", "would",
+    "should", "there", "here", "them", "these", "those", "has", "have", "had"
+])
+
+
+def _distinctive_phrase(content: str, words_wanted: int = 6) -> str | None:
+    """A phrase from the middle of the note, stopwords removed.
+
+    From the middle rather than the start because a note's first line is usually
+    its title, which is also what the vector arm indexes most strongly -- taking
+    the opening would make the query easier than a real one.
+    """
+    words = [w for w in re.findall(r"[A-Za-z][A-Za-z'-]+", content) if w.lower() not in _STOP]
+    if len(words) < words_wanted:
+        return None
+    start = len(words) // 3
+    return " ".join(words[start : start + words_wanted])
+
+
+def _search(backend_url: str, query: str, k: int) -> list[dict]:
+    resp = httpx.get(
+        f"{backend_url}/notes/search", params={"q": query, "k": k}, timeout=120.0
+    )
+    resp.raise_for_status()
+    return resp.json()["results"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the note search eval.")
+    parser.add_argument("--backend-url", default="http://localhost:7820")
+    parser.add_argument("--db", default=str(REPO_ROOT / ".luminary" / "luminary.db"))
+    parser.add_argument("--sample", type=int, default=40)
+    parser.add_argument("--assert-thresholds", action="store_true")
+    args = parser.parse_args()
+
+    db_path = Path(args.db)
+    if not db_path.is_file():
+        print(f"ERROR: no database at {db_path}.", file=sys.stderr)
+        sys.exit(2)
+
+    db = sqlite3.connect(db_path)
+    total_notes = db.execute("SELECT COUNT(*) FROM notes").fetchone()[0]
+    rows = db.execute(
+        "SELECT id, content FROM notes WHERE length(content) > 200"
+    ).fetchall()
+    live_ids = {r[0] for r in db.execute("SELECT id FROM notes")}
+
+    # Requested but not computable is a failure, never a quiet pass: a library
+    # this small cannot resolve a rate at all, and reporting one would invent it.
+    if len(rows) < 10:
+        print(
+            f"ERROR: only {len(rows)} notes over 200 chars in {db_path}; this eval "
+            "needs at least 10 to produce a rate that means anything. Nothing was "
+            "measured -- this is a failure, not a pass.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    random.Random(42).shuffle(rows)  # noqa: S311 -- sampling, not cryptography
+    rows = rows[: args.sample]
+
+    hit1 = hit5 = 0
+    scored = 0
+    slots = 0
+    vector_slots = 0
+    ghosts = 0
+    for note_id, content in rows:
+        query = _distinctive_phrase(content)
+        if query is None:
+            continue
+        scored += 1
+        results = _search(args.backend_url, query, 5)
+        ids = [r["note_id"] for r in results]
+        for r in results:
+            slots += 1
+            if r["source"] in ("vector", "both"):
+                vector_slots += 1
+            if r["note_id"] not in live_ids:
+                ghosts += 1
+        if ids and ids[0] == note_id:
+            hit1 += 1
+        if note_id in ids:
+            hit5 += 1
+
+    if scored == 0:
+        print("ERROR: no note yielded a usable query; nothing measured.", file=sys.stderr)
+        sys.exit(2)
+
+    rejected = sum(1 for q in NOISE_QUERIES if not _search(args.backend_url, q, 10))
+
+    metrics = {
+        "self_recall_1": hit1 / scored,
+        "self_recall_5": hit5 / scored,
+        "ghost_rate": ghosts / slots if slots else 0.0,
+        "vector_share": vector_slots / slots if slots else 0.0,
+        "noise_rejection": rejected / len(NOISE_QUERIES),
+        "notes_scored": scored,
+        "result_slots": slots,
+        "library_notes": total_notes,
+    }
+
+    violations: list[str] = []
+    for key, floor in FLOORS.items():
+        if metrics[key] < floor:
+            violations.append(f"{key} {metrics[key]:.4f} < {floor}")
+    for key, ceiling in CEILINGS.items():
+        if metrics[key] > ceiling:
+            violations.append(f"{key} {metrics[key]:.4f} > {ceiling}")
+    passed = not violations
+
+    print(f"\n{'=' * 58}")
+    print("  Note search evaluation")
+    print(f"{'=' * 58}")
+    for key in ("self_recall_1", "self_recall_5", "ghost_rate", "vector_share", "noise_rejection"):
+        if key in FLOORS:
+            mark = f"   (floor {FLOORS[key]})"
+        elif key in CEILINGS:
+            mark = f"   (ceiling {CEILINGS[key]})"
+        else:
+            mark = ""
+        print(f"  {key:<18} {metrics[key]:.4f}{mark}")
+    print(f"  {'self_recall_5':<18} is not gated -- it saturates; read it only when it drops")
+    print(f"{'-' * 58}")
+    print(f"  scored {scored} notes / {slots} result slots, library has {total_notes} notes")
+    print(f"{'=' * 58}\n")
+
+    append_history(
+        "notes_live",
+        "note-search",
+        metrics,
+        passed,
+        eval_kind="note_search",
+        environment=capture_environment(args.backend_url),
+    )
+
+    if args.assert_thresholds and violations:
+        print("QUALITY GATE FAILED: " + "; ".join(violations), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Note search is the surface 0.8.2 changed most — a liveness join against `notes`
and a cosine floor on the semantic arm — and nothing measured it. This closes
that hole.

## No golden, deliberately

The corpus is the user's own notes, so a committed golden would measure one
machine's library and nothing else. Queries are derived from whatever notes
exist, so the eval runs anywhere. The cost is that recall is corpus-coupled:
compare against your own previous run on an unchanged library, never the floor.

## Metrics

Measured 2026-08-28 on a 125-note library (40 sampled, seed 42, 119 result
slots), bit-reproducible across re-runs:

| metric | measured | gate | catches |
|---|---|---|---|
| `self_recall_1` | 0.9000 | floor 0.70 | the funnel stops finding a note by its own words |
| `self_recall_5` | 1.0000 | **none** | saturated — see below |
| `ghost_rate` | 0.0000 | ceiling 0.0 | deleted content being served |
| `vector_share` | 0.7563 | floor 0.20 | the semantic arm going silent |
| `noise_rejection` | 1.0000 | floor 0.75 | the similarity floor missing |

**`self_recall_5` is reported and not gated.** It cannot move upward — the query
is a phrase from the note's own body, which the keyword arm answers without the
semantic arm doing anything. A metric with no headroom is not evidence, so it is
printed with that said out loud rather than counted as a pass.

**`vector_share` is the one that earns its place.** Raise
`NOTE_SEMANTIC_MIN_SIMILARITY` too far and the semantic arm stops contributing
while every other metric here stays green. That failure is invisible without it.

`noise_rejection` uses mundane domain-specific queries (VAT reconciliation,
descaling an espresso machine), not nonsense strings — nonsense is trivially far
from everything in embedding space and would pass without the floor doing work.

## Verification

- Gate fired on purpose: floor at 0.99 exits 1 with
  `QUALITY GATE FAILED: self_recall_1 0.9000 < 0.99`.
- A library too small to resolve a rate exits 2 rather than reporting one —
  requested-but-uncomputed is a failure, not a pass.
- Three consecutive runs identical.
- `make ci` green (3309 passed).

Floors and ceilings are separate dicts. One dict made the comparison direction
implicit and the first version of this file got the operator wrong for
`ghost_rate`, which is the metric that must never be a floor.

## Not measured

Paraphrase recall. No query here shares zero words with the note it should find,
which is exactly the case the semantic arm exists for. The floor is bracketed by
two measured cases (0.5004 drop / 0.7516 keep) — that justifies a threshold, not
a quality bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)