### PR TITLE
The page field can reach a printed page number

### DIFF
--- a/frontend/src/components/reader/PDFViewer.tsx
+++ b/frontend/src/components/reader/PDFViewer.tsx
@@ -21,7 +21,7 @@ import {
 import { usableSections } from "./sectionTitle"
 import { createLinkService } from "./pdfLinkService"
 import { PdfSearchBar } from "./PdfSearchBar"
-import { ZOOM_PRESETS, ZOOM_STOPS, type PageMatch, activeMatchIndexForPage, buildGlobalMatches, findMatchIndices, formatMatchCounts, printedPageLabel, stepZoom } from "./pdfSearchUtils"
+import { ZOOM_PRESETS, ZOOM_STOPS, type PageMatch, activeMatchIndexForPage, buildGlobalMatches, findMatchIndices, formatMatchCounts, parsePageEntry, printedPageLabel, sheetForPrintedLabel, stepZoom } from "./pdfSearchUtils"
 import { clearOverlays, computeHighlightRects, renderOverlayDivs } from "./pdfHighlightOverlay"
 
 // Set worker once at module load
@@ -661,9 +661,26 @@ export const PDFViewer = forwardRef<PDFViewerHandle, PDFViewerProps>(
       setPageInput(String(clamped))
     }
 
+    /** The sheet a typed entry names, or null if it names nothing.
+     *
+     * A `p`-prefixed entry that matches no printed label returns null rather
+     * than falling back to a sheet: silently landing on sheet 19 when the
+     * reader asked for the page printed 19 is the confusion this exists to fix.
+     */
+    function resolvePageEntry(raw: string): number | null {
+      const entry = parsePageEntry(raw)
+      if (!entry) return null
+      if (entry.kind === "sheet") return entry.sheet
+      return sheetForPrintedLabel(declaredLabels, pageLabels, entry.label)
+    }
+
     function commitPageInput() {
-      const n = parseInt(pageInput, 10)
-      if (!isNaN(n)) goToPage(n)
+      const sheet = resolvePageEntry(pageInput)
+      if (sheet === null) {
+        setPageInput(String(currentPage))
+        return
+      }
+      goToPage(sheet)
     }
 
     // The page field only committed on blur/Enter, so the spinner arrows (and any
@@ -672,10 +689,10 @@ export const PDFViewer = forwardRef<PDFViewerHandle, PDFViewerProps>(
     function handlePageInputChange(value: string) {
       setPageInput(value)
       if (pageCommitTimer.current) window.clearTimeout(pageCommitTimer.current)
-      const n = parseInt(value, 10)
-      if (isNaN(n)) return
+      const sheet = resolvePageEntry(value)
+      if (sheet === null) return
       pageCommitTimer.current = window.setTimeout(() => {
-        setCurrentPage(Math.max(1, Math.min(n, totalPages)))
+        setCurrentPage(Math.max(1, Math.min(sheet, totalPages)))
       }, 250)
     }
     function commitPageInputNow() {
@@ -1091,16 +1108,18 @@ export const PDFViewer = forwardRef<PDFViewerHandle, PDFViewerProps>(
               <ChevronLeft className="h-4 w-4" />
             </button>
             <input
-              type="number"
+              // Text, not number: a printed page can be `xiv`, which a numeric
+              // field cannot hold. The spinner arrows go with it; the prev/next
+              // chevrons on either side already do that job.
+              type="text"
               // w-12 clipped a three-digit sheet: a 386-page book showed "34".
               className="w-16 text-center text-sm tabular-nums border rounded px-1 py-0.5"
               value={pageInput}
-              min={1}
-              max={totalPages}
               onChange={(e) => handlePageInputChange(e.target.value)}
               onBlur={commitPageInputNow}
               onKeyDown={(e) => { if (e.key === "Enter") commitPageInputNow() }}
-              aria-label="Current page"
+              title="Sheet number, or p19 for the page printed 19"
+              aria-label="Current page: a sheet number, or p19 for the page printed 19"
             />
             <span className="text-xs text-muted-foreground tabular-nums">/ {totalPages}</span>
             {printedLabel && (

--- a/frontend/src/components/reader/pdfSearchUtils.test.ts
+++ b/frontend/src/components/reader/pdfSearchUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { activeMatchIndexForPage, buildGlobalMatches, findMatchIndices, formatMatchCounts, printedPageLabel, stepZoom } from "./pdfSearchUtils"
+import { activeMatchIndexForPage, buildGlobalMatches, findMatchIndices, formatMatchCounts, parsePageEntry, printedPageLabel, sheetForPrintedLabel, stepZoom } from "./pdfSearchUtils"
 
 describe("findMatchIndices", () => {
   it("returns empty for empty query", () => {
@@ -177,5 +177,53 @@ describe("zoom stepping", () => {
   it("steps down from a value above every stop", () => {
     // The old control capped at 200% and could not represent 287% at all.
     expect(stepZoom(9, -1)).toBe(4)
+  })
+})
+
+describe("parsePageEntry", () => {
+  it("reads a bare number as a sheet, unchanged", () => {
+    expect(parsePageEntry("19")).toEqual({ kind: "sheet", sheet: 19 })
+    expect(parsePageEntry("  386 ")).toEqual({ kind: "sheet", sheet: 386 })
+  })
+
+  it("reads a p-prefix as a printed page", () => {
+    // The prefix mirrors the `p.19` chip beside the field.
+    expect(parsePageEntry("p19")).toEqual({ kind: "printed", label: "19" })
+    expect(parsePageEntry("p.19")).toEqual({ kind: "printed", label: "19" })
+    expect(parsePageEntry("P. xiv")).toEqual({ kind: "printed", label: "xiv" })
+  })
+
+  it("rejects what names no page", () => {
+    expect(parsePageEntry("")).toBeNull()
+    expect(parsePageEntry("   ")).toBeNull()
+    expect(parsePageEntry("p")).toBeNull()
+    expect(parsePageEntry("12a")).toBeNull()
+  })
+})
+
+describe("sheetForPrintedLabel", () => {
+  // Measured on one 613-page book: sheet 41 is printed "19", sheet 6 is "iv".
+  const declared = ["i", "ii", "iii", "iv", "v", "1", "2", "3"]
+  const derived = { "41": "19", "42": "20" }
+
+  it("finds the sheet from the ingestion-derived map", () => {
+    expect(sheetForPrintedLabel(null, derived, "19")).toBe(41)
+  })
+
+  it("finds the sheet from the PDF's own declared labels", () => {
+    expect(sheetForPrintedLabel(declared, null, "iv")).toBe(4)
+    expect(sheetForPrintedLabel(declared, null, "1")).toBe(6)
+  })
+
+  it("matches case-insensitively so p.XIV finds a page printed xiv", () => {
+    expect(sheetForPrintedLabel(["xiv"], null, "XIV")).toBe(1)
+  })
+
+  it("returns null when no page carries that label", () => {
+    // The caller must not fall back to treating it as a sheet: landing on
+    // sheet 19 when the reader asked for the page printed 19 is the confusion
+    // this whole path exists to remove.
+    expect(sheetForPrintedLabel(declared, derived, "999")).toBeNull()
+    expect(sheetForPrintedLabel(null, null, "19")).toBeNull()
   })
 })

--- a/frontend/src/components/reader/pdfSearchUtils.ts
+++ b/frontend/src/components/reader/pdfSearchUtils.ts
@@ -137,6 +137,60 @@ export function printedPageLabel(
   return label
 }
 
+/** What the reader typed into the page field.
+ *
+ * `19` is sheet 19, unchanged. `p19` and `p.xiv` name the number *printed* on
+ * the page, which is what the footer chip, the contents list and every citation
+ * report -- the field was the only surface with no way to accept one.
+ *
+ * The prefix is required rather than inferred: on a book with front matter,
+ * `19` is a valid sheet and a valid printed page at once, and guessing would
+ * silently move where a typed number lands.
+ */
+export function parsePageEntry(
+  raw: string,
+): { kind: "sheet"; sheet: number } | { kind: "printed"; label: string } | null {
+  const text = (raw ?? "").trim()
+  if (!text) return null
+  const printed = /^p\.?\s*(.+)$/i.exec(text)
+  if (printed) {
+    const label = printed[1].trim()
+    return label ? { kind: "printed", label } : null
+  }
+  if (!/^\d+$/.test(text)) return null
+  return { kind: "sheet", sheet: parseInt(text, 10) }
+}
+
+/** The sheet carrying this printed label, or null if no page is printed with it.
+ *
+ * Both label sources are consulted because they disagree in coverage: the PDF's
+ * own declared labels are absent from many files, and the ingestion-derived map
+ * only covers documents where enough pages agreed on one offset.
+ *
+ * Case-insensitive so `p.XIV` finds a page printed `xiv`.
+ */
+export function sheetForPrintedLabel(
+  declared: string[] | null | undefined,
+  derived: Record<string, string> | null | undefined,
+  label: string,
+): number | null {
+  const wanted = label.trim().toLowerCase()
+  if (!wanted) return null
+
+  for (const [sheet, value] of Object.entries(derived ?? {})) {
+    if (String(value).trim().toLowerCase() === wanted) {
+      const n = parseInt(sheet, 10)
+      if (!isNaN(n)) return n
+    }
+  }
+  if (declared) {
+    for (let i = 0; i < declared.length; i++) {
+      if ((declared[i] ?? "").trim().toLowerCase() === wanted) return i + 1
+    }
+  }
+  return null
+}
+
 // The ladder the +/- buttons walk. Steps rather than a linear slider because a
 // fixed increment is coarse at 50% and useless at 300%; these are the stops
 // every PDF reader offers. Auto-fit can land between or above them, which is


### PR DESCRIPTION
Part of #96. Completes it, alongside #118.

## What was wrong

The page field counted sheets and was the only surface that did — the footer chip, the contents list and every citation name the **printed** page. On a book with twenty pages of front matter, typing the number from a citation landed twenty pages away, and there was no way to ask for the printed one.

## What it does now

| typed | goes to |
|---|---|
| `19` | sheet 19 — unchanged |
| `p19`, `p.19` | the page printed 19 |
| `p.xiv` | front matter printed xiv |

The prefix is **required rather than inferred**. On a book with front matter, `19` is a valid sheet and a valid printed page at once, so guessing would silently move where an existing habit lands. The form mirrors the `p.19` chip already sitting beside the field.

A `p` entry that matches no printed label leaves the page where it is, rather than falling back to the sheet — that fallback is exactly the confusion being removed.

Both label sources are consulted, because they differ in coverage: the PDF's own declared labels are absent from many files, and the ingestion-derived map only covers documents where enough pages agreed on one offset. Matching is case-insensitive so `p.XIV` finds a page printed `xiv`.

## Trade-off

The input becomes `type="text"`, because a printed page can be `xiv` and a numeric field cannot hold it. That loses the spinner arrows; the prev/next chevrons on either side already do that job.

## Verified

`make ci` green. 33 tests in `pdfSearchUtils.test.ts` including the parse and lookup cases above. eslint sits at exactly 90 warnings — unchanged, so this adds none against the `--max-warnings 90` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bf2fnAyQ6FxhHPviJ3hHrx