### PR TITLE
docs(readme): group the hardware reference; fix host-Ollama on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,16 @@ cannot see the host's `PATH`.
 > First launch is slow because it downloads ML models. Every launcher polls the
 > server and prints `Luminary is ready` only when it is. Background `Warmup:` log
 > lines after that are normal.
+## Running it on real hardware
 
-## How much memory it actually needs
+Everything below is reference. Skip it unless something feels slow or the app
+warns you about memory — the defaults are sized for the machine you are on.
+
+**On a Mac under Docker, expect ingestion to be slow.** No GPU passes through;
+run the model outside the container instead. The Docker section has both ways.
+
+<details>
+<summary><b>How much memory it actually needs</b></summary>
 
 Measured, not estimated — every figure below was read off a running instance.
 
@@ -304,6 +312,7 @@ Measured, not estimated — every figure below was read off a running instance.
 **Give Luminary 12 GB to work with, and treat 8 GB as the floor where it runs
 but will swap under load.** Ingestion is the peak; answering questions afterwards
 sits around 6.5 GB.
+</details>
 
 ### Running under Docker
 
@@ -338,9 +347,10 @@ model configuration: ollama/qwen3.5:4b needs 8GB and this machine has 7GB -- it 
 | **Model** | Pulled into a Docker volume on first run by the `--profile ai` sidecar |
 | **Secrets** | A container has no OS keyring, so a cloud API key saved in Settings is stored in the database as plain text — readable by anyone who can read the `luminary-data` volume. Put it in `.env` beside the compose file instead |
 
-`make docker-run-host-ollama` runs the model on your Mac instead of in the VM,
-which takes the memory and speed rows off the table. macOS only — on Linux the
-container needs `extra_hosts: host-gateway` to reach the host.
+`make docker-run-host-ollama` runs the model on your machine instead of in the
+VM, which takes the memory and speed rows off the table. The compose file maps
+`host.docker.internal` to the host gateway, so this works on Linux as well as
+Docker Desktop.
 
 **Stopping.** `make docker-stop` leaves the containers in place for a fast
 restart; `make docker-down` also removes them and the network. Neither touches
@@ -354,17 +364,8 @@ Reclaim disk with `docker builder prune -af` (build cache) and
 `docker image prune -af` (unused images). **Never add `--volumes`** — that
 deletes `luminary-data`, which is your library.
 
-### Runtime bounds
-
-Two runtime bounds ship set, because Ollama's own defaults are not sized for a
-laptop: the model stays resident for 30 minutes rather than Ollama's 5, and
-llama.cpp's prompt cache is capped at 512 MB rather than its default 8192 MB —
-which is more than a default Docker VM has in total. Override either with
-`OLLAMA_KEEP_ALIVE` and `LLAMA_ARG_CACHE_RAM`. On a native macOS or Linux
-install the Ollama server is yours, not ours, so set them there (`launchctl
-setenv`, or your systemd unit) if you want them changed.
-
-### When the first question after a break is slow
+<details>
+<summary><b>Why the first question after a break is slow, and what is already done about it</b></summary>
 
 On a host without GPU acceleration, loading the model is the single largest
 thing a question can wait on. Measured on an Intel i7-8850H in a 12 GB Docker
@@ -395,7 +396,14 @@ abandoned and the ready-made suggestions are shown instead — the question gets
 the machine. Where suggestions are quick they finish first and nothing is
 abandoned.
 
----
+**Two runtime bounds ship set.** Ollama's own defaults are not sized for a
+laptop: the model stays resident for 30 minutes rather than Ollama's 5, and
+llama.cpp's prompt cache is capped at 512 MB rather than its default 8192 MB —
+which is more than a default Docker VM has in total. Override either with
+`OLLAMA_KEEP_ALIVE` and `LLAMA_ARG_CACHE_RAM`. On a native macOS or Linux
+install the Ollama server is yours, not ours, so set them there (`launchctl
+setenv`, or your systemd unit) if you want them changed.
+</details>
 
 ## Choosing a model
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,13 @@ services:
       - "127.0.0.1:7820:7820"
     volumes:
       - luminary-data:/data
+    # `make docker-run-host-ollama` points OLLAMA_URL at host.docker.internal.
+    # Docker Desktop resolves that name for free; plain Linux does not, so the
+    # host-Ollama path failed there with a DNS error while working on a Mac.
+    # host-gateway is a no-op where the name already resolves, so this costs the
+    # Desktop path nothing and makes the Linux one work.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     # A ceiling, not a wait: compose stops as soon as the process exits. Shutdown
     # is variable -- 10.8s settled, 17s during warmup, over 30s when it lands
     # while a model is loading, because the process blocks on an uncancellable

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -207,6 +207,26 @@ articles; the ninth returned 0 images statically against 78 rendered.
 Windows (#24) and Linux need their own shell before rendering follows. Canvas-drawn figures are
 not covered on any platform: they need an element screenshot, not a DOM capture.
 
+### 9. Two behaviours that ship without a measurement
+
+Both are opt-out-able, both change what a user receives, and neither has a number attached.
+
+- **The slow-host context budget.** Where the start-up probe measures local inference expensive,
+  `resolve_context_budget()` narrows the synthesis budget from 1500 to 750 tokens
+  (`config.py`, `QA_CONTEXT_TOKEN_BUDGET_SLOW_HOST`). The latency it buys is measured
+  (~56s → ~29s prefill at 31 tok/s) and the passages it costs are measured (roughly half), but
+  **the answer-quality cost is not** — the constant says so itself. It engages automatically
+  above a 20s probe, so the hosts that get it are the ones least able to spare quality. Measure
+  with `QA_CONTEXT_TOKEN_BUDGET=750` and a `study --generate` run before treating it as a
+  shipped default rather than a rescue for hosts that are unusable without it.
+
+- **Paraphrase recall in note search.** `make eval-notes` gates `self_recall_1`, `ghost_rate`,
+  `vector_share` and `noise_rejection`, but every query it builds shares words with the note it
+  should find. Nothing scores the case the semantic arm exists for: a query with no lexical
+  overlap. `NOTE_SEMANTIC_MIN_SIMILARITY = 0.62` is bracketed by two measured cases (0.5004
+  drop, 0.7516 keep), which justifies the threshold and does not measure the axis. `vector_share`
+  catches the arm dying, not the arm getting worse.
+
 ## Deferred — decided, not scheduled
 
 Nothing currently deferred.


### PR DESCRIPTION
## README

Memory, Docker, runtime bounds and "why the first question is slow" were four
headings on one topic, ~110 fully expanded lines sitting between the install
paths and everything else. They are now a single **Running it on real hardware**
section that opens by telling you to skip it, with the memory table and the
model-residency material behind disclosures, and runtime bounds folded into the
slow-answer block — same subject, two headings.

Linear read (before expanding anything): **~330 → 220 lines**. All 10
`<details>`/`<summary>` pairs balanced, all 7 internal anchors resolve.

`### Running under Docker` deliberately stays expanded: three links point at that
anchor and a heading inside a collapsed block is not reliably reachable.

## Linux host-Ollama

`docker-compose.yml` now maps `host.docker.internal` to `host-gateway`. Docker
Desktop resolves that name for free; plain Linux does not, so
`make docker-run-host-ollama` failed there with a DNS error while working on a
Mac. The mapping is a no-op where the name already resolves, so the Desktop path
is unaffected. Verified with `docker compose --profile ai config`.

The README previously said Linux needed this; now it has it, and the text says so.

## Roadmap

Records the two behaviours that ship without a measurement — the slow-host
context budget's answer-quality cost, and paraphrase recall in note search.
Neither is new; neither was written down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)