### PR TITLE
docs(readme): no install path said how to update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The README had no updating section.** Four install paths, no statement of how
+  to update any of them, and the Docker one is easy to get wrong (`make
+  docker-run` already passes `--build`). `make dev`, `make clean`, `make logs`,
+  `make eval` and `make docker-build` were also missing from the command table.
+- **A TODO pointed at a doc that does not exist** and at work already done: the
+  OS-keychain migration shipped in `settings_service`. Replaced with what is
+  actually load-bearing — the generic `PATCH /settings` bypasses the keyring, so
+  secrets must go through `PATCH /settings/llm`.
+
 ## [0.8.24] - 2026-08-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -287,6 +287,32 @@ cannot see the host's `PATH`.
 > First launch is slow because it downloads ML models. Every launcher polls the
 > server and prints `Luminary is ready` only when it is. Background `Warmup:` log
 > lines after that are normal.
+
+## Updating
+
+**Your library is never touched by an update.** It lives at `~/.luminary` (or
+`~/Library/Application Support/sh.luminary.app` for the bundled app), outside
+whatever the update replaces. Schema changes are applied by migrations when the
+server next boots.
+
+| How you installed | How you update |
+|---|---|
+| One-command script (`bootstrap.sh`) | `luminary update` — re-runs the installer against the latest release |
+| DMG | Download the new DMG and replace the app |
+| From source | `git pull && make install` — `install.sh` is idempotent |
+| Docker | `git pull && make docker-run` — it passes `--build`, so this rebuilds |
+
+`luminary update` resolves the newest **published release**, not `master`, and
+verifies the download against the release's `.sha256` before replacing anything.
+It stages the download and swaps it in, so an interrupted update cannot leave a
+half-replaced install behind. Pin a specific version with
+`LUMINARY_VERSION=0.8.24`.
+
+Under Docker, `make docker-run` already passes `--build`, so it rebuilds the
+image and recreates the containers in one step — `make docker-build` is only for
+building without starting. Neither stop target passes `--volumes`, so your
+library survives `make docker-down`.
+
 ## Running it on real hardware
 
 Everything below is reference. Skip it unless something feels slow or the app
@@ -582,13 +608,18 @@ frontend/src/
 | `make install` | One-time setup (uv, Node, Ollama, models, build) |
 | `make start` | Public-mode server on :7820 |
 | `make luminary` | Backend + frontend in full mode (:7820 + :5173) |
+| `make dev` | Backend with `--reload` + frontend dev server, for editing code |
 | `make stop` | Stop Luminary on :7820, gracefully (also stops the container when it serves the port) |
+| `make clean` | Free :7820, :5173 and :5174 — listeners only, SIGTERM first |
+| `make logs` | Backend + frontend with colorized, prefixed output in one terminal |
 | `make test` | Backend unit + integration tests |
 | `make lint` | Ruff + tsc + eslint + manifest checks |
 | `make ci` | **The gate.** Lint, layer check, tests, build, tsc, eslint, vitest |
 | `make smoke` | ~180 HTTP contract scripts against a running backend |
+| `make eval` | Retrieval quality against committed floors; needs a running backend |
 | `make db-migrate` | Apply pending migrations (the server also does this on boot) |
 | `make db-revision m="..."` | Generate a migration after changing `models.py` |
+| `make docker-build` | Build the image (`WITH_MEDIA=1` adds ffmpeg and the transcriber) |
 | `make docker-run` | Run via Docker Compose (with Ollama sidecar) |
 | `make docker-stop` | Stop the compose stack, containers kept for a fast restart |
 | `make docker-down` | Stop and remove containers and network; **volumes, i.e. your library, are kept** |

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -560,7 +560,10 @@ async def patch_settings(
     request: SettingsUpdate,
     session: AsyncSession = Depends(get_db),
 ) -> dict:
-    # TODO: migrate to OS keychain — see tech-debt-tracker.md
+    # Writes straight to SettingsModel, so it does NOT reach the OS keyring.
+    # Secrets must go through PATCH /settings/llm, which routes them via
+    # settings_service (keyring where there is one, `__plain__:` in a container).
+    # Never add an API key to whatever calls this.
     updates = request.root
     for key, value in updates.items():
         setting = SettingsModel(key=key, value=value)


### PR DESCRIPTION
## Updating

Four documented install paths, none of them saying how to move to a new version. Added a
table covering all four, and what `luminary update` actually does.

**Verified end to end against v0.8.24**, rather than read:

```
resolved latest = 0.8.24
luminary-0.8.24-macos.tar.gz: OK            # sha256 checked
payload contains luminary-0.8.24/backend/app/main.py    # the file bootstrap.sh asserts on
```

It resolves the newest *published release*, not `master` — only the bootstrap script itself
is fetched from master. `release.yml`'s asset names match what `bootstrap.sh` expects, the
checksum is verified before anything is replaced, and the download is staged then swapped so
an interrupted update cannot leave a half-replaced install. `install.sh` is idempotent, so
`git pull && make install` is the source path. No Tauri updater is configured, so the DMG
does need a manual replace.

The Docker row is the one worth getting right: `make docker-run` already passes `--build`,
so a separate `make docker-build` step is redundant. I had written it the wrong way first.

## Command coverage

`make dev`, `make clean`, `make logs`, `make eval` and `make docker-build` were missing from
the reference table. Found by diffing all 73 Makefile targets against the README; the other
omissions are internal (`stage-*`, `golden-*`, eval variants) and stay out. `make logs`
starts both servers with prefixed output — it does not tail a log, which is what I assumed
before checking.

## The one TODO in the tree

`main.py:563` pointed at `tech-debt-tracker.md`, which does not exist, for work already
done — the OS-keychain migration shipped in `settings_service`.

Checked whether it was hiding a real defect, since `patch_settings` writes straight to
`SettingsModel` and bypasses the keyring: it is not. API keys go through
`PATCH /settings/llm`, which is keyring-aware, and `SettingsDrawer` uses that path. Replaced
the dangling TODO with the directive that is load-bearing — never route a secret through the
generic endpoint. No TODO or FIXME markers remain anywhere in the tree.

## Testing

`make ci` green, exit 0. Docs and comments only; no behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)