### PR TITLE
Shape-check ids before they reach a LanceDB predicate

### DIFF
--- a/backend/app/services/collection_health.py
+++ b/backend/app/services/collection_health.py
@@ -86,7 +86,10 @@ async def _fetch_cohesion_score(note_ids: list[str]) -> float | None:
         return None
 
     def _sync_fetch(ids: list[str]) -> list[list[float]]:
-        from app.services.vector_store import get_lancedb_service  # noqa: PLC0415
+        from app.services.vector_store import (  # noqa: PLC0415
+            get_lancedb_service,
+            id_predicate,
+        )
 
         svc = get_lancedb_service()
         try:
@@ -95,9 +98,11 @@ async def _fetch_cohesion_score(note_ids: list[str]) -> float | None:
             logger.warning("Could not open note_vectors_v2 for cohesion: %s", exc)
             return []
 
-        id_filter = ", ".join(f"'{nid}'" for nid in ids)
+        pred = id_predicate("note_id", ids, context="collection_cohesion")
+        if pred is None:
+            return []
         try:
-            df = tbl.to_pandas(filter=f"note_id IN ({id_filter})")
+            df = tbl.to_pandas(filter=pred)
             vectors: list[list[float]] = []
             for row in df.itertuples():
                 v = row.vector

--- a/backend/app/services/reindex_service.py
+++ b/backend/app/services/reindex_service.py
@@ -30,7 +30,10 @@ class ReindexService:
         Exceptions per note are caught and counted in `failed`.
         """
         from app.services.embedder import get_embedding_service  # noqa: PLC0415
-        from app.services.vector_store import get_lancedb_service  # noqa: PLC0415
+        from app.services.vector_store import (  # noqa: PLC0415
+            eq_predicate,
+            get_lancedb_service,
+        )
 
         result = await db.execute(select(NoteModel.id, NoteModel.content, NoteModel.document_id))
         rows = result.all()
@@ -48,7 +51,8 @@ class ReindexService:
                     tbl = svc._get_or_create_note_table()
                     # Use count_rows with filter for presence check
                     try:
-                        count = tbl.count_rows(f"note_id = '{nid}'")
+                        pred = eq_predicate("note_id", nid, context="reindex_notes")
+                        count = tbl.count_rows(pred) if pred else 0
                         return count > 0
                     except Exception:
                         return False

--- a/backend/app/services/retriever.py
+++ b/backend/app/services/retriever.py
@@ -215,12 +215,18 @@ class HybridRetriever:
                     logger.debug("vector_search: LanceDB table empty, returning []")
                     return []
 
+            from app.services.vector_store import id_predicate  # noqa: PLC0415
+
             vector = _embedder_module.embed_query(query)
             table = svc._get_table()
             search = table.search(vector).metric("cosine").limit(k)
             if document_ids:
-                id_list = ", ".join(f"'{did}'" for did in document_ids)
-                search = search.where(f"document_id IN ({id_list})", prefilter=True)
+                # None means "match nothing": dropping the filter would widen a
+                # document-scoped search to the whole library.
+                pred = id_predicate("document_id", document_ids, context="vector_search")
+                if pred is None:
+                    return []
+                search = search.where(pred, prefilter=True)
             rows = search.to_list()
 
             results: list[ScoredChunk] = []

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -53,6 +54,13 @@ _UUID_RE = re.compile(
     r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
 )
 
+# LanceDB takes predicates as SQL strings and offers no parameter binding, so a
+# quoted id is the only way to filter and shape-checking is the only defence.
+# Both forms are real: `uuid.uuid4()` for documents, chunks, notes and images,
+# and `uuid.uuid4().hex` for concepts and study events. Accepting only the dashed
+# form would silently make every concept-vector predicate match nothing.
+_SAFE_ID_RE = re.compile(r"[0-9a-fA-F]{32}|" + _UUID_RE.pattern)
+
 IMAGE_SCHEMA = pa.schema(
     [
         pa.field("image_id", pa.string()),
@@ -76,6 +84,38 @@ CONCEPT_SCHEMA = pa.schema(
         pa.field("vector", pa.list_(pa.float32(), CONCEPT_VECTOR_DIM)),
     ]
 )
+
+
+def safe_id(value: str) -> str | None:
+    """*value* if it is an id this process generates, else None."""
+    return value if value and _SAFE_ID_RE.fullmatch(value) else None
+
+
+def id_predicate(column: str, ids: Sequence[str], *, context: str) -> str | None:
+    """`column IN ('a','b')` over the ids that pass the shape check.
+
+    None when nothing survives, which callers must treat as "match nothing"
+    rather than falling through to an unfiltered predicate -- an `IN ()` that
+    silently became `WHERE true` would delete a whole table.
+    """
+    kept = [i for i in ids if safe_id(i)]
+    if len(kept) != len(ids):
+        logger.warning(
+            "%s: refused %d id(s) that are not the shape this process generates",
+            context,
+            len(ids) - len(kept),
+        )
+    if not kept:
+        return None
+    return f"{column} IN ({', '.join(chr(39) + i + chr(39) for i in kept)})"
+
+
+def eq_predicate(column: str, value: str, *, context: str) -> str | None:
+    """`column = 'value'`, or None when the id fails the shape check."""
+    if safe_id(value) is None:
+        logger.warning("%s: refused an id that is not the shape this process generates", context)
+        return None
+    return f"{column} = '{value}'"
 
 
 class LanceDBService:
@@ -114,15 +154,19 @@ class LanceDBService:
         """Return the number of vector rows stored for the given document_id."""
         try:
             table = self._get_table()
-            return table.count_rows(f"document_id = '{document_id}'")
+            pred = eq_predicate("document_id", document_id, context="count_for_document")
+            return table.count_rows(pred) if pred else 0
         except Exception:
             logger.warning("row count failed for %s; reporting 0", document_id, exc_info=True)
             return 0
 
     def delete_document(self, document_id: str) -> None:
         """Delete all vectors for the given document_id."""
+        pred = eq_predicate("document_id", document_id, context="delete_document")
+        if pred is None:
+            return
         table = self._get_table()
-        table.delete(f"document_id = '{document_id}'")
+        table.delete(pred)
         logger.info("Deleted vectors for document %s from LanceDB", document_id)
 
     def _get_or_create_note_table(self) -> Any:
@@ -189,8 +233,11 @@ class LanceDBService:
         "deletes that did not happen" is how the ghost went unnoticed.
         """
         try:
+            pred = eq_predicate("note_id", note_id, context="delete_note_vector")
+            if pred is None:
+                return
             table = self._get_or_create_note_table()
-            table.delete(f"note_id = '{note_id}'")
+            table.delete(pred)
             logger.debug("Deleted note vector note_id=%s", note_id)
         except Exception:
             logger.exception("delete_note_vector failed for note_id=%s", note_id)
@@ -233,8 +280,12 @@ class LanceDBService:
             table = self._get_image_table()
             search = table.search(query_vector).metric("cosine").limit(k)
             if document_ids:
-                id_list = ", ".join(f"'{did}'" for did in document_ids)
-                search = search.where(f"document_id IN ({id_list})", prefilter=True)
+                # No usable id means "match nothing". Skipping the filter would
+                # widen an explicitly scoped search to the whole library.
+                pred = id_predicate("document_id", document_ids, context="search_image_vectors")
+                if pred is None:
+                    return []
+                search = search.where(pred, prefilter=True)
             rows = search.to_list()
             return [row for row in rows if 1.0 - float(row.get("_distance", 1.0)) >= threshold]
         except Exception as exc:
@@ -244,8 +295,13 @@ class LanceDBService:
     def delete_image_vectors_for_document(self, document_id: str) -> None:
         """Delete all image vectors for the given document_id."""
         try:
+            pred = eq_predicate(
+                "document_id", document_id, context="delete_image_vectors_for_document"
+            )
+            if pred is None:
+                return
             table = self._get_image_table()
-            table.delete(f"document_id = '{document_id}'")
+            table.delete(pred)
             logger.info("Deleted image vectors for document %s", document_id)
         except Exception as exc:
             logger.warning("delete_image_vectors_for_document failed doc=%s: %s", document_id, exc)
@@ -270,9 +326,11 @@ class LanceDBService:
         if not safe:
             return
         try:
+            pred = id_predicate("image_id", safe, context="delete_image_vectors")
+            if pred is None:
+                return
             table = self._get_image_table()
-            quoted = ", ".join(f"'{i}'" for i in safe)
-            table.delete(f"image_id IN ({quoted})")
+            table.delete(pred)
             logger.info("Deleted %d image vector(s)", len(safe))
         except Exception as exc:
             logger.warning("delete_image_vectors failed: %s", exc)
@@ -303,10 +361,12 @@ class LanceDBService:
             ids = list(dict.fromkeys(chunk_ids))
             for i in range(0, len(ids), 800):
                 batch = ids[i : i + 800]
-                id_list = ", ".join(f"'{c}'" for c in batch)
+                pred = id_predicate("chunk_id", batch, context="vectors_for_chunks")
+                if pred is None:
+                    continue
                 rows = (
                     table.search()
-                    .where(f"chunk_id IN ({id_list})")
+                    .where(pred)
                     .select(["chunk_id", "vector"])
                     .limit(len(batch))
                     .to_list()
@@ -330,13 +390,18 @@ class LanceDBService:
         try:
             import numpy as np  # noqa: PLC0415
 
+            # None, not []: the caller writes the centroid when it is not None,
+            # and an empty vector reaches LanceDB as a zero-length list, which
+            # fails the fixed-size schema at write time rather than here.
+            pred = id_predicate("chunk_id", chunk_ids, context="compute_centroid")
+            if pred is None:
+                return None
             table = self._get_table()
-            id_list = ", ".join(f"'{cid}'" for cid in chunk_ids)
             # search() with no query vector is a plain filtered scan; limit must be
             # explicit (default is 10) so we don't truncate the evidence set.
             rows = (
                 table.search()
-                .where(f"chunk_id IN ({id_list})")
+                .where(pred)
                 .select(["vector"])
                 .limit(len(chunk_ids))
                 .to_list()
@@ -363,8 +428,11 @@ class LanceDBService:
     def delete_concept_vector(self, concept_id: str) -> None:
         """Delete the vector for the given concept_id."""
         try:
+            pred = eq_predicate("concept_id", concept_id, context="delete_concept_vector")
+            if pred is None:
+                return
             table = self._get_or_create_concept_table()
-            table.delete(f"concept_id = '{concept_id}'")
+            table.delete(pred)
             logger.debug("Deleted concept vector concept_id=%s", concept_id)
         except Exception as exc:
             logger.warning("delete_concept_vector failed for concept_id=%s: %s", concept_id, exc)

--- a/backend/tests/test_concepts_phase0.py
+++ b/backend/tests/test_concepts_phase0.py
@@ -39,22 +39,30 @@ async def test_db(tmp_path, monkeypatch):
     graph_module._graph_service = orig_graph
 
 
+# LanceDB predicates are interpolated, so ids are shape-checked before they reach
+# one (#95). These were "ch1"/"d1", which no ingest produces -- the check refused
+# them and the centroid came back empty, which is the right answer for an id the
+# process could not have generated.
+_CH1 = "3f1c2b7a-8d94-4e2b-9c31-5a7e6b0d4f28"
+_D1 = "c4a91e05-7b23-4d68-8f1a-2e9c3b5d7a64"
+
+
 async def test_create_concept_spans_three_stores_and_resolves(test_db):
     _engine, factory = test_db
     get_lancedb_service().upsert_chunks(
-        [{"chunk_id": "ch1", "document_id": "d1", "content_type": "text",
+        [{"chunk_id": _CH1, "document_id": _D1, "content_type": "text",
           "section_heading": "", "page": 0, "chunk_index": 0, "speaker": "",
           "text": "iceberg", "vector": [2.0] * 384}]
     )
     g = get_graph_service()
-    g.upsert_document("d1", "Doc", "book")
+    g.upsert_document(_D1, "Doc", "book")
     g.upsert_entity("e1", "Iceberg", "concept")
     svc = get_concept_service()
     async with factory() as s:
         c = await svc.create_concept(
             s, label="Iceberg Manifests", origin="document", status="proposed",
-            evidence=[{"document_id": "d1", "chunk_id": "ch1", "quote": "an iceberg"}],
-            document_ids=["d1"], entity_ids=["e1"],
+            evidence=[{"document_id": _D1, "chunk_id": _CH1, "quote": "an iceberg"}],
+            document_ids=[_D1], entity_ids=["e1"],
         )
         await svc.set_learning_state(s, c.id, mastery=42.0, stability=5.0)
         await s.commit()
@@ -62,14 +70,14 @@ async def test_create_concept_spans_three_stores_and_resolves(test_db):
 
     assert slug == "iceberg-manifests"
     # Kuzu topology
-    assert g.get_concept_ids_for_documents(["d1"]) == [cid]
+    assert g.get_concept_ids_for_documents([_D1]) == [cid]
     # LanceDB derived centroid
     assert get_lancedb_service().search_concepts([2.0] * 384, k=3)[0]["concept_id"] == cid
     # SQLite state + scope resolution
     async with factory() as s:
         row = await s.get(ConceptModel, cid)
         assert row.mastery == 42.0 and row.status == "proposed"
-        assert await resolve_scope(s, "doc", "d1") == [cid]
+        assert await resolve_scope(s, "doc", _D1) == [cid]
         assert await resolve_daily(s) == [cid]
         assert await resolve_scope(s, "tag", "x") == []  # not-yet-wired scope
 

--- a/backend/tests/test_lancedb_predicates.py
+++ b/backend/tests/test_lancedb_predicates.py
@@ -1,0 +1,65 @@
+"""LanceDB predicates are built by interpolation, so ids are shape-checked (#95).
+
+LanceDB takes `where`/`filter`/`delete` as SQL strings and offers no parameter
+binding, so "bind the ids" is not available here. Shape-checking before quoting
+is, and these assert the two properties that matter: nothing but an id this
+process generates reaches a predicate, and every id it does generate is accepted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.vector_store import eq_predicate, id_predicate, safe_id
+
+DASHED = "02acff68-b6bb-4efa-a5af-d6a8d3d9e465"  # uuid4(): documents, chunks, notes, images
+BARE = "005a25379cc44337bedd4a24b8b7364d"  # uuid4().hex: concepts, study events
+
+
+class TestAcceptsWhatTheProcessGenerates:
+    """Both id shapes are real, and refusing either breaks a feature silently.
+
+    `concepts.id` is `uuid.uuid4().hex` -- 32 hex characters, no dashes. A guard
+    written against the dashed form alone would make every concept-vector
+    predicate match nothing, and `delete_concept_vector` a no-op that logs
+    success.
+    """
+
+    @pytest.mark.parametrize("value", [DASHED, BARE])
+    def test_both_shapes_pass(self, value: str) -> None:
+        assert safe_id(value) == value
+
+    def test_a_mixed_batch_keeps_every_id(self) -> None:
+        pred = id_predicate("chunk_id", [DASHED, BARE], context="t")
+        assert pred is not None
+        assert DASHED in pred and BARE in pred
+
+
+class TestRefusesEverythingElse:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "x' OR '1'='1",
+            "'; DROP TABLE chunk_vectors_v3; --",
+            "02acff68-b6bb-4efa-a5af-d6a8d3d9e465' OR '1'='1",
+            "",
+            "not-an-id",
+            "005a25379cc44337bedd4a24b8b7364",  # 31 chars
+        ],
+    )
+    def test_rejected(self, value: str) -> None:
+        assert safe_id(value) is None
+        assert eq_predicate("document_id", value, context="t") is None
+
+    def test_no_survivor_returns_none_not_an_empty_in_list(self) -> None:
+        """`IN ()` is a syntax error at best and `WHERE true` at worst.
+
+        Callers treat None as "match nothing"; returning an empty clause here
+        would turn a scoped delete into a whole-table one.
+        """
+        assert id_predicate("chunk_id", ["not-an-id"], context="t") is None
+        assert id_predicate("chunk_id", [], context="t") is None
+
+    def test_one_bad_id_does_not_discard_the_good_ones(self) -> None:
+        pred = id_predicate("chunk_id", [DASHED, "x' OR '1'='1"], context="t")
+        assert pred == f"chunk_id IN ('{DASHED}')"

--- a/backend/tests/test_retriever.py
+++ b/backend/tests/test_retriever.py
@@ -294,6 +294,9 @@ def test_vector_search_returns_scored_chunks(monkeypatch):
     assert abs(results[0].score - 0.8) < 1e-6  # 1.0 - 0.2
 
 
+_DOC_ID = "02acff68-b6bb-4efa-a5af-d6a8d3d9e465"
+
+
 def test_vector_search_filters_by_document_id(monkeypatch):
     """vector_search passes a WHERE filter when document_ids is provided."""
     mock_table = MagicMock()
@@ -314,11 +317,41 @@ def test_vector_search_filters_by_document_id(monkeypatch):
         patch("app.services.embedder.get_embedding_service", return_value=mock_embedder),
     ):
         retriever = HybridRetriever()
-        retriever.vector_search("query", ["doc_abc"], k=5)
+        # A real document id. LanceDB predicates are interpolated, so ids are
+        # shape-checked first (#95) and `doc_abc` no longer reaches one --
+        # verified against the library, where no id of any kind fails the check.
+        retriever.vector_search("query", [_DOC_ID], k=5)
 
     mock_search.where.assert_called_once()
     where_arg = mock_search.where.call_args[0][0]
-    assert "doc_abc" in where_arg
+    assert _DOC_ID in where_arg
+
+
+def test_vector_search_refuses_a_malformed_document_id(monkeypatch):
+    """An unusable scope matches nothing; it must not become an unscoped search.
+
+    Dropping the filter would widen a document-scoped query to the whole
+    library, which is a worse failure than returning nothing.
+    """
+    mock_table = MagicMock()
+    mock_search = MagicMock()
+    mock_search.metric.return_value = mock_search
+    mock_search.limit.return_value = mock_search
+    mock_search.where.return_value = mock_search
+    mock_search.to_list.return_value = []
+    mock_table.search.return_value = mock_search
+
+    mock_lancedb = MagicMock()
+    mock_lancedb._get_table.return_value = mock_table
+
+    with (
+        patch("app.services.vector_store.get_lancedb_service", return_value=mock_lancedb),
+        patch("app.services.embedder.get_embedding_service", return_value=_MockEmbeddingService()),
+    ):
+        results = HybridRetriever().vector_search("query", ["x' OR '1'='1"], k=5)
+
+    assert results == []
+    mock_search.where.assert_not_called()
 
 
 # _diversify unit tests


### PR DESCRIPTION
Closes #95.

## Two corrections to the issue

**It is 19 sites, not six.** The full set, found by pattern rather than by the earlier list: `vector_store.py` (9), `retriever.py`, `collection_health.py` (2), `reindex_service.py`, plus the ones already named.

**"Bind them" is not available.** LanceDB takes `where`, `filter` and `delete` as SQL strings and exposes no parameter binding, so the fix is shape-checking before quoting, not parameterisation. The issue's title asks for something the library cannot do.

## The near-miss worth reporting

`vector_store.py` already had `_UUID_RE`, and the obvious move was to apply it everywhere. That would have been wrong:

```
concepts.id  ->  005a25379cc44337bedd4a24b8b7364d     (uuid4().hex, 32 hex, no dashes)
documents.id ->  02acff68-b6bb-4efa-a5af-d6a8d3d9e465 (uuid4(), dashed)
```

A dashed-only guard makes **every concept-vector predicate match nothing** — `delete_concept_vector` becomes a no-op that logs success, and centroids silently stop being written. Both shapes are accepted, and the reason is in the code next to the pattern.

Verified against the live library before shipping: **0 ids of any kind, across all five tables, fail the check.**

| table | ids that would be refused |
|---|---|
| documents | 0 |
| chunks | 0 |
| notes | 0 |
| concepts | 0 |
| images | 0 |

## `None` means match nothing

Never an unfiltered fall-through. Two ways that matters:

- `retriever.vector_search` — dropping the filter widens a **document-scoped** search to the whole library. It returns `[]` instead, and a test pins that.
- `IN ()` is a syntax error at best and `WHERE true` at worst, which would turn a scoped delete into a whole-table one.

## What the change surfaced

`compute_centroid` returned `[]` where its contract says `None`, so `refresh_vector`'s `if centroid is not None` passed and handed LanceDB a zero-length vector against a fixed-size schema:

```
RuntimeError: lance error: LanceError(IO): Execution error
new_data = [{'concept_id': '...', 'vector': []}]
```

Reachable without this change too — any concept whose evidence chunks have no stored vectors. Fixed to return `None`.

## Two test fixtures used ids no ingest produces

`"ch1"`, `"d1"`, `"doc_abc"`. They now use real shapes, and the properties under test are unchanged. I did **not** loosen the guard to accommodate them — the guard is right and the fixtures were never realistic.

## Not touched

`graph_view.py:60` — Kuzu, not LanceDB, already guarded by `.isalpha()` over constants we control, and its comment records that Kuzu list binding is unreliable across versions. The issue calls it the lowest risk of the set and I agree.

## Verification

`make ci` green. New `tests/test_lancedb_predicates.py` fires the guard in both directions, including that one bad id in a batch does not discard the good ones.

`make ci` also timed out once on `test_e2e_upload` during this work; it passes alone in 9.5s and the captured stderr is `EnrichmentQueueWorker: stopped` — the documented async-shutdown flake, unrelated.