### PR TITLE
release: 0.8.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.24] - 2026-08-28
+
 ### Fixed
 - **A 128-page book extracted 81 "figures", 79 of them pages of body text.**
   PDFs generated from reflowable sources carry one fill rectangle spanning the

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "luminary-backend"
-version = "0.8.2"
+version = "0.8.24"
 description = "Luminary — local-first personal knowledge and learning assistant"
 requires-python = ">=3.13"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1669,7 +1669,7 @@ wheels = [
 
 [[package]]
 name = "luminary-backend"
-version = "0.8.2"
+version = "0.8.24"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.8.2",
+  "version": "0.8.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.8.2",
+      "version": "0.8.24",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.8.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "luminary-desktop"
-version = "0.8.2"
+version = "0.8.24"
 dependencies = [
  "chrono",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminary-desktop"
-version = "0.8.2"
+version = "0.8.24"
 description = "Luminary"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminary",
-  "version": "0.8.2",
+  "version": "0.8.24",
   "identifier": "sh.luminary.app",
   "build": {
     "frontendDist": "boot"


### PR DESCRIPTION
Version bump only — no code changes. Diff is the eight files a release commit touches here.

Carries into the release:

- **PDF over-extraction (I-38).** A drawing primitive larger than its page is a container from
  a reflowable source, and the measurement has to happen before the clip. One 128-page book
  went from 81 "figures" (79 of them pages of body text) to 2, and from a 34-minute failure to
  143s.
- **A degraded extraction pass no longer retires anything.** The extractors log-and-skip an
  object they cannot read, so a partial pass looked identical to "no longer produced" and
  deleted stored figures, their files, their vectors and their descriptions.
- **Vision ceiling follows the host measurement (I-37)**, never a platform check.
- **The Intel Mac CI image can run the suite**, and no longer inherits the developer's
  `.luminary` model cache or virtualenvs.
- **`DEEP_DIVE.md` corrected** against the code: eval floors were quoted at 0.60/0.45/0.65
  against actual 0.50/0.35/0.30, nDCG@10 was called a gate when it is report-only, and
  performance SLOs were called "enforced in CI" when all are `@pytest.mark.slow`.

## Verified

- `make ci` on this exact tree: green, exit 0 (3306 backend passed in the Docker path, 695
  frontend).
- Version consistent across `pyproject.toml`, `package.json`, `Cargo.toml`, `tauri.conf.json`
  and the three lockfiles.

**Not run:** `make eval` and `make smoke` — no wire contract or retrieval path changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)