### PR TITLE
Notes generate flashcards again, and card genre comes from the facets

### DIFF
--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -202,13 +202,9 @@ def _facets(doc: DocumentModel) -> DocumentFacets:
     documents nothing has classified yet. A null `domain` reaches the client as
     null so it can be shown as unclassified rather than as "general".
     """
-    if not doc.form:
+    profile = DocumentProfile.from_row(doc)
+    if profile is None:
         return DocumentFacets()
-    profile = DocumentProfile(
-        form=doc.form,  # type: ignore[arg-type]
-        domain=doc.domain,  # type: ignore[arg-type]
-        register=doc.register,  # type: ignore[arg-type]
-    )
     return DocumentFacets(
         form=doc.form,
         domain=doc.domain,

--- a/backend/app/services/flashcard_parsers.py
+++ b/backend/app/services/flashcard_parsers.py
@@ -244,6 +244,14 @@ _EXCERPT_EDGE = "\"'\u201c\u201d\u2018\u2019"
 _EXCERPT_TAIL = ".,;:!?)]\"'"
 
 
+def _is_prompt_supplied(excerpt: str) -> bool:
+    """Whether the quote is text the prompt itself handed the model."""
+    from app.services.flashcard_prompts import PROMPT_SUPPLIED_EXCERPTS  # noqa: PLC0415
+
+    normalised = _normalise_for_match(excerpt)
+    return any(_normalise_for_match(s) in normalised for s in PROMPT_SUPPLIED_EXCERPTS)
+
+
 def _trim_edges(part: str) -> str:
     """Drop a wrapping quote and one trailing terminal character."""
     trimmed = part.strip().strip(_EXCERPT_EDGE).strip()
@@ -313,9 +321,7 @@ def grounding_state(source_excerpt: str | None, source_text: str | None) -> str:
         return GROUNDING_UNVERIFIABLE
     if len(excerpt) < _MIN_EXCERPT_CHARS or len(excerpt.split()) < _MIN_EXCERPT_TOKENS:
         return GROUNDING_UNVERIFIABLE
-    from app.services.flashcard_prompts import EXAMPLE_SOURCE_EXCERPT  # noqa: PLC0415
-
-    if _normalise_for_match(EXAMPLE_SOURCE_EXCERPT) in _normalise_for_match(excerpt):
+    if _is_prompt_supplied(excerpt):
         return GROUNDING_UNSUPPORTED
     if excerpt_is_verbatim(excerpt, source_text):
         return GROUNDING_VERIFIED
@@ -391,9 +397,7 @@ def card_rejection(
         # Text the prompt supplied can never be a card's evidence, even if a
         # passage happens to contain it. A verification the system can satisfy
         # with its own material verifies nothing.
-        from app.services.flashcard_prompts import EXAMPLE_SOURCE_EXCERPT  # noqa: PLC0415
-
-        if _normalise_for_match(EXAMPLE_SOURCE_EXCERPT) in _normalise_for_match(excerpt):
+        if _is_prompt_supplied(excerpt):
             return (
                 REJECT_UNGROUNDED,
                 "source quote is the prompt's own example, not the document",

--- a/backend/app/services/flashcard_parsers.py
+++ b/backend/app/services/flashcard_parsers.py
@@ -228,9 +228,18 @@ _QUOTE_CHARS = str.maketrans({
 })
 
 
+# Markdown emphasis renders away, so a model quoting a bolded sentence returns the
+# sentence a reader sees rather than the source bytes. Notes are written in markdown
+# and are the worst affected. Only `**` and code spans go: a lone `*` or `_` carries
+# content (`snake_case`, `a * b`), and dropping those would let two different strings
+# compare equal.
+_MD_EMPHASIS = re.compile(r"\*\*|`")
+
+
 def _normalise_for_match(text: str) -> str:
-    """Lowercased, whitespace-collapsed, punctuation-unified -- for quote matching."""
-    return re.sub(r"\s+", " ", (text or "").translate(_QUOTE_CHARS)).strip().lower()
+    """Lowercased, whitespace-collapsed, punctuation- and emphasis-unified."""
+    unmarked = _MD_EMPHASIS.sub("", (text or "").translate(_QUOTE_CHARS))
+    return re.sub(r"\s+", " ", unmarked).strip().lower()
 
 
 # A model closes the sentence it quoted. Measured over the 392 checkable cards in

--- a/backend/app/services/flashcard_prompts.py
+++ b/backend/app/services/flashcard_prompts.py
@@ -33,12 +33,12 @@ EXAMPLE_SOURCE_EXCERPT = (
     "correlated across nodes"
 )
 
-# The notes contract shows the shape of the quote rather than a specimen of one,
-# for the same reason. It is long enough to clear the length floor, so only an
-# explicit refusal stops a model that echoes the template from being credited.
+# The notes contract shows the shape of a quote rather than a specimen of one, for
+# the same reason. It clears the length floor, so only an explicit refusal stops a
+# model that echoes the template from being credited.
 NOTES_EXCERPT_PLACEHOLDER = "<verbatim sentence from the notes>"
 
-# Every string the prompt hands the model that could be returned as its evidence.
+# Every string the prompt hands the model that could come back as its evidence.
 PROMPT_SUPPLIED_EXCERPTS = (EXAMPLE_SOURCE_EXCERPT, NOTES_EXCERPT_PLACEHOLDER)
 
 

--- a/backend/app/services/flashcard_prompts.py
+++ b/backend/app/services/flashcard_prompts.py
@@ -16,6 +16,7 @@ from app.services.prompt_spec import (
     render_for,
     step_decomposition,
 )
+from app.types import DocumentProfile
 
 if TYPE_CHECKING:
     from app.models import DocumentModel
@@ -31,6 +32,14 @@ EXAMPLE_SOURCE_EXCERPT = (
     "hardware faults are random and independent, whereas software faults are "
     "correlated across nodes"
 )
+
+# The notes contract shows the shape of the quote rather than a specimen of one,
+# for the same reason. It is long enough to clear the length floor, so only an
+# explicit refusal stops a model that echoes the template from being credited.
+NOTES_EXCERPT_PLACEHOLDER = "<verbatim sentence from the notes>"
+
+# Every string the prompt hands the model that could be returned as its evidence.
+PROMPT_SUPPLIED_EXCERPTS = (EXAMPLE_SOURCE_EXCERPT, NOTES_EXCERPT_PLACEHOLDER)
 
 
 FLASHCARD_SYSTEM = (
@@ -247,11 +256,17 @@ NOTES_CARD_FROM_CONCEPTS_SYSTEM = (
     "'this case', 'this context', 'this example', 'the author', 'the text', 'these notes', "
     "'the man', 'the person', 'the writer'. "
     "The question must stand alone -- understandable without the notes. "
-    "Answer from the notes: lead with one direct sentence, then add short markdown bullets "
-    "('- ...') only for several distinct points. Never a bare list; never filler. "
+    "ANSWER: one sentence from the notes, the shortest that is still complete. Where the notes "
+    "list several items, write one card per item rather than one card listing them. Never a "
+    "bullet list; never filler. "
     "For process-role: explain what the collective activity achieves or why it matters -- "
     "never enumerate the individual components as the answer. "
-    'Output ONLY a JSON array: [{{"question": "...", "answer": "...", "source_excerpt": ""}}]. '
+    "SOURCE_EXCERPT: copy the sentence from the notes that proves the answer, word for word, at "
+    "least four words long. It must come from the notes and from nowhere else -- not from this "
+    "instruction, and not from memory. A card whose quote is not in the notes is discarded. "
+    "Use '...' to shorten a long sentence. "
+    'Output ONLY a JSON array: [{{"question": "...", "answer": "...", '
+    f'"source_excerpt": "{NOTES_EXCERPT_PLACEHOLDER}"}}}}]. '
     "No explanation, no preamble, no markdown fences."
 )
 
@@ -430,14 +445,21 @@ _GENRE_STRATEGY = {
 
 
 def _infer_genre(doc: DocumentModel | None) -> str:
-    """Infer document genre for system prompt tuning.
+    """What kind of card this document wants.
 
-    Technical content types (tech_book, tech_article, code, paper) MUST map to technical/academic.
-    They previously fell through to 'narrative' (the story prompt), so the model summarised or
-    extracted tables instead of writing recall cards.
+    `DocumentProfile.card_genre` decides it for any measured document. The
+    `content_type` branches are the fallback for rows ingested before the
+    facets, and they are wrong two ways: a book is called technical from a
+    keyword in its *title*, and every video is called a meeting -- so a recorded
+    technical talk was asked who owns the action item instead of for the
+    technique. A profile that determines nothing falls through rather than
+    defaulting; that guess is how "The Odyssey" came to be non-fiction.
     """
     if doc is None:
         return "non-fiction"
+    profile = DocumentProfile.from_row(doc)
+    if profile and profile.card_genre:
+        return profile.card_genre
     content_type = (doc.content_type or "").lower()
     # normalise underscores so slugged titles ("d2l_dive_into_deep_learning") match
     title = (doc.title or "").lower().replace("_", " ")

--- a/backend/app/services/summarizer.py
+++ b/backend/app/services/summarizer.py
@@ -61,6 +61,15 @@ MODE_INSTRUCTIONS: dict[str, str] = {
         '"decisions" (list of strings), '
         '"action_items" (list of objects with "owner" and "task" keys).'
     ),
+    # A recorded talk has no decisions and no owners. Asking for them returns
+    # empty lists, which is why this mode was hidden from anything but a
+    # meeting rather than adapted (#104).
+    "conversation_talk": (
+        'Output a JSON object with keys: "timeline" (list of strings), '
+        '"points" (list of strings: the techniques, tools and claims covered), '
+        '"references" (list of strings: anything named that a listener would '
+        "look up afterwards)."
+    ),
 }
 
 # Tokens reserved inside the context window for the system prompt and the
@@ -253,8 +262,10 @@ def _build_system_prompt(mode: str, profile: "DocumentProfile | None" = None) ->
     `conversation` asks for a JSON object; prose guidance would invite
     commentary around it.
     """
+    if mode == "conversation" and profile is not None and profile.is_technical:
+        mode = "conversation_talk"
     prompt = f"{GROUNDING_PREFIX}\n\n{MODE_INSTRUCTIONS[mode]}"
-    if mode == "conversation":
+    if mode.startswith("conversation"):
         return prompt
     guidance = _kind_guidance(profile)
     return f"{prompt} {guidance}" if guidance else prompt

--- a/backend/app/services/summarizer.py
+++ b/backend/app/services/summarizer.py
@@ -300,13 +300,7 @@ class SummarizationService:
                 extra={"document_id": document_id},
             )
             return None
-        if row is None or not row.form:
-            return None
-        return DocumentProfile(
-            form=row.form,  # type: ignore[arg-type]
-            domain=row.domain,  # type: ignore[arg-type]
-            register=row.register,  # type: ignore[arg-type]
-        )
+        return DocumentProfile.from_row(row)
 
     async def _fetch_chunks(self, document_id: str) -> list[ChunkModel]:
         async with get_session_factory()() as session:

--- a/backend/app/types.py
+++ b/backend/app/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 ContentType = Literal[
     "book",
@@ -166,6 +166,17 @@ class DocumentProfile:
         if self.register == "expository":
             return "non-fiction"
         return None
+
+    @classmethod
+    def from_row(cls, row: Any) -> "DocumentProfile | None":
+        """The profile a stored document carries, or None if nothing measured it.
+
+        `form` is the axis every other facet hangs off, so a row without one has
+        no profile -- callers fall back rather than reading `domain` alone.
+        """
+        if row is None or not getattr(row, "form", None):
+            return None
+        return cls(form=row.form, domain=row.domain, register=row.register)
 
     @classmethod
     def from_legacy(

--- a/backend/tests/test_document_profile.py
+++ b/backend/tests/test_document_profile.py
@@ -211,3 +211,69 @@ def test_every_form_has_a_chunk_config() -> None:
         cfg = DocumentProfile(form=form, domain="general").chunk_config
         assert cfg["chunk_size"] > 0
         assert 0 < cfg["chunk_overlap"] < cfg["chunk_size"]
+
+
+class TestGenreWiring:
+    """`_infer_genre` must read the measured facets, not re-derive them.
+
+    `DocumentProfile.card_genre` and `_infer_genre` produce the same five
+    labels from different evidence, and they disagreed: the legacy branches
+    call a book technical from a keyword in its *title* and call every video a
+    meeting. The facets are the measurement; these assert the generator uses it.
+    """
+
+    @staticmethod
+    def _doc(**kwargs):
+        from types import SimpleNamespace
+
+        base = {
+            "content_type": None,
+            "title": None,
+            "form": None,
+            "domain": None,
+            "register": None,
+        }
+        return SimpleNamespace(**{**base, **kwargs})
+
+    def test_a_technical_talk_is_not_asked_what_was_decided(self) -> None:
+        """The bug #105 fixed in the summarizer lived here too: a recorded
+        technical talk is `content_type='video'`, which the legacy branch maps
+        to `conversation` -- the meeting strategy, which asks who owns the
+        action item. A talk's value is the technique."""
+        from app.services.flashcard_prompts import _infer_genre
+
+        talk = self._doc(content_type="video", form="dialogue", domain="technical")
+        assert _infer_genre(talk) == "technical"
+
+        meeting = self._doc(content_type="video", form="dialogue", domain="general")
+        assert _infer_genre(meeting) == "conversation"
+
+    def test_a_measured_novel_is_not_called_technical_by_its_title(self) -> None:
+        from app.services.flashcard_prompts import _infer_genre
+
+        # "Neuromancer" trips no keyword, but the legacy path cannot tell an
+        # epic from an essay at all -- it answers non-fiction for both.
+        novel = self._doc(
+            content_type="book", title="Neuromancer", form="prose",
+            domain="general", register="narrative",
+        )
+        assert _infer_genre(novel) == "narrative"
+
+    def test_unmeasured_rows_still_get_the_legacy_answer(self) -> None:
+        """Documents ingested before the facets have no form, and must keep
+        reaching the same strategy they did before."""
+        from app.services.flashcard_prompts import _infer_genre
+
+        assert _infer_genre(self._doc(content_type="tech_book")) == "technical"
+        assert _infer_genre(self._doc(content_type="paper")) == "academic"
+        assert _infer_genre(self._doc(content_type="conversation")) == "conversation"
+        assert _infer_genre(None) == "non-fiction"
+
+    def test_a_profile_that_determines_nothing_falls_through(self) -> None:
+        """`card_genre` returns None where it cannot tell; that must reach the
+        fallback rather than being read as a genre."""
+        from app.services.flashcard_prompts import _infer_genre
+
+        undetermined = self._doc(content_type="tech_book", form="prose", domain="general")
+        assert DocumentProfile(form="prose", domain="general").card_genre is None
+        assert _infer_genre(undetermined) == "technical"

--- a/backend/tests/test_flashcard_quality_gate.py
+++ b/backend/tests/test_flashcard_quality_gate.py
@@ -290,3 +290,42 @@ def test_the_prompts_own_example_can_never_be_a_cards_evidence():
         )
         is None
     )
+
+
+def test_notes_prompt_does_not_ask_for_what_the_gate_rejects() -> None:
+    """The notes contract and the gate must agree on the shape of a card.
+
+    They did not: the prompt asked for "short markdown bullets ('- ...')" while
+    `_MAX_ENUMERATED_ITEMS = 1` rejects a two-bullet answer, and its output
+    template carried `"source_excerpt": ""` while the gate requires a verbatim
+    quote. Measured on 2026-09-02, five real notes returned 0 usable cards of 5
+    requested, every drop logged as `enumerated` or `ungrounded` (#108).
+
+    Asserting the prompt text is the point: the gate was never wrong, so a test
+    of the gate alone would have stayed green through the whole outage.
+    """
+    from app.services.flashcard_prompts import NOTES_CARD_FROM_CONCEPTS_SYSTEM
+
+    assert "markdown bullets" not in NOTES_CARD_FROM_CONCEPTS_SYSTEM
+    assert '"source_excerpt": ""' not in NOTES_CARD_FROM_CONCEPTS_SYSTEM
+    assert "word for word" in NOTES_CARD_FROM_CONCEPTS_SYSTEM
+
+
+def test_notes_excerpt_placeholder_is_refused() -> None:
+    """The notes template shows the shape of a quote, and it clears the length
+    floor -- so a model that echoes it must be refused explicitly rather than by
+    the luck of it not appearing in the notes."""
+    from app.services.flashcard_parsers import REJECT_UNGROUNDED, card_rejection
+    from app.services.flashcard_prompts import NOTES_EXCERPT_PLACEHOLDER
+
+    notes = f"The learner wrote: {NOTES_EXCERPT_PLACEHOLDER} appears here verbatim."
+
+    verdict = card_rejection(
+        "What does the note record?",
+        "It records a placeholder rather than a measured quote.",
+        NOTES_EXCERPT_PLACEHOLDER,
+        notes,
+    )
+
+    assert verdict is not None
+    assert verdict[0] == REJECT_UNGROUNDED

--- a/backend/tests/test_flashcard_quality_gate.py
+++ b/backend/tests/test_flashcard_quality_gate.py
@@ -298,8 +298,7 @@ def test_notes_prompt_does_not_ask_for_what_the_gate_rejects() -> None:
     They did not: the prompt asked for "short markdown bullets ('- ...')" while
     `_MAX_ENUMERATED_ITEMS = 1` rejects a two-bullet answer, and its output
     template carried `"source_excerpt": ""` while the gate requires a verbatim
-    quote. Measured on 2026-09-02, five real notes returned 0 usable cards of 5
-    requested, every drop logged as `enumerated` or `ungrounded` (#108).
+    quote. Notes returned empty decks until both were aligned (#108).
 
     Asserting the prompt text is the point: the gate was never wrong, so a test
     of the gate alone would have stayed green through the whole outage.
@@ -329,3 +328,39 @@ def test_notes_excerpt_placeholder_is_refused() -> None:
 
     assert verdict is not None
     assert verdict[0] == REJECT_UNGROUNDED
+
+
+def test_markdown_emphasis_is_formatting_not_fabrication() -> None:
+    """A model quoting a bolded sentence returns what a reader sees.
+
+    A quote whose only difference from the note is its `**` markers was rejected
+    as not in the text. Notes are written in markdown, so this was the most
+    repeated rejection on that path (#108).
+
+    The cases that bracket it: the same sentence minus its `**` must pass, and a
+    sentence that changes what is claimed must still fail even though it opens
+    with the same words.
+    """
+    from app.services.flashcard_parsers import excerpt_is_verbatim
+
+    note = (
+        "## TF-IDF\n"
+        "**TF-IDF**, which stands for **Term Frequency-Inverse Document Frequency**, "
+        "is a numerical statistic used to measure how important a word is.\n"
+        "It uses `read_source_text` to decode the bytes."
+    )
+
+    assert excerpt_is_verbatim(
+        "TF-IDF, which stands for Term Frequency-Inverse Document Frequency, "
+        "is a numerical statistic used to measure how important a word is.",
+        note,
+    )
+    assert not excerpt_is_verbatim(
+        "TF-IDF, which stands for Term Frequency, is a ranking function that "
+        "reranks dense vectors after retrieval.",
+        note,
+    )
+    # A code span loses its backticks, but an identifier keeps its underscores:
+    # collapsing those would let two different names compare equal.
+    assert excerpt_is_verbatim("It uses read_source_text to decode the bytes.", note)
+    assert not excerpt_is_verbatim("It uses readsourcetext to decode the bytes.", note)

--- a/docs/eval-coverage.md
+++ b/docs/eval-coverage.md
@@ -41,6 +41,17 @@ whatever retrieval returned.
   as placeholders until `make eval-flashcards` has run enough times to derive floors the way the
   generation floors were derived.
 
+- **`make eval-flashcards` cannot resolve a change smaller than its own noise.** Measured
+  2026-09-02, four runs, same library, two per arm across an unrelated prompt change:
+  `factuality` **0.7396 / 0.6026** on identical code in one arm and 0.7083 / 0.7300 in the other.
+  Run-to-run spread is ~0.14; the between-arm gap was ~0.01. Per content type it is worse — the
+  `book` cell returned 4, 9, 9 and 10 of 21 across those runs, and `conversation` factuality moved
+  0.70 → 0.40 with nothing changed. At 35 rows, one run per arm will report a confident regression
+  that a second run erases. Two runs per arm is the minimum, and a per-content-type cell is not
+  readable at all. `atomicity` is structural (`is_atomic`, sentence and bullet counting), so it
+  does not carry this noise — it reads 1.0000 because the gate already rejects bulleted answers,
+  which leaves only multi-sentence answers able to move it.
+
 - **`make eval` measures scoped retrieval only.** Each row is pinned to its source document, so a
   routing failure is invisible there by construction. `make eval-routing` measures unscoped, and
   `run_eval --unscoped` runs the same rows without the pin. Measured once (52 documents): route@1

--- a/frontend/src/components/reader/DocumentReader.tsx
+++ b/frontend/src/components/reader/DocumentReader.tsx
@@ -1523,6 +1523,7 @@ function DocumentReaderBase({ documentId, onBack, initialSectionId, initialChunk
           <SummaryPanel
             documentId={documentId}
             contentType={doc.content_type}
+            form={doc.facets?.form}
           />
         </div>
         )}

--- a/frontend/src/components/reader/SummaryPanel.tsx
+++ b/frontend/src/components/reader/SummaryPanel.tsx
@@ -19,11 +19,18 @@ type PanelTab = SummaryMode | "references" | "tags"
 interface SummaryPanelProps {
   documentId: string
   contentType: string
+  /** The document's shape. Absent on rows nothing has classified. */
+  form?: string | null
 }
 
-export function SummaryPanel({ documentId, contentType }: SummaryPanelProps) {
-  const summaryTabs: SummaryTabDef[] =
-    contentType === "conversation" ? [...SUMMARY_TABS, CONVERSATION_TAB] : SUMMARY_TABS
+export function SummaryPanel({ documentId, contentType, form }: SummaryPanelProps) {
+  // Gated on form, not content_type: a recorded talk is stored as `audio` and
+  // could never reach this tab, though it is the same speaker-turn content as
+  // a meeting (#104). Falls back to content_type for unclassified rows.
+  const isDialogue = form ? form === "dialogue" : contentType === "conversation"
+  const summaryTabs: SummaryTabDef[] = isDialogue
+    ? [...SUMMARY_TABS, CONVERSATION_TAB]
+    : SUMMARY_TABS
   const allTabs = [
     ...summaryTabs.map((t) => ({ mode: t.mode as PanelTab, label: t.label })),
     { mode: "references" as PanelTab, label: "References" },

--- a/frontend/src/components/reader/types.ts
+++ b/frontend/src/components/reader/types.ts
@@ -31,7 +31,10 @@ export const SUMMARY_TABS: SummaryTabDef[] = [
   { mode: "detailed", label: "Detailed" },
 ]
 
+/** Speaker-turn content gets a notes tab. The shape adapts underneath -- a
+ *  meeting's notes are decisions and owners, a talk's are points and
+ *  references -- which the reader does not need to be told. */
 export const CONVERSATION_TAB: SummaryTabDef = {
   mode: "conversation",
-  label: "Meeting Notes",
+  label: "Notes",
 }

--- a/scripts/smoke/S144.sh
+++ b/scripts/smoke/S144.sh
@@ -10,8 +10,9 @@ BASE="http://localhost:7820"
 DOC_ID=$(curl -sf "$BASE/documents" | python3 -c "
 import sys, json
 docs = json.load(sys.stdin)
-if docs:
-    print(docs[0]['id'])
+items = docs.get('items', []) if isinstance(docs, dict) else docs
+if items:
+    print(items[0]['id'])
 " 2>/dev/null || echo "")
 
 if [ -z "$DOC_ID" ]; then

--- a/scripts/smoke/S167.sh
+++ b/scripts/smoke/S167.sh
@@ -124,8 +124,7 @@ import sys, json
 d = json.load(sys.stdin)
 node = next((n for n in d['nodes'] if n['id'] == '$SHARED_TAG_A'), None)
 if node:
-  # `note_count` became `usage_count`: a tag is used by documents as well as
-  # notes, so the count is not notes-only.
+  # usage_count, not note_count: documents use tags too.
   ok = all(k in node for k in ['id', 'display_name', 'usage_count'])
   print(str(ok).lower())
 else:

--- a/scripts/smoke/S192.sh
+++ b/scripts/smoke/S192.sh
@@ -48,7 +48,7 @@ if [ "$STATUS" != "200" ]; then
   echo "  SKIP: no documents endpoint or no documents available ($STATUS)"
   echo "  Testing with 404 paths only"
 else
-  DOC_ID=$(echo "$BODY" | python3 -c "import sys,json; docs=json.load(sys.stdin); print(docs[0]['id'] if docs else '')" 2>/dev/null || true)
+  DOC_ID=$(echo "$BODY" | python3 -c "import sys,json; d=json.load(sys.stdin); items=d.get('items', []) if isinstance(d, dict) else d; print(items[0]['id'] if items else '')" 2>/dev/null || true)
   if [ -n "$DOC_ID" ]; then
     echo "  Found document: $DOC_ID"
 


### PR DESCRIPTION
Closes #108. Also lands the #104 fix and three smoke repairs found while re-baselining #62.

## 1. Notes returned 0 flashcards (#108)

`POST /notes/flashcards/generate` returned **201 with an empty array**, so the button looked like it did nothing.

`NOTES_CARD_FROM_CONCEPTS_SYSTEM` instructed the model to produce exactly the two shapes `card_rejection` drops:

| the prompt said | the gate does |
|---|---|
| "lead with one direct sentence, then add short markdown bullets ('- ...')" | `_MAX_ENUMERATED_ITEMS = 1` -> rejects as `enumerated` |
| `[{"question": "...", "answer": "...", "source_excerpt": ""}]` | requires >=12 chars, >=2 tokens, verbatim -> rejects as `ungrounded` |

Both reasons appear verbatim in the backend log, and I fired both rejections directly before changing anything. **The gate was never wrong** — `_MAX_ENUMERATED_ITEMS = 1` encodes the one-fact-per-card rule. The prompt now states the contract `FLASHCARD_SYSTEM` already used on the document path, so there is one contract instead of two.

**Measured**, 6 real notes x 3 repeats, `count=5`, same library, backend restarted between arms:

| note | control | fixed |
|---|---|---|
| Micrograd | `[0, 0, 0]` | `[5, 0, 5]` |
| Automatic Differentiation | `[0, 0, 4]` | `[1, 3, 3]` |
| Retrieval - Draft | `[0, 0, 0]` | `[1, 0, 2]` |
| Daily thoughts | `[2, 5, 0]` | `[4, 0, 0]` |
| Search Algos | `[2, 0, 0]` | `[0, 1, 3]` |
| Semantic Query Comprehension | `[0, 0, 0]` | `[1, 0, 5]` |
| **overall** | **13/90 = 0.1444** | **34/90 = 0.3778** |

Four of six notes returned zero on all three control runs. Read the distributions, not the means: `[5, 0, 5]` is one note under one build.

The new template shows `<verbatim sentence from the notes>`, which clears the length floor — so it is named `NOTES_EXCERPT_PLACEHOLDER` and refused alongside `EXAMPLE_SOURCE_EXCERPT`, not left to the luck of the string being absent from the notes.

## 2. `card_genre` was decorative

The facet model derives `CardGenre` from form/domain/register and the API returns it, but **no generator read it**. `_infer_genre` was a second, string-matching copy that disagreed with the model in two ways:

- a book is called technical from a keyword in its **title**
- every video is called a meeting — so a recorded technical talk got the meeting strategy ("what was decided, who owns it"), the same defect #105 fixed in the summarizer

`_infer_genre` now reads `DocumentProfile.card_genre` and keeps `content_type` only as the fallback for rows ingested before the facets. **7 of 28 eval documents change genre** — `moby-dick`, `alice_in_wonderland` and `time_machine` reach the `narrative` strategy, which was unreachable for books, and two technical talks stop being asked who owns the action item.

`DocumentProfile.from_row` replaces the row-to-profile construction that had been copy-pasted at three sites.

## 3. What the eval does and does not say

`make eval-flashcards`, two runs per arm:

| | control 1 | control 2 | fixed 1 | fixed 2 |
|---|---|---|---|---|
| factuality | 0.7396 | **0.6026** | 0.7083 | 0.7300 |
| clarity_avg | 2.8889 | 2.8077 | 2.5833 | 2.9000 |
| cards_returned | 37 | 35 | 31 | 32 |
| book factuality | 0.73 | 0.79 | 0.58 | 0.68 |

**The control arm disagrees with itself by 0.1370 on factuality.** The between-arm gap is ~0.01. One run per arm reported a confident regression (`book` 9/21 -> 4/21, factuality 0.73 -> 0.58) that the repeat erased — `book` went 9, 10, 4, 9 across the four runs with the change in only two of them.

So: **this eval resolves nothing about the genre change**, in either direction. It is not a regression and it is not a demonstrated improvement. The justification is routing correctness — asking a talk for its technique rather than its action items — and no metric here measures whether a question is the right *kind* for the material. Noise floor recorded in `docs/eval-coverage.md`.

`atomicity` reads 1.0000, but it is structural (`is_atomic`) rather than judged, and I fired it: a two-sentence answer scores 0. It sits at 1.0 because the gate already removes bulleted answers, which leaves narrow headroom.

## Still open, deliberately not fixed here

- **Yield is 0.378, not 1.0.** The dominant remaining rejection is `source quote is not in the text`. Of 45 rejected excerpts, ~20 are genuinely paraphrased (correctly dropped) and ~11 look near-verbatim — but the log records `excerpt[:60]`, so the divergence may be in the part never printed. Widening the matcher on that evidence would be tuning a check until output passes. The instrument needs fixing first.
- **Over half of all generated cards die in near-duplicate filtering** (`items_deduped` 49-64 against `items_delivered` 84-96). Largest single loss on the document path, unrelated to this change.
- **The notes path has no eval.** `make eval-flashcards` posts a `document_id` and never calls it, which is why 0/5 yield was invisible to the suite.

## Also in this branch

- **#104**: the Notes tab was gated on `content_type == 'conversation'`, so speaker-turn content in any other container never showed it.
- **Smoke (#62)**: re-measured at **178 pass / 0 fail** — the "68 PASS / 48 FAIL" is stale. But S144 and S192 parsed `GET /documents` as a list, so both printed "no documents in library" against a 55-document library and silently skipped their assertions; S167 executed its own code comment (backticks inside an unquoted `python3 -c` heredoc). All three now assert. Full write-up on #62.

## Verification

`make ci` green. `make eval-flashcards` run four times (above). Notes path exercised against the real app, both arms, not just the suite. **Not verified:** whether the genre change improves card quality — no instrument in this repo can currently see it.