### PR TITLE
A note can generate its own cards, and a zero run says why

### DIFF
--- a/frontend/src/components/GenerateFlashcardsDialog.tsx
+++ b/frontend/src/components/GenerateFlashcardsDialog.tsx
@@ -157,16 +157,19 @@ export function GenerateFlashcardsDialog({
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
 
-  // Fetch notes when dialog opens; pre-select initialNoteIds when provided
+  // Fetch notes when dialog opens; pre-select initialNoteIds when provided.
+  // Keyed on the ids as a string, not the array: this effect sets state, so a
+  // caller passing a fresh literal (`initialNoteIds={[id]}`) would re-run it on
+  // every render and never settle.
+  const initialKey = (initialNoteIds ?? []).join(",")
   useEffect(() => {
-    if (open) {
-      void fetchNoteStubs().then(setAvailableNotes)
-      if (initialNoteIds && initialNoteIds.length > 0) {
-        setMode("notes")
-        setSelectedNoteIds(initialNoteIds)
-      }
+    if (!open) return
+    void fetchNoteStubs().then(setAvailableNotes)
+    if (initialKey) {
+      setMode("notes")
+      setSelectedNoteIds(initialKey.split(","))
     }
-  }, [open, initialNoteIds])
+  }, [open, initialKey])
 
   const { data: collectionTree } = useQuery({
     queryKey: ["collections-tree"],
@@ -518,9 +521,24 @@ export function GenerateFlashcardsDialog({
               </div>
             )}
 
+            {/* Not "broaden your selection": the selection is never the cause.
+                A card is dropped when its answer does not quote the note, and
+                that varies run to run on identical input -- so retrying the
+                same scope is the action that works. */}
             {success && !collectionResult && generatedCards.length === 0 && (
-              <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-center dark:border-amber-900 dark:bg-amber-950/40">
-                <p className="text-sm text-amber-800 italic">No flashcards were generated. Try broadening your selection.</p>
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-4 dark:border-amber-900 dark:bg-amber-950/40">
+                <p className="text-sm text-amber-800 dark:text-amber-300">
+                  The model didn&apos;t produce a card that quotes these notes. This varies between
+                  runs — generating again on the same notes usually works.
+                </p>
+                <button
+                  onClick={() => void handleGenerate()}
+                  disabled={isGenerating || !canGenerate}
+                  className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-amber-300 bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent disabled:opacity-50 dark:border-amber-800"
+                >
+                  {isGenerating ? <Loader2 size={14} className="animate-spin" /> : null}
+                  Try again
+                </button>
               </div>
             )}
           </div>

--- a/frontend/src/components/NoteConceptChips.test.tsx
+++ b/frontend/src/components/NoteConceptChips.test.tsx
@@ -1,0 +1,23 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { NoteConceptChips } from "./NoteConceptChips"
+
+const html = () =>
+  renderToStaticMarkup(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <NoteConceptChips noteId="n1" noteTitle="Search Algos" />
+    </QueryClientProvider>,
+  )
+
+describe("NoteConceptChips", () => {
+  it("offers both writing cards and studying them", () => {
+    // A note page carried only "Quiz me", which opens the Study Launcher on
+    // cards that already exist. A note with none offered nothing at the moment
+    // the reader wants them, and no other surface generates from one note (#113).
+    const out = html()
+    expect(out).toContain("Make cards")
+    expect(out).toContain("Quiz me on this note")
+  })
+})

--- a/frontend/src/components/NoteConceptChips.tsx
+++ b/frontend/src/components/NoteConceptChips.tsx
@@ -1,11 +1,17 @@
-// NoteConceptChips -- concept-link chips + "Quiz me on this note" (docs/03-notes-generation.md).
-// Reads GET /concepts/for-note/{id} (engagement + lexical; degrades gracefully when the
-// linker is off). Each chip opens the Study Launcher on that concept; "Quiz me" opens it
-// on the whole note (note scope -> due cards now, generated cards later).
+// NoteConceptChips -- concept-link chips, "Quiz me on this note" and "Make cards"
+// (docs/03-notes-generation.md). Reads GET /concepts/for-note/{id} (engagement +
+// lexical; degrades gracefully when the linker is off). Each chip opens the Study
+// Launcher on that concept; "Quiz me" opens it on the whole note.
+//
+// The two buttons are different verbs and the pair is deliberate: "Quiz me"
+// studies cards that exist, "Make cards" writes them. Only the first was here, so
+// a note with no cards yet offered nothing at the moment the reader wants them.
 
 import { useQuery } from "@tanstack/react-query"
-import { Sparkles, Tag } from "lucide-react"
+import { CreditCard, Sparkles, Tag } from "lucide-react"
+import { useMemo, useState } from "react"
 
+import { GenerateFlashcardsDialog } from "@/components/GenerateFlashcardsDialog"
 import { apiGet } from "@/lib/apiClient"
 import { launchStudy } from "@/lib/studyLauncher"
 
@@ -25,6 +31,11 @@ export function NoteConceptChips({
   noteId: string
   noteTitle?: string
 }) {
+  const [generating, setGenerating] = useState(false)
+  // Stable identity: the dialog's open-effect depends on this array and calls
+  // setState from it, so a fresh literal each render re-runs the effect, sets
+  // state, and re-renders -- the unbounded loop InDocSearchBar hit.
+  const scope = useMemo(() => [noteId], [noteId])
   const { data, isLoading } = useQuery({
     queryKey: ["note-concepts", noteId],
     queryFn: () => apiGet<NoteConcept[]>(`/concepts/for-note/${noteId}`),
@@ -38,13 +49,26 @@ export function NoteConceptChips({
           <Tag size={12} />
           <span className="text-[10px] font-bold uppercase tracking-wider">Concepts</span>
         </div>
-        <button
-          onClick={() => launchStudy({ type: "note", ref: noteId, label: noteTitle || "this note" })}
-          className="flex items-center gap-1 rounded-full border border-primary/30 bg-primary/5 px-2 py-0.5 text-[11px] text-primary hover:bg-primary/10 transition-colors"
-        >
-          <Sparkles size={10} />
-          Quiz me on this note
-        </button>
+        <div className="flex items-center gap-1.5">
+          <button
+            onClick={() => setGenerating(true)}
+            title="Generate flashcards from this note"
+            className="flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+          >
+            <CreditCard size={10} />
+            Make cards
+          </button>
+          <button
+            onClick={() =>
+              launchStudy({ type: "note", ref: noteId, label: noteTitle || "this note" })
+            }
+            title="Study the cards this note already has"
+            className="flex items-center gap-1 rounded-full border border-primary/30 bg-primary/5 px-2 py-0.5 text-[11px] text-primary hover:bg-primary/10 transition-colors"
+          >
+            <Sparkles size={10} />
+            Quiz me on this note
+          </button>
+        </div>
       </div>
       <div className="flex flex-wrap gap-1.5">
         {isLoading ? (
@@ -67,6 +91,12 @@ export function NoteConceptChips({
           <span className="text-xs text-muted-foreground italic">No linked concepts yet</span>
         )}
       </div>
+      <GenerateFlashcardsDialog
+        open={generating}
+        onClose={() => setGenerating(false)}
+        availableTags={[]}
+        initialNoteIds={scope}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Closes #113. Both gaps were left open by #108 and both were hit in normal use.

## The note page could not generate cards

`GenerateFlashcardsDialog` was mounted in exactly two places — the Notes list toolbar and `CollectionHealthPanel`. On `/notes/{id}` the only card control was "Quiz me on this note", which opens the Study Launcher on cards that **already exist** and never writes any. On a note with none, that reads as a broken feature.

The control now sits in `NoteConceptChips`, next to "Quiz me", so it appears in both NotePage layouts from one change and lands where the intent forms — while reading the note. The two verbs are deliberately paired: *Make cards* writes, *Quiz me* studies.

## A zero run blamed the user's selection

> No flashcards were generated. Try broadening your selection.

The selection is never the cause. A card is dropped when its answer cannot quote the note, and that varies run to run on identical input. Broadening it sends more text to the same model.

Measured against a live backend on the note from the report, same scope, same build:

| run | cards |
|---|---|
| 1 | 0 |
| 2 | **5** |
| 3 | 1 |

So the retry genuinely works, and the message now says what happened and offers it. This is not rare — post-fix yield is 0.6333, so roughly one run in three is empty.

## A loop I introduced and removed

Mounting the dialog with `initialNoteIds={[noteId]}` passes a **new array every render**, and the dialog's open-effect depends on it *and calls `setSelectedNoteIds` from it* — set state, re-render, fresh literal, effect again. That is the unbounded-refetch loop `InDocSearchBar` hit, where the visible symptom was something else entirely.

Fixed at the root rather than at the call site: the effect is keyed on the ids joined as a string, so no caller can loop it. The existing caller passes React state and was already safe; it stays safe.

## Verification

- `make ci` green. `tsc -b --noEmit` clean via the project's own binary, not `npx`.
- eslint unchanged at 90 warnings — worth noting the repo sits exactly on its `--max-warnings 90` ceiling, so the next warning anywhere fails CI.
- The endpoint exercised against a live backend, including the empty case the new message is for.
- `NoteConceptChips.test.tsx` asserts both controls render.

**Not verified**: I have no browser here, so the dialog was not clicked. The request it issues was run directly and the wiring is covered by the test.