### PR TITLE
A parent section no longer stores its children's text

### DIFF
--- a/backend/app/services/parser.py
+++ b/backend/app/services/parser.py
@@ -402,13 +402,12 @@ class DocumentParser:
             raw_parts: list[str] = []
 
             for i, (lv, ti, pg) in enumerate(toc):
-                # End page = start of the next entry at the same or higher level,
-                # minus 1. This correctly handles nested entries.
-                next_page = total_pages + 1
-                for j in range(i + 1, len(toc)):
-                    if toc[j][0] <= lv:
-                        next_page = toc[j][2]
-                        break
+                # Up to the NEXT entry, whatever its level. Ending at the next
+                # same-or-higher level made a chapter span all its children and
+                # store their text as well as its own (#97). A parent whose
+                # first child opens on its own page therefore owns no whole page
+                # and gets empty text; that prose goes to the child.
+                next_page = toc[i + 1][2] if i + 1 < len(toc) else total_pages + 1
                 page_end = min(next_page - 1, total_pages)
 
                 texts: list[str] = []
@@ -463,7 +462,9 @@ class DocumentParser:
                         level=lv,
                         text=text,
                         page_start=pg,
-                        page_end=page_end,
+                        # An owns-nothing parent still sits on a page; an end
+                        # before its start is a range no client can read.
+                        page_end=max(pg, page_end),
                         page_breaks=page_breaks,
                     )
                 )

--- a/backend/tests/test_pdf_nested_toc_sections.py
+++ b/backend/tests/test_pdf_nested_toc_sections.py
@@ -1,0 +1,89 @@
+"""A parent section must not store its children's text as well as its own (#97).
+
+Each TOC entry used to end at the next entry at the same or higher level, so a
+level-1 chapter's page range spanned every one of its level-2 children. Measured
+on one library's eight TOC-bearing PDFs, 3,271 pages were held by more than one
+section; on a 1,017-section manual the top section held 5,063,040 characters.
+"""
+
+import fitz
+import pytest
+
+from app.services.parser import DocumentParser
+
+# One unmistakable token per page, so containment needs no fuzzy matching.
+PAGES = [
+    "CHAPTERONEOPENING the chapter's own introductory prose.",
+    "SECTIONELEVEN the first subsection's body text.",
+    "SECTIONTWELVE the second subsection's body text.",
+    "CHAPTERTWOOPENING the second chapter's own prose.",
+    "SECTIONTWENTYONE the last subsection's body text.",
+]
+TOKENS = [p.split()[0] for p in PAGES]
+
+NESTED_TOC = [
+    [1, "Chapter One", 1],
+    [2, "Section 1.1", 2],
+    [2, "Section 1.2", 3],
+    [1, "Chapter Two", 4],
+    [2, "Section 2.1", 5],
+]
+
+
+def _pdf(path, toc):
+    doc = fitz.open()
+    for body in PAGES:
+        page = doc.new_page()
+        page.insert_text(fitz.Point(72, 100), body, fontsize=11)
+    doc.set_toc(toc)
+    doc.save(str(path))
+    doc.close()
+    return path
+
+
+@pytest.fixture
+def nested(tmp_path):
+    return DocumentParser().parse(_pdf(tmp_path / "nested.pdf", NESTED_TOC), "pdf")
+
+
+def test_no_page_is_stored_in_two_sections(nested):
+    for token in TOKENS:
+        holders = [s.heading for s in nested.sections if token in s.text]
+        assert len(holders) == 1, f"{token} stored in {len(holders)}: {holders}"
+
+
+def test_every_page_is_still_stored_somewhere(nested):
+    """The fix must remove duplication without losing text.
+
+    This is the half that makes the change safe: narrowing a parent's range
+    could silently drop a page that no other section covers.
+    """
+    for token in TOKENS:
+        assert any(token in s.text for s in nested.sections), f"{token} lost"
+
+
+def test_a_chapter_holds_its_own_prose_and_not_its_children(nested):
+    chapter = next(s for s in nested.sections if s.heading == "Chapter One")
+    assert "CHAPTERONEOPENING" in chapter.text
+    assert "SECTIONELEVEN" not in chapter.text
+    assert "SECTIONTWELVE" not in chapter.text
+
+
+def test_page_end_is_never_before_page_start(nested):
+    """A parent owning no whole page still sits on one.
+
+    An end before the start is a range no client can read, and `page_end`
+    reaches the API and the section rows.
+    """
+    for s in nested.sections:
+        assert s.page_end >= s.page_start, f"{s.heading}: {s.page_start}..{s.page_end}"
+
+
+def test_a_flat_toc_is_unchanged(tmp_path):
+    """No nesting means no parents, which is why some documents never showed this."""
+    flat = [[1, f"Part {i + 1}", i + 1] for i in range(len(PAGES))]
+    parsed = DocumentParser().parse(_pdf(tmp_path / "flat.pdf", flat), "pdf")
+
+    for token in TOKENS:
+        holders = [s.heading for s in parsed.sections if token in s.text]
+        assert len(holders) == 1, f"{token} stored in {len(holders)}: {holders}"


### PR DESCRIPTION
Part of #97.

## What was wrong

Each TOC entry ended at the next entry **at the same or higher level**, so a level-1 chapter's page range spanned every one of its level-2 children, and the extraction loop stored their text inside the chapter as well as in each child.

## Measured

Across the eight TOC-bearing PDFs in one library, by page coverage:

| | old rule | new rule |
|---|---|---|
| pages held by more than one section | **3,271** | **0** |
| pages held by no section | 0 | **0** |

End to end on a real 386-page book, stored section text falls from **1,396,053 to 721,850 characters** with no page lost. On the 2,528-page manual from the report, a direct span check finds **0 overlapping non-empty ranges**.

The "no page lost" half is what makes this safe rather than a trade — narrowing a parent's range could silently drop a page no other section covers, and it does not.

## The cost, stated

A parent whose first child opens on the parent's own page owns no whole page and gets empty text — 172 of 1,388 entries in that library. Its prose is attributed to the child rather than lost, which page granularity cannot do better than. `page_end` is clamped so it is never before `page_start`.

## Takes effect on ingest

Existing documents keep their duplicated text until re-ingested. No eval number moves: the eval manifest holds exactly one PDF and it has **zero TOC entries**, so this path is not exercised by the suite at all.

## Verified

`make ci` green. `test_pdf_nested_toc_sections.py` builds a real nested-TOC PDF and asserts no page is stored twice, every page is still stored somewhere, and a flat TOC is unchanged. Two of its cases fail against the old rule.

One measurement caution for anyone re-checking this: a text-probe over the 2,528-page manual reports ~1,047 "duplicated" pages under **both** rules, because an instruction-set manual genuinely repeats boilerplate across pages. The page-range check is the sound instrument here; the text probe cannot tell storage duplication from a book saying the same thing twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bf2fnAyQ6FxhHPviJ3hHrx