### PR TITLE
Gate the smoke suite against API drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,6 +354,7 @@ lint:
 	python3 scripts/check_manifest_schema.py
 	python3 scripts/check_manifest_coverage.py
 	python3 scripts/check_public_surface_calls.py
+	python3 scripts/check_smoke_paths.py
 	bash scripts/check_powershell.sh
 
 test:
@@ -686,6 +687,7 @@ endif
 	python3 scripts/check_manifest_schema.py
 	python3 scripts/check_manifest_coverage.py
 	python3 scripts/check_public_surface_calls.py
+	python3 scripts/check_smoke_paths.py
 	bash scripts/check_powershell.sh
 	cd frontend && npm run build
 	python3 scripts/check_public_bundle_excludes_full.py

--- a/scripts/check_smoke_paths.py
+++ b/scripts/check_smoke_paths.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Assert every path a smoke script calls still exists in the API surface.
+
+`make smoke` needs a live backend and a local model, so it cannot run on a CI
+runner -- which is how 48 of its scripts came to test endpoints that had been
+renamed or deleted without anything noticing (#62). This check needs neither: it
+reads the OpenAPI schema straight off the FastAPI app and compares it against the
+URLs the scripts build.
+
+**What it catches**: a call whose route is gone entirely -- the `/code/execute`,
+`/chat/confusion-signals`, `/qa/history` and `/explain/glossary/*` classes, which
+were four of the five in that report.
+
+**What it cannot**: a rename into a slot the API still declares as a parameter.
+`/documents/upload` matches `/documents/{document_id}` for the same reason
+`/documents/nonexistent-s146-doc-id` does -- a 404 probe and a rename are the
+same string shape, and 27 scripts legitimately probe 404s that way. Guessing
+between them produces false alarms on a green suite, which is how a check stops
+being read. `make smoke` catches that class by running it.
+
+It catches drift, not behaviour. A script whose endpoint still exists but whose
+assertions are wrong is `make smoke`'s job.
+
+A script that asserts an endpoint stays *gone* declares it:
+
+    # smoke-expects-absent: /code/execute
+
+Those are the scripts this check must never flag. S140 guards a code-execution
+sandbox that was deleted for security, and a flag inviting someone to "repair" it
+by restoring the route is the one outcome worse than the drift.
+
+Wired into `make lint`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SMOKE = REPO / "scripts" / "smoke"
+
+# `curl ... "${BASE}/documents/${DOC_ID}/sections"`. Both brace styles appear.
+_CALL = re.compile(r"\$\{?BASE\}?\"?(/[A-Za-z0-9_${}/.-]*)")
+_EXPECTS_ABSENT = re.compile(r"^#\s*smoke-expects-absent:\s*(\S+)", re.M)
+
+_SHELL_VAR = re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$[A-Za-z_][A-Za-z0-9_]*")
+_UUID = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.I)
+
+# Served by FastAPI itself and deliberately absent from `paths`.
+_BUILTINS = {"/openapi.json", "/docs", "/redoc", "/docs/oauth2-redirect"}
+
+
+def route_paths() -> list[str]:
+    """The live surface, read off the app's routes rather than its schema.
+
+    The routes keep their converters -- `/tags/{tag_id:path}` -- and the schema
+    does not. That distinction is the whole check: without it a parameter has to
+    be allowed to swallow several segments, and `/documents/upload` then matches
+    `/documents/{document_id}` as though `upload` were an id, which is exactly
+    the rename this is supposed to catch.
+    """
+    code = (
+        "import json,os;"
+        "os.environ.setdefault('LUMINARY_MODE','full');"
+        "from app.main import app;"
+        "print(json.dumps(sorted({r.path for r in app.routes if hasattr(r,'path')})))"
+    )
+    out = subprocess.run(
+        ["uv", "run", "python", "-c", code],
+        cwd=REPO / "backend",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode != 0:
+        print("could not read the OpenAPI schema:", file=sys.stderr)
+        print(out.stderr[-2000:], file=sys.stderr)
+        raise SystemExit(2)
+    return set(json.loads(out.stdout.strip().splitlines()[-1]))
+
+
+def normalise(raw: str) -> str:
+    """A called URL reduced to the shape OpenAPI declares."""
+    path = raw.split("?", maxsplit=1)[0].split("#", maxsplit=1)[0].rstrip("\"'&;|)")
+    path = _SHELL_VAR.sub("{p}", path)
+    path = _UUID.sub("{p}", path)
+    return re.sub(r"/+", "/", path).rstrip("/") or "/"
+
+
+def matcher(route_path: str) -> re.Pattern[str]:
+    """A declared route as a regex over called paths.
+
+    A parameter matches one segment, or several when the route declared
+    `:path`. Anything may fill a parameter: smoke scripts put literal ids there
+    to probe 404s (`/documents/nonexistent-s146-doc-id`), and those are
+    indistinguishable from a renamed sub-resource.
+    """
+    parts = []
+    for seg in route_path.strip("/").split("/"):
+        if not seg.startswith("{"):
+            parts.append(re.escape(seg))
+        else:
+            parts.append(r".+" if seg.endswith(":path}") else r"[^/]+")
+    return re.compile("^/" + "/".join(parts) + "$")
+
+
+def main() -> int:
+    declared = [p for p in route_paths() if not p.startswith("/{full_path")]
+    patterns = [matcher(p) for p in declared]
+    literal = {p for p in declared if "{" not in p} | _BUILTINS
+
+    missing: list[tuple[str, str]] = []
+    checked = 0
+    scripts = sorted(SMOKE.glob("S*.sh"))
+    for script in scripts:
+        text = script.read_text()
+        absent = {p.rstrip("/") for p in _EXPECTS_ABSENT.findall(text)}
+        for raw in _CALL.findall(text):
+            path = normalise(raw)
+            if path == "/":
+                continue
+            checked += 1
+            if path in literal or path in absent:
+                continue
+            if any(pat.match(path) for pat in patterns):
+                continue
+            missing.append((script.name, path))
+
+    if missing:
+        print(f"{len(missing)} smoke call(s) target paths the API no longer serves:\n")
+        for name, path in sorted(set(missing)):
+            print(f"  {name:12} {path}")
+        print(
+            "\nEach needs a decision, not a mechanical repair: renamed, deliberately\n"
+            "removed, or genuinely lost. If the script asserts the endpoint stays gone,\n"
+            "declare it with `# smoke-expects-absent: <path>` -- never bring the route\n"
+            "back to make this pass."
+        )
+        return 1
+
+    print(f"smoke paths OK: {checked} calls across {len(scripts)} scripts")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke/S140.sh
+++ b/scripts/smoke/S140.sh
@@ -15,6 +15,7 @@
 #      as still-removed
 #
 # Requires a running backend at localhost:7820.
+# smoke-expects-absent: /code/execute
 set -euo pipefail
 
 BASE="${BASE:-http://localhost:7820}"

--- a/scripts/smoke/S187.sh
+++ b/scripts/smoke/S187.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Smoke test for S187: Chat document-aware contextual recommendations
+# smoke-expects-absent: /chat/confusion-signals
 set -euo pipefail
 
 BASE="${LUMINARY_BASE_URL:-http://localhost:7820}"


### PR DESCRIPTION
Closes the open half of #62. The suite is green (178/178, re-measured), but nothing stops it rotting again — which is how 48 scripts came to call endpoints that no longer existed, across three releases, with no signal.

`make smoke` needs a live backend and a local model, so it cannot run on a runner. This check needs neither: it reads the routes off the FastAPI app and asserts every path a smoke script builds still resolves. Wired into `make lint` and `make ci`.

## What it catches, verified by firing it

Each of these was appended to a real script and the check confirmed to flag it:

| injected path | result |
|---|---|
| `/code/execute` | CAUGHT |
| `/chat/confusion-signals` | CAUGHT |
| `/qa/history` | CAUGHT |
| `/explain/glossary/term` | CAUGHT |

Four of the five drift classes in #62.

## What it cannot catch, and why I stopped trying

`/documents/upload` — the fifth class — matches `/documents/{document_id}`, because a renamed sub-resource and a 404 probe are the same string shape. **27 scripts legitimately probe 404s that way** (`/documents/nonexistent-s146-doc-id`, `/flashcards/audit/smoke-test-doc`, `/model-lab/runs/does-not-exist`).

I built the strict version that distinguishes them by treating a literal segment in a parameter slot as a rename. It flagged all 27 on a suite passing 178/178. A check that cries wolf on a green suite stops being read, which is the failure this issue is about. `make smoke` catches that class by running it; this one is deliberately the zero-false-positive half, and the docstring says so.

## Negative tests declare themselves

Two scripts assert an endpoint stays **gone**, and they are the most valuable in the suite:

```bash
# smoke-expects-absent: /code/execute
```

S140 guards a code-execution sandbox deleted for security in `33748f2`. A tool flagging it as "broken" invites exactly the repair #62 warns against — restoring the route to make the gate green. The declaration is path-scoped, not a blanket suppression: I verified S140 still fails if it calls a *different* dead path.

## Verification

- `make ci` green.
- Check passes on the current tree: 598 calls across 178 scripts.
- Fired on purpose in both directions — each removed class caught, and the suppression proven not to over-reach.

## Also here

Nothing else. The `/openapi.json` allowlist covers FastAPI built-ins that are served but absent from `paths`, and `{tag_id:path}` catch-alls are read from the route rather than the schema, which strips the converter.