### PR TITLE
A page number set in display type is not a section heading

### DIFF
--- a/backend/app/services/parser.py
+++ b/backend/app/services/parser.py
@@ -182,6 +182,10 @@ def _printed_page_labels(doc) -> dict[int, str]:
 # footer. A page number lives there; a number three lines in is content.
 _PAGE_NUMBER_BAND = 2
 
+# Digits a bare number may have and still read as a page number rather than a
+# year. Read by the folio scan and by heading detection, which must agree.
+_PAGE_NUMBER_MAX_DIGITS = 3
+
 # The share of a document's pages that must agree on one sheet-minus-printed
 # offset before the reading is trusted. Bracketing cases: a scanned book prints
 # its number on nearly every body page, so agreement is high; a slide deck with
@@ -214,7 +218,7 @@ def _printed_numbers_from_text(doc) -> dict[int, str]:
             band = lines[:_PAGE_NUMBER_BAND] + lines[-_PAGE_NUMBER_BAND:]
             for line in band:
                 # Four digits is a year in a header far more often than a page.
-                if line.isdigit() and 1 <= len(line) <= 3:
+                if line.isdigit() and 1 <= len(line) <= _PAGE_NUMBER_MAX_DIGITS:
                     sheet = index + 1
                     detected[sheet] = int(line)
                     offsets[sheet - int(line)] += 1
@@ -257,6 +261,19 @@ def _block_start_offsets(blocks: list[str]) -> list[int]:
         offsets.append(running)
         running += len(block) + 2  # the "\n\n" the blocks are joined with
     return offsets
+
+
+def _is_folio(text: str) -> bool:
+    """A line that is only a number is a page number, not a heading.
+
+    The no-TOC scan promotes any large short line to a heading, and a book that
+    sets its chapter-opening folio in display type therefore gets sections
+    titled after the page number. Bounded at three digits for the reason
+    `_printed_numbers_from_text` uses the same bound: `265` is a page, `1984` is
+    a year and a legitimate heading.
+    """
+    stripped = text.strip().rstrip(".")
+    return stripped.isdigit() and 1 <= len(stripped) <= _PAGE_NUMBER_MAX_DIGITS
 
 
 def _is_page_furniture(block: dict, page_height: float) -> bool:
@@ -558,7 +575,11 @@ class DocumentParser:
                     line_text = _join_spans(spans).strip()
                     if not line_text:
                         continue
-                    if max_size >= heading_threshold and len(line_text) < 120:
+                    if (
+                        max_size >= heading_threshold
+                        and len(line_text) < 120
+                        and not _is_folio(line_text)
+                    ):
                         level = 1 if max_size >= h1_min else 2
                         flush_section(line_text, level, page_num + 1)
                     else:

--- a/backend/tests/test_pdf_folio_heading.py
+++ b/backend/tests/test_pdf_folio_heading.py
@@ -1,0 +1,76 @@
+"""A no-TOC PDF must not turn its page numbers into section headings (#96).
+
+The fallback scan promotes any large short line to a heading. A book that sets
+its chapter-opening folio in display type therefore produced sections titled
+`27` and `265` on a real library.
+"""
+
+import fitz
+import pytest
+
+from app.services.parser import DocumentParser, _is_folio
+
+
+class TestIsFolio:
+    """The bound is three digits, and both bracketing cases are real.
+
+    `265` is a page number on the book that reported this; `1984` is a year, and
+    a legitimate heading in any book that has one.
+    """
+
+    @pytest.mark.parametrize("text", ["27", "265", "9", "265.", "  27  "])
+    def test_a_bare_number_is_a_folio(self, text: str) -> None:
+        assert _is_folio(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        ["1984", "Chapter 5", "1. Introduction", "27 Ronin", "", "IV"],
+    )
+    def test_anything_else_is_not(self, text: str) -> None:
+        assert _is_folio(text) is False
+
+
+def _pdf_with_display_folio(path):
+    """One page, no TOC: a big folio, a big heading, and body text.
+
+    The folio is set larger than the heading, which is what makes it the
+    document's top font size and so a level-1 heading to the old scan.
+    """
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text(fitz.Point(72, 60), "27", fontsize=28)
+    page.insert_text(fitz.Point(72, 120), "The Nature of Bread", fontsize=22)
+    for i in range(12):
+        page.insert_text(
+            fitz.Point(72, 170 + i * 14),
+            "Bread is made of flour and water and time, in that order.",
+            fontsize=11,
+        )
+    doc.save(str(path))
+    doc.close()
+    return path
+
+
+def test_a_display_folio_does_not_become_a_heading(tmp_path):
+    pdf = _pdf_with_display_folio(tmp_path / "folio.pdf")
+
+    parsed = DocumentParser().parse(pdf, "pdf")
+
+    headings = [s.heading for s in parsed.sections]
+    assert "27" not in headings, f"page number became a section heading: {headings}"
+    assert any("Nature of Bread" in h for h in headings), (
+        f"the real heading was lost: {headings}"
+    )
+
+
+def test_the_folio_text_is_still_present(tmp_path):
+    """Rejecting it as a heading must not drop it from the document.
+
+    The reported defect is a wrong heading, not lost text, and the fix must not
+    turn one into the other.
+    """
+    pdf = _pdf_with_display_folio(tmp_path / "folio.pdf")
+
+    parsed = DocumentParser().parse(pdf, "pdf")
+
+    assert "27" in parsed.raw_text


### PR DESCRIPTION
Part of #96.

## What was wrong

The no-TOC PDF path promotes any line above the heading font threshold and under 120 characters to a section heading (`parser.py`). A book that sets its chapter-opening folio larger than its headings therefore gets sections titled after the page number — `27` and `265` on the library that reported this.

## The fix

A line that is only a number is a folio, not a heading. It falls through to body text, so nothing is dropped: the defect is a wrong heading and the fix must not turn it into lost text — there is a test for exactly that.

Bounded at three digits, and the constant is now **shared with the folio scan**, which had already made the same judgement inline. Both bracketing cases are real and are in the test:

- `265` is a page number on the book that reported this.
- `1984` is a year, and a legitimate heading in any book that has one.

## Verified

`make ci` green. The end-to-end test builds a real one-page PDF with no TOC, a 28pt folio and a 22pt heading, and asserts the folio does not become a section while the real heading survives. Fired against the unguarded parser it fails, so the guard is load-bearing rather than decorative.

## The other two parts of #96

- **Cmd+F leaving the reader is already fixed**, in `baaf231`. `InDocSearchBar` now renders outside the tab content, gated on `sections || read`, and `openReaderSearch` only changes tab when the current one cannot host it. No change needed.
- **The page box counting sheets is not addressed here.** It needs a decision about what the field should mean, not just a patch — front matter printed in roman numerals cannot be represented by a numeric input at all, so "make the box show printed numbers" implies changing its type and losing its spinner arrows. Left open on #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bf2fnAyQ6FxhHPviJ3hHrx