### PR TITLE
release: 0.8.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Re-uploading a document you already have looked like it did nothing.**
+  Ingestion dedupes on file hash, but the endpoint answered `"processing"` for a
+  copy that was already complete — so the client tracked a document that would
+  never move and no progress ever appeared. It now answers `"duplicate"`, and
+  the upload dialog says the document is already in your library.
 - **A library card could say a document was finished while its enrichment was
   still running.** The badge reported one job — image_analyze, else
   image_extract, else the newest — not the document. Six job types exist, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A library card could say a document was finished while its enrichment was
+  still running.** The badge reported one job — image_analyze, else
+  image_extract, else the newest — not the document. Six job types exist, so a
+  document whose image work had finished read "Analysis complete" while its
+  concept_link was still queued, contradicting the enrichment pill on the same
+  screen. It now aggregates over every job for the document.
+- **The enrichment and ingestion overlays covered the nav rail.** Both sat at
+  `left-5` while the rail is 72px wide and always rendered, so they hid the
+  streak widget, the dev icons and the settings controls.
+- **The README did not say what an Intel Mac should actually do.** Both documented
+  Docker topologies run generation on a CPU with no GPU (~6 tok/s, ~121s a
+  question), and neither the install section nor the platform table suggested
+  the hosted-model option that fixes it. Says so now, with the privacy trade
+  stated.
+- **Figures were missing from the feature table** despite being extracted,
+  described by a vision model and fed into answers — and being the one genuinely
+  expensive part of ingest.
+- **`eval-coverage.md` claimed `make smoke` runs ~230 scripts.** It runs 178.
+  The note-search eval was also missing from the coverage table.
 - **The README had no updating section.** Four install paths, no statement of how
   to update any of them, and the Docker one is easy to get wrong (`make
   docker-run` already passes `--build`). `make dev`, `make clean`, `make logs`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.28] - 2026-08-28
+
 ### Fixed
 - **Re-uploading a document you already have looked like it did nothing.**
   Ingestion dedupes on file hash, but the endpoint answered `"processing"` for a

--- a/README.md
+++ b/README.md
@@ -96,10 +96,16 @@ machine**, and it will not even offer you a cloud model.
 | **Study** | Regular, cloze and code-trace cards; FSRS scheduling; three-phase sessions; prediction calibration |
 | **Notes** | Markdown editor with live preview, wiki-links, backlinks, Mermaid and Excalidraw |
 | **Track** | Mastery rings per document, "what's about to slip", study activity, time on task |
+| **Figures** | Diagrams and charts pulled out of PDFs and described by a vision model, so an answer can draw on them |
 | **Export** | Markdown vault (Obsidian-compatible), Anki `.apkg`, flashcard CSV |
 
 The Hub is the daily entry point: it picks the one thing most worth doing now —
 review what is due, carry on reading, or write something down.
+
+Figure descriptions are the one genuinely expensive part of ingest — one vision
+call per figure — so on a CPU-only host a heavily illustrated PDF takes a while
+to finish enriching. The document is readable and searchable before that
+finishes, and `PDF_VECTOR_FIGURES=false` turns the fallback off.
 
 ---
 
@@ -261,6 +267,29 @@ make docker-run
 
 Either way, open http://localhost:7820. First run pulls a ~3.4 GB model and
 builds the image, so give it time.
+
+**Fastest on Intel: point generation at a hosted model**
+
+Both options above run generation on an Intel CPU with no GPU, and that is the
+whole of the cost. Measured on an i7-8850H: `qwen3.5:4b` decodes at ~6 tok/s, a
+question takes ~121s end to end, five flashcards ~118s, and enriching a
+128-page book ~143s. Nothing in the retrieval stack is slow — search is
+milliseconds — the model is. **If this is your first look at Luminary on an
+Intel Mac, use a hosted model for generation.** Everything else still runs on
+your machine: ingestion, embeddings, search, the graph and your library never
+leave it.
+
+```bash
+# in .env beside the compose file — a Docker container has no OS keyring, so a
+# key saved in Settings would be stored in the database as plain text
+LITELLM_DEFAULT_MODEL=openai/gpt-4o
+OPENAI_API_KEY=sk-...
+```
+
+The trade is explicit and worth stating: your question and the passages
+retrieved for it go to that provider. Nothing else does, and Private mode turns
+it off entirely — see [Choosing a model](#choosing-a-model). Apple Silicon does
+not need this; local generation there is comfortable.
 
 **If answering feels slow**
 
@@ -648,7 +677,7 @@ being skipped.
 | Platform | Status |
 |---------|--------|
 | macOS Apple Silicon | Native, fully supported |
-| macOS Intel | Docker required for backend |
+| macOS Intel | Docker required for backend; a hosted model is recommended for generation (no GPU, ~6 tok/s locally) |
 | Linux / WSL | Native, same steps |
 | Windows | Docker, or natively via `scripts/install.ps1` |
 

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -128,6 +128,16 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/documents", tags=["documents"])
 
+# Mirrors the CASE in the enrichment aggregate below; keep the two in step.
+# `pending` and `running` collapse to one reported state because the reader acts
+# on them identically -- work is outstanding.
+_ENRICHMENT_STATUS_BY_PRIORITY: dict[int, str] = {
+    1: "running",
+    2: "failed",
+    3: "skipped",
+    4: "done",
+}
+
 # DocumentDetail carries one preview per section, so the stored cap is far too
 # large for the wire. Set well above the two lines the section list renders,
 # because PredictPanel reads the first code fence from this field and the
@@ -253,19 +263,33 @@ async def list_documents(
             .correlate(DocumentModel)
             .scalar_subquery()
         )
-        enrichment_status_sq = (
-            select(EnrichmentJobModel.status)
-            .where(EnrichmentJobModel.document_id == DocumentModel.id)
-            .order_by(
-                # Prioritize image-related jobs for the status display
-                case(
-                    (EnrichmentJobModel.job_type == "image_analyze", 1),
-                    (EnrichmentJobModel.job_type == "image_extract", 2),
-                    else_=3,
-                ),
-                EnrichmentJobModel.created_at.desc(),
+        # The document's enrichment state, aggregated over ALL its jobs.
+        #
+        # This used to report a single job -- image_analyze, else image_extract,
+        # else whichever was newest -- which is not the document's state. Six job
+        # types are registered, so a document whose image work had finished read
+        # "Analysis complete" while its concept_link or web_refs was still queued,
+        # and the card contradicted the enrichment queue that was still counting
+        # the task. A badge that says a document is finished while work is running
+        # is worse than no badge.
+        #
+        # Precedence is by what the reader can act on, not by job type:
+        # outstanding work first, then a failure, then a skip (a model that was
+        # never installed -- actionable, so it must not hide behind "done"), then
+        # done. MIN over the priority keeps it to one correlated subquery.
+        enrichment_priority_sq = (
+            select(
+                func.min(
+                    case(
+                        (EnrichmentJobModel.status.in_(("pending", "running")), 1),
+                        (EnrichmentJobModel.status == "failed", 2),
+                        (EnrichmentJobModel.status == "skipped", 3),
+                        (EnrichmentJobModel.status == "done", 4),
+                        else_=5,
+                    )
+                )
             )
-            .limit(1)
+            .where(EnrichmentJobModel.document_id == DocumentModel.id)
             .correlate(DocumentModel)
             .scalar_subquery()
         )
@@ -394,7 +418,7 @@ async def list_documents(
             chunk_count_sq.label("chunk_count"),
             section_count_sq.label("section_count"),
             read_section_count_sq.label("read_section_count"),
-            enrichment_status_sq.label("enrichment_status"),
+            enrichment_priority_sq.label("enrichment_priority"),
             objectives_total_sq.label("objectives_total"),
             objectives_covered_sq.label("objectives_covered"),
             mastery_sum_contribution_sq.label("mastery_sum_contribution"),
@@ -426,7 +450,7 @@ async def list_documents(
         chunk_count = row[5] or 0
         section_count = row[6] or 0
         read_section_count = row[7] or 0
-        enrichment_status = row[8]
+        enrichment_status = _ENRICHMENT_STATUS_BY_PRIORITY.get(row[8])
         objectives_total = row[9] or 0
         objectives_covered = row[10] or 0
         mastery_sum_contribution = row[11]

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -52,6 +52,7 @@ from app.schemas.documents import (
     EpubChapterResponse,
     EpubChapterTocItem,
     EpubTocResponse,
+    IngestResponse,
     KindleIngestResponse,
     LearningObjectiveItem,
     LearningObjectivesResponse,
@@ -700,7 +701,7 @@ async def detect_document_type(file: UploadFile = File(...)):
         tmp.unlink(missing_ok=True)
 
 
-@router.post("/ingest")
+@router.post("/ingest", response_model=IngestResponse)
 async def ingest_document(
     file: UploadFile = File(...),
     content_type: ContentType | None = Form(None),
@@ -768,7 +769,9 @@ async def ingest_document(
                         "Duplicate upload detected (stage=complete), returning existing doc",
                         extra={"doc_id": existing.id, "file_hash": file_hash},
                     )
-                return {"document_id": existing.id, "status": "processing"}
+                # Already complete: nothing will progress, so saying "processing"
+                # leaves the client tracking a document that never moves.
+                return {"document_id": existing.id, "status": "duplicate"}
 
             if existing.stage == "error":
                 # Previous attempt failed — reset stage and retry ingestion on

--- a/backend/app/schemas/documents.py
+++ b/backend/app/schemas/documents.py
@@ -164,6 +164,19 @@ class YouTubeIngestRequest(BaseModel):
     url: str
 
 
+class IngestResponse(BaseModel):
+    """Result of POST /documents/ingest.
+
+    `status` distinguishes work started from a file we already hold. Ingestion
+    dedupes on file hash, and a duplicate of an already-complete document used to
+    be reported as "processing" -- so the client tracked a document that would
+    never progress, and the user saw an upload that appeared to do nothing.
+    """
+
+    document_id: str
+    status: Literal["processing", "duplicate"]
+
+
 class KindleIngestResponse(BaseModel):
     document_ids: list[str]
     book_count: int

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "luminary-backend"
-version = "0.8.24"
+version = "0.8.28"
 description = "Luminary — local-first personal knowledge and learning assistant"
 requires-python = ">=3.13"
 dependencies = [

--- a/backend/tests/test_documents_enrichment_status.py
+++ b/backend/tests/test_documents_enrichment_status.py
@@ -1,0 +1,134 @@
+"""`enrichment_status` on GET /documents is the document's state, not one job's.
+
+It used to report a single job -- image_analyze, else image_extract, else
+whichever was newest. Six job types are registered, so a document whose image
+work had finished reported "done" while its concept_link was still queued: the
+library card read "Analysis complete" while the enrichment queue was still
+counting the task, and the two surfaces contradicted each other on screen.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+import app.database as db_module
+from app.database import make_engine
+from app.db_init import create_all_tables
+from app.main import app
+from app.models import DocumentModel, EnrichmentJobModel
+
+
+@pytest.fixture
+async def test_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    await create_all_tables(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    orig_engine, orig_factory = db_module._engine, db_module._session_factory
+    db_module._engine, db_module._session_factory = engine, factory
+
+    yield factory
+
+    db_module._engine, db_module._session_factory = orig_engine, orig_factory
+    get_settings.cache_clear()
+    await engine.dispose()
+
+
+async def _seed(factory, jobs: list[tuple[str, str]]) -> str:
+    """One document with the given (job_type, status) pairs."""
+    doc_id = str(uuid.uuid4())
+    async with factory() as s:
+        s.add(
+            DocumentModel(
+                id=doc_id,
+                title="Doc",
+                format="pdf",
+                content_type="book",
+                word_count=10,
+                page_count=1,
+                file_path="/tmp/x.pdf",
+                stage="complete",
+                created_at=datetime.now(UTC),
+            )
+        )
+        for job_type, status in jobs:
+            s.add(
+                EnrichmentJobModel(
+                    id=str(uuid.uuid4()),
+                    document_id=doc_id,
+                    job_type=job_type,
+                    status=status,
+                )
+            )
+        await s.commit()
+    return doc_id
+
+
+async def _status(doc_id: str) -> str | None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        body = (await c.get("/documents")).json()
+    item = next(d for d in body["items"] if d["id"] == doc_id)
+    return item["enrichment_status"]
+
+
+@pytest.mark.anyio
+async def test_outstanding_work_outranks_a_finished_image_job(test_db):
+    """The regression this exists for: image work done, other work still queued.
+
+    The old query sorted image_analyze first and took one row, so this document
+    reported "done" while a task of its own was still pending.
+    """
+    doc_id = await _seed(
+        test_db, [("image_analyze", "done"), ("image_extract", "done"), ("concept_link", "pending")]
+    )
+
+    assert await _status(doc_id) == "running"
+
+
+@pytest.mark.anyio
+async def test_a_running_job_reports_running(test_db):
+    doc_id = await _seed(test_db, [("image_extract", "done"), ("web_refs", "running")])
+
+    assert await _status(doc_id) == "running"
+
+
+@pytest.mark.anyio
+async def test_a_failure_outranks_the_jobs_that_succeeded(test_db):
+    doc_id = await _seed(test_db, [("image_analyze", "done"), ("concept_link", "failed")])
+
+    assert await _status(doc_id) == "failed"
+
+
+@pytest.mark.anyio
+async def test_a_skip_is_not_hidden_behind_done(test_db):
+    """`skipped` means a model the user never installed, so it is actionable.
+
+    Reporting "done" for the document would bury the one thing they could fix.
+    """
+    doc_id = await _seed(test_db, [("concept_link", "done"), ("image_analyze", "skipped")])
+
+    assert await _status(doc_id) == "skipped"
+
+
+@pytest.mark.anyio
+async def test_all_done_reports_done(test_db):
+    doc_id = await _seed(
+        test_db, [("image_extract", "done"), ("image_analyze", "done"), ("concept_link", "done")]
+    )
+
+    assert await _status(doc_id) == "done"
+
+
+@pytest.mark.anyio
+async def test_a_document_with_no_jobs_reports_nothing(test_db):
+    """No jobs is not a state to render; the card shows no badge at all."""
+    doc_id = await _seed(test_db, [])
+
+    assert await _status(doc_id) is None

--- a/backend/tests/test_ingest_duplicate_signal.py
+++ b/backend/tests/test_ingest_duplicate_signal.py
@@ -1,0 +1,121 @@
+"""A re-upload of a document we already hold must not be reported as work.
+
+Ingestion dedupes on file hash. When the existing copy is already `complete`,
+nothing will run -- but the endpoint used to answer "processing", so the client
+tracked a document that would never move and the user saw an upload that
+appeared to do nothing at all. `status` now distinguishes the two.
+
+The stages that DO start work keep saying "processing": `error` relaunches
+ingestion on the same row, and an in-progress duplicate has a real job behind it.
+"""
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+import app.database as db_module
+from app.database import make_engine
+from app.db_init import create_all_tables
+from app.main import app
+from app.models import DocumentModel
+
+
+@pytest.fixture
+async def test_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    await create_all_tables(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    orig_engine, orig_factory = db_module._engine, db_module._session_factory
+    db_module._engine, db_module._session_factory = engine, factory
+
+    yield factory
+
+    db_module._engine, db_module._session_factory = orig_engine, orig_factory
+    get_settings.cache_clear()
+    await engine.dispose()
+
+
+_CONTENT = b"the same bytes every time, so the hash matches"
+
+
+async def _seed_existing(factory, *, stage: str) -> str:
+    """A document already holding _CONTENT's hash, at the given stage."""
+    import hashlib
+
+    doc_id = str(uuid.uuid4())
+    async with factory() as s:
+        s.add(
+            DocumentModel(
+                id=doc_id,
+                title="already here",
+                format="txt",
+                content_type="notes",
+                word_count=5,
+                page_count=1,
+                file_path="/tmp/already-here.txt",
+                file_hash=hashlib.sha256(_CONTENT).hexdigest(),
+                stage=stage,
+            )
+        )
+        await s.commit()
+    return doc_id
+
+
+async def _upload() -> dict:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/documents/ingest",
+            files={"file": ("already-here.txt", _CONTENT, "text/plain")},
+        )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+@pytest.mark.anyio
+async def test_reuploading_a_complete_document_reports_duplicate(test_db):
+    """The regression this exists for: nothing runs, so nothing may claim to."""
+    doc_id = await _seed_existing(test_db, stage="complete")
+
+    body = await _upload()
+
+    assert body["status"] == "duplicate"
+    assert body["document_id"] == doc_id, "the caller is pointed at the copy we hold"
+
+
+@pytest.mark.anyio
+async def test_an_in_progress_duplicate_still_reports_processing(test_db):
+    """A real job is behind it, and its progress is worth tracking."""
+    await _seed_existing(test_db, stage="embedding")
+
+    body = await _upload()
+
+    assert body["status"] == "processing"
+
+
+@pytest.mark.anyio
+async def test_a_new_file_reports_processing(test_db, monkeypatch):
+    """The ordinary path is untouched."""
+    launched: list[str] = []
+    from app.services import ingestion_jobs as jobs_module
+
+    class _Jobs:
+        def launch(self, doc_id, coro):
+            launched.append(doc_id)
+            coro.close()
+
+    monkeypatch.setattr(jobs_module, "get_ingestion_jobs", lambda: _Jobs())
+    import app.routers.documents as docs_router
+
+    monkeypatch.setattr(docs_router, "get_ingestion_jobs", lambda: _Jobs())
+
+    body = await _upload()
+
+    assert body["status"] == "processing"
+    assert launched, "a genuinely new file must actually start ingestion"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1669,7 +1669,7 @@ wheels = [
 
 [[package]]
 name = "luminary-backend"
-version = "0.8.24"
+version = "0.8.28"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/eval-coverage.md
+++ b/docs/eval-coverage.md
@@ -22,10 +22,11 @@ whatever retrieval returned.
 | Summaries | `make eval-summary` — theme coverage, grounding (HHEM), conciseness, hallucination | `golden/summaries.jsonl` | yes |
 | Flashcards | `make eval-flashcards` — generation rate, repairs, factuality/atomicity/clarity | `golden/flashcards.jsonl`, 35 rows over 5 content types | yes |
 | Corpus routing | `make eval-routing` — route@1, route@5, unscoped HR@5 | book, paper, legal, play, study | baseline only, no floor |
+| Note search | `make eval-notes` — recall over the user's own notes | no committed golden, by design (see below) | baseline only, corpus-coupled |
 | Model output quality | `GET /evals/output-stats` — repair kinds, first-pass rate, shape deviations, card-gate rejections, attempts per generation | any run | recorded per eval run |
 | Model choice | `make eval-matrix MODELS=a,b` — the model-sensitive runners across candidates, structural tier only | whatever the chosen tasks use | `--assert-separation` gates the instrument, not a model |
 | Generation variance | `make eval-variance` — mean/sd over N runs, gated on the mean | any dataset | on demand |
-| HTTP contract | `make smoke` — ~230 scripts | live backend | yes, separately |
+| HTTP contract | `make smoke` — ~180 scripts | live backend | yes, separately |
 
 ## What is not covered
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -250,6 +250,24 @@ not complete under test. Fix the second before the first, or the gate goes red. 
 timing policy, which failed before. The patch that corrects the doubles is trivial to
 reconstruct from the signatures above.
 
+### 11. `GET /documents` costs ~1.3s because its per-row counts are unindexed
+
+The library list runs about thirteen correlated subqueries per row. Measured on a 59-document
+library while three documents enriched: `GET /documents?page_size=24` takes **1.5s**, against
+**0.003s** for `GET /enrichment/queue` on the same server — so this is the query, not event-loop
+contention, and enrichment is not the cause.
+
+The counts are over tables with no `document_id` index: `chunks` (75,646 rows), `sections`
+(2,346), `flashcards` (826), `summaries` (452). `reading_progress`, `prediction_events` and
+`learning_objectives` already have one; `enrichment_jobs` does too, and at 162 rows it is not
+the cost. So the fix is an Alembic migration adding the missing indexes (I-23), not a query
+rewrite — and it wants a before/after measurement on a library this size rather than a rushed one.
+
+Bracketing what is already known: the enrichment aggregate added in `b647604` accounts for
+about 0.2s of the 1.5s (the single-job version it replaced measured 1.27s on the same library,
+same load). That is a real cost and worth re-measuring once the indexes exist, but it is not
+what makes the page slow.
+
 ## Deferred — decided, not scheduled
 
 Nothing currently deferred.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -228,6 +228,28 @@ Both are opt-out-able, both change what a user receives, and neither has a numbe
   drop, 0.7516 keep), which justifies the threshold and does not measure the axis. `vector_share`
   catches the arm dying, not the arm getting worse.
 
+### 10. The ingestion tests' entity extractor is a double that always raises
+
+`NERService.extract` is `(chunks, content_type="unknown", is_technical=None)`
+(`services/ner.py:458`) and `entity_extract_node` calls it with all three
+(`workflows/ingestion_nodes/entity_extract.py:258`). Both test doubles stopped at the
+signature it had before `is_technical`: `tests/test_e2e_upload.py:187` takes two, and
+`tests/test_concurrent.py:50` takes one. **Every call raises `TypeError`**, which the node
+catches as non-fatal and proceeds — so the ingestion tests pass without ever exercising
+entity extraction, and each mock's carefully-built return value is dead code.
+
+Correcting either signature is not a one-line fix, which is why this is an item rather than a
+commit. Measured on one machine, minutes apart: with the broken doubles
+`tests/test_e2e_upload.py` is **3 passed in 7.9s**; with the signatures corrected so
+extraction actually runs, it **exceeds the 120s per-test timeout** and ingestion stalls at
+`stage=indexing, progress_pct=80`. The `TypeError` is load-bearing for the suite being green.
+
+So there are two defects stacked: the doubles have drifted, and the path they were hiding does
+not complete under test. Fix the second before the first, or the gate goes red. Related to the
+`unstable` quarantine (item 3) and to the leaked-task shutdown work — do not attempt it with a
+timing policy, which failed before. The patch that corrects the doubles is trivial to
+reconstruct from the signatures above.
+
 ## Deferred — decided, not scheduled
 
 Nothing currently deferred.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.8.24",
+  "version": "0.8.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.8.24",
+      "version": "0.8.28",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.8.24",
+  "version": "0.8.28",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -664,7 +664,10 @@ function App() {
           <BrowserRouter>
             <AppShell />
           </BrowserRouter>
-          <div className="pointer-events-none fixed bottom-5 left-5 z-40 flex flex-col gap-3">
+          {/* Clear of the nav rail: it is w-[4.5rem] and unconditional, so a
+              bottom-left overlay at left-5 sits on top of the streak widget,
+              the dev icons and the settings controls at the foot of it. */}
+          <div className="pointer-events-none fixed bottom-5 left-[5.75rem] z-40 flex flex-col gap-3">
             <IngestionProgressPills />
             <EnrichmentStatusPill />
           </div>

--- a/frontend/src/components/library/UploadDialog.tsx
+++ b/frontend/src/components/library/UploadDialog.tsx
@@ -438,8 +438,17 @@ export function UploadDialog({ open, onClose }: UploadDialogProps) {
     logger.info("[Upload] start", { filename: file.name, size_mb: sizeMB.toFixed(2), content_type: contentType })
 
     try {
-      const docId = await submitFile(file, contentType)
-      logger.info("[Upload] uploaded", { filename: file.name, doc_id: docId })
+      const { documentId: docId, duplicate } = await submitFile(file, contentType)
+      logger.info("[Upload] uploaded", { filename: file.name, doc_id: docId, duplicate })
+      if (duplicate) {
+        // Ingestion dedupes on file hash and this copy is already complete, so
+        // there is no job to follow. Tracking it would show a progress card that
+        // never moves, which is what made a re-upload look like it did nothing.
+        toast.success(`${title} is already in your library`)
+        reset()
+        onClose()
+        return
+      }
       track(docId, title)
       setTrackedDocId(docId)
       // Close the dialog immediately — progress is shown via the

--- a/frontend/src/lib/ingestionApi.ts
+++ b/frontend/src/lib/ingestionApi.ts
@@ -51,10 +51,16 @@ export async function detectFileType(file: File): Promise<ContentTypeValue | nul
   }
 }
 
+export interface FileIngestResult {
+  documentId: string
+  /** The library already held this file; nothing is running, so do not track it. */
+  duplicate: boolean
+}
+
 export async function submitFile(
   file: File,
   contentType: ContentTypeValue | null,
-): Promise<string> {
+): Promise<FileIngestResult> {
   const form = new FormData()
   form.append("file", file)
   // Omitted, not blank, when the user did not choose: the backend skips
@@ -62,11 +68,11 @@ export async function submitFile(
   // silently overrides detection.
   if (contentType) form.append("content_type", contentType)
   try {
-    const data = await apiPost<{ document_id: string }>(
+    const data = await apiPost<{ document_id: string; status: string }>(
       "/documents/ingest",
       form,
     )
-    return data.document_id
+    return { documentId: data.document_id, duplicate: data.status === "duplicate" }
   } catch (err) {
     throw detailFromError(err, "Upload failed")
   }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -8707,6 +8707,24 @@ export interface components {
             /** Page Size */
             page_size: number;
         };
+        /**
+         * IngestResponse
+         * @description Result of POST /documents/ingest.
+         *
+         *     `status` distinguishes work started from a file we already hold. Ingestion
+         *     dedupes on file hash, and a duplicate of an already-complete document used to
+         *     be reported as "processing" -- so the client tracked a document that would
+         *     never progress, and the user saw an upload that appeared to do nothing.
+         */
+        IngestResponse: {
+            /** Document Id */
+            document_id: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "processing" | "duplicate";
+        };
         /** InstallableModel */
         InstallableModel: {
             /** Id */
@@ -13039,7 +13057,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["IngestResponse"];
                 };
             };
             /** @description Validation Error */

--- a/scripts/smoke/S245.sh
+++ b/scripts/smoke/S245.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# S245 smoke: POST /documents/ingest reports a duplicate as "duplicate", not "processing".
+#
+# Ingestion dedupes on file hash. When the copy we already hold is complete,
+# nothing runs -- and answering "processing" made the client track a document
+# that never moved, so a re-upload looked like it did nothing. The second upload
+# of identical bytes is the whole test.
+#
+# Uploads a tiny unique text file twice and deletes it, so it leaves no residue
+# in the library it ran against.
+set -euo pipefail
+
+BASE="http://localhost:7820"
+STAMP="s245_$(date +%s)_$$"
+TMP="$(mktemp -t s245).txt"
+printf 'S245 duplicate-signal fixture %s\n' "$STAMP" > "$TMP"
+DOC_ID=""
+# Cleanup on EXIT, not at the end: `set -e` plus a curl timeout can kill this
+# script mid-run, and an abandoned fixture in someone's real library is exactly
+# the residue smoke scripts have left before.
+cleanup() {
+  rm -f "$TMP"
+  [ -n "$DOC_ID" ] && curl -sf -m 30 -X DELETE "${BASE}/documents/${DOC_ID}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+FIRST=$(curl -sf -m 120 -X POST "${BASE}/documents/ingest" -F "file=@${TMP};filename=${STAMP}.txt")
+DOC_ID=$(printf '%s' "$FIRST" | sed -n 's/.*"document_id":"\([^"]*\)".*/\1/p')
+STATUS=$(printf '%s' "$FIRST" | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')
+
+if [ -z "$DOC_ID" ]; then
+  echo "FAIL: S245 -- first upload returned no document_id: $FIRST"
+  exit 1
+fi
+if [ "$STATUS" != "processing" ]; then
+  echo "FAIL: S245 -- a new file must report processing, got '$STATUS'"
+  exit 1
+fi
+
+# Wait for it to reach a terminal stage; the duplicate branch only fires on complete.
+for _ in $(seq 1 60); do
+  STAGE=$(curl -sf -m 10 "${BASE}/documents/${DOC_ID}/status" \
+    | sed -n 's/.*"stage":"\([^"]*\)".*/\1/p')
+  [ "$STAGE" = "complete" ] && break
+  [ "$STAGE" = "error" ] && break
+  sleep 2
+done
+
+if [ "$STAGE" != "complete" ]; then
+  echo "SKIP: S245 -- fixture did not reach complete (stage=$STAGE); duplicate branch not reachable"
+  exit 0
+fi
+
+SECOND=$(curl -sf -m 120 -X POST "${BASE}/documents/ingest" -F "file=@${TMP};filename=${STAMP}.txt")
+DUP_STATUS=$(printf '%s' "$SECOND" | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')
+DUP_ID=$(printf '%s' "$SECOND" | sed -n 's/.*"document_id":"\([^"]*\)".*/\1/p')
+
+if [ "$DUP_STATUS" != "duplicate" ]; then
+  echo "FAIL: S245 -- re-upload of a complete document reported '$DUP_STATUS', expected 'duplicate'"
+  exit 1
+fi
+if [ "$DUP_ID" != "$DOC_ID" ]; then
+  echo "FAIL: S245 -- duplicate pointed at '$DUP_ID', expected the held copy '$DOC_ID'"
+  exit 1
+fi
+
+echo "PASS: S245 -- a re-upload of a complete document reports duplicate"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "luminary-desktop"
-version = "0.8.24"
+version = "0.8.28"
 dependencies = [
  "chrono",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luminary-desktop"
-version = "0.8.24"
+version = "0.8.28"
 description = "Luminary"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Luminary",
-  "version": "0.8.24",
+  "version": "0.8.28",
   "identifier": "sh.luminary.app",
   "build": {
     "frontendDist": "boot"


### PR DESCRIPTION
Final release for today's public launch. Six commits: four fixes, a docs pass, and the bump.

## Fixes

- **A re-upload of a document you already hold said "processing".** Ingestion dedupes on file
  hash; when the held copy is complete nothing runs, so the client tracked a document that
  never moved and the upload appeared to do nothing. Now `"duplicate"`, behind an
  `IngestResponse` model, with the upload dialog saying so. Found from a real re-upload.
- **A library card could say a document was finished while its enrichment was still running.**
  The badge reported one job, not the document. Six job types exist, so image work finishing
  read "Analysis complete" while `concept_link` was still queued — contradicting the pill on
  the same screen.
- **The status overlays sat on top of the nav rail**, hiding the streak widget and the settings
  controls.
- **The README did not say what an Intel Mac should do.** Both Docker topologies run generation
  on a GPU-less CPU (~6 tok/s, ~121s a question); neither suggested the hosted model that fixes
  it. Also corrected `eval-coverage.md`'s "~230 smoke scripts" (it is 178) and added the
  note-search eval to its table.

## Verification

- `make ci`: **3329 passed, 0 failed**, exit 0.
- **33 targeted smoke scripts, 0 failed** — `/documents/ingest` (15) plus the `/documents` list
  and enrichment surfaces (21), covering every wire surface this release touches.
- Both new checks were fired against the old behaviour first: the pytest fails with
  `assert 'processing' == 'duplicate'`, and S245 fails live with the message it exists to print.

**Full smoke was not run.** At 6 of 178 scripts in four minutes it would not have finished in
the window, and several scripts run `pytest`/`tsc` internally. That is a stated gap, not an
oversight.

## Recorded, not fixed

- **Roadmap 10** — both ingestion test doubles for `NERService.extract` raise `TypeError` on
  every call, so entity extraction is never exercised; correcting them turns a 7.9s green into
  a >120s hang. Fix the hang first.
- **Roadmap 11** — `GET /documents` takes ~1.5s because its per-row counts run over unindexed
  tables (`chunks` at 75,646 rows). Wants a migration and a real before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)