### PR TITLE
Every host is a first-class host: widen windows-host-policy toward make ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,13 +115,21 @@ jobs:
   # suite cannot read its own hardware. Same argument as `desktop-shell`: code
   # that cannot run on ubuntu has no automated coverage without a job for it.
   #
-  # Deliberately narrow. `make ci` on Windows is 0.13.0's exit gate, not this
-  # job's claim -- what this proves is that the shipped Windows install path's
-  # dependency step resolves, that the app imports, and that the policy answers
-  # where it was wrong. Widen it as that rung lands.
+  # Widened for 0.13.0's exit gate: `make ci` and `make smoke` green on
+  # Windows. There is no `make` on windows-latest, so this runs the same
+  # commands `make ci` runs rather than the target itself -- the ubuntu `ci`
+  # job above is the one source of truth for what those commands are.
+  # Deliberately still missing two pieces of `make ci`: `check_public_import.sh`
+  # rebuilds a second uv environment at a hardcoded `/tmp/luminary-public-env`,
+  # which is a Linux path under Git Bash's MSYS root rather than a Windows one,
+  # and `check_powershell.sh` is already covered on Windows-authored intent by
+  # the `powershell-syntax` job. The frontend steps (build/tsc/eslint/vitest)
+  # stay ubuntu-only: Node's toolchain is not the platform seam this rung is
+  # about, and running them twice would cost the job's time without teaching
+  # anything ubuntu's `ci` job did not already prove.
   windows-host-policy:
     runs-on: windows-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     needs: [branch-check]
     if: always() && (needs.branch-check.result == 'success' || github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
     defaults:
@@ -147,8 +155,29 @@ jobs:
       - name: The app imports
         run: uv run python -c "import app.main"
 
-      - name: The host-support policy, on the platform it got wrong
-        run: uv run pytest tests/test_host_support.py -q
+      - name: ruff
+        run: uv run ruff check .
+
+      - name: Layer linter
+        run: uv run python tools/layer_linter.py
+
+      - name: Boundary checker
+        run: uv run python tools/boundary_checker.py
+
+      - name: Full backend suite, on the platform it got wrong
+        run: uv run pytest
+
+      - name: Manifest schema
+        run: uv run python ../scripts/check_manifest_schema.py
+
+      - name: Manifest coverage
+        run: uv run python ../scripts/check_manifest_coverage.py
+
+      - name: Public-surface calls
+        run: uv run python ../scripts/check_public_surface_calls.py
+
+      - name: Smoke script paths still exist in the API surface
+        run: uv run python ../scripts/check_smoke_paths.py
 
   powershell-syntax:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
   # anything ubuntu's `ci` job did not already prove.
   windows-host-policy:
     runs-on: windows-latest
-    timeout-minutes: 35
+    timeout-minutes: 50
     needs: [branch-check]
     if: always() && (needs.branch-check.result == 'success' || github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
     defaults:
@@ -137,6 +137,16 @@ jobs:
         working-directory: backend
     steps:
       - uses: actions/checkout@v4
+
+      # 3765 tests do enough small-file I/O (SQLite, LanceDB, Kuzu, tmp_path
+      # churn) that Defender's real-time scan turns this into a 2-3x tax: one
+      # run finished pytest in 28m18s, an unrelated later run hit the timeout
+      # at 83% with no code change that would explain a slowdown. Excluding
+      # the checkout is the documented mitigation for exactly this on hosted
+      # Windows runners.
+      - name: Exclude the workspace from Defender's real-time scan
+        shell: pwsh
+        run: Add-MpPreference -ExclusionPath "${{ github.workspace }}"
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5

--- a/backend/app/routers/blog.py
+++ b/backend/app/routers/blog.py
@@ -115,7 +115,7 @@ async def get_blog_config(kind: str = "blog") -> BlogConfigResponse:
     )
     return BlogConfigResponse(
         repo_path=str(repo),
-        content_subdir=str(_content_dir(kind).relative_to(repo)),
+        content_subdir=_content_dir(kind).relative_to(repo).as_posix(),
         url_base=get_settings().LUMINARY_BLOG_URL_BASE,
         existing_slugs=sorted(blog_service.existing_slugs(content_dir)),
         ahead=ahead,
@@ -222,7 +222,7 @@ async def publish(
     repo = _configured_repo()
 
     # Honor a user-edited destination folder, but never let it escape the repo.
-    subdir = req.subdir or str(_content_dir(kind).relative_to(repo))
+    subdir = req.subdir or _content_dir(kind).relative_to(repo).as_posix()
     content_dir = (repo / subdir).resolve()
     if not _within(content_dir, repo):
         raise HTTPException(status_code=400, detail=f"destination escapes repo: {subdir}")
@@ -258,7 +258,7 @@ async def publish(
     return BlogPublishResponse(
         committed=True,
         commit_sha=sha,
-        files=[str(f.relative_to(repo)) for f in files],
+        files=[f.relative_to(repo).as_posix() for f in files],
         pushed=False,
         push_hint=f"git -C {repo} push origin {settings.LUMINARY_BLOG_BRANCH}",
         url=_post_url(slug, kind),
@@ -355,8 +355,8 @@ async def update_post(
     return BlogPublishResponse(
         committed=True,
         commit_sha=sha,
-        files=[str(f.relative_to(repo)) for f in files],
-        removed_assets=[str(f.relative_to(repo)) for f in removed],
+        files=[f.relative_to(repo).as_posix() for f in files],
+        removed_assets=[f.relative_to(repo).as_posix() for f in removed],
         pushed=False,
         push_hint=f"git -C {repo} push origin {settings.LUMINARY_BLOG_BRANCH}",
         url=_post_url(clean, kind),
@@ -381,7 +381,7 @@ async def delete_post(slug: str, kind: str = "blog") -> BlogPublishResponse:
     return BlogPublishResponse(
         committed=True,
         commit_sha=sha,
-        files=[str(f.relative_to(repo)) for f in files],
+        files=[f.relative_to(repo).as_posix() for f in files],
         pushed=False,
         push_hint=f"git -C {repo} push origin {settings.LUMINARY_BLOG_BRANCH}",
         url=f"{settings.LUMINARY_BLOG_URL_BASE}/{kind}/",

--- a/backend/app/services/blog_service.py
+++ b/backend/app/services/blog_service.py
@@ -403,7 +403,7 @@ async def git_add_commit(repo: Path, files: list[Path], message: str) -> str:
 
     Does not push -- the user pushes manually.
     """
-    rel = [str(f.relative_to(repo)) for f in files]
+    rel = [f.relative_to(repo).as_posix() for f in files]
     # -A so the same path stages new files, edits, AND deletions (used by delete).
     code, _, err = await _git(["add", "-A", "--", *rel], repo)
     if code != 0:

--- a/backend/tests/test_background_registries.py
+++ b/backend/tests/test_background_registries.py
@@ -31,7 +31,7 @@ def _bare_registry_declarations() -> list[str]:
     for path in sorted(APP_ROOT.rglob("*.py")):
         if "__pycache__" in str(path):
             continue
-        tree = ast.parse(path.read_text())
+        tree = ast.parse(path.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
             targets = (
                 [node.target] if isinstance(node, ast.AnnAssign) else getattr(node, "targets", [])

--- a/backend/tests/test_background_routing_privacy.py
+++ b/backend/tests/test_background_routing_privacy.py
@@ -76,7 +76,7 @@ def test_hybrid_sends_background_work_to_ollama(hybrid_routing):
 @pytest.mark.parametrize(("module_path", "callee"), LOCAL_ONLY_CALL_SITES)
 def test_local_only_call_sites_declare_background(module_path, callee):
     path = pathlib.Path(__file__).resolve().parents[1] / module_path
-    tree = ast.parse(path.read_text())
+    tree = ast.parse(path.read_text(encoding="utf-8"))
 
     calls = [
         node

--- a/backend/tests/test_detect_type_and_media_components.py
+++ b/backend/tests/test_detect_type_and_media_components.py
@@ -14,6 +14,7 @@ Two shipped defects are pinned here:
 """
 
 import io
+import sys
 from pathlib import Path
 
 import pytest
@@ -178,6 +179,15 @@ def test_a_tool_outside_the_bundles_path_is_still_found(tmp_path, monkeypatch):
     assert components_module.resolve_tool("ffmpeg") == str(tool)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "os.access(path, os.X_OK) is not meaningful on Windows -- CPython documents it "
+        "as true for any existing file there -- and _WELL_KNOWN_TOOL_DIRS is a tuple of "
+        "POSIX prefixes (Homebrew, MacPorts, /usr/bin) that never resolve on that "
+        "platform, so the fallback branch this test exercises is unreachable there too."
+    ),
+)
 def test_a_present_but_unexecutable_file_is_not_a_find(tmp_path, monkeypatch):
     """Reporting one turns "not installed" into a failure at the point of use."""
     import app.services.components as components_module

--- a/backend/tests/test_installer_models.py
+++ b/backend/tests/test_installer_models.py
@@ -500,12 +500,31 @@ def _run_platform_guard(sh: str, os_name: str, arch: str):
     with `uname` shadowed rather than the block reimplemented, so this proves
     the actual file's logic and not a paraphrase of it."""
     import subprocess
+    import tempfile
 
     start = sh.index("_info()  { printf")
     end = sh.index("fi\n", sh.index("Native install isn't supported")) + len("fi\n")
     block = sh[start:end]
     harness = f'uname() {{ case "$1" in -s) echo {os_name};; -m) echo {arch};; esac; }}\n' + block
-    return subprocess.run(["bash", "-c", harness], capture_output=True, text=True, timeout=10)
+
+    # A `-c` argument this long, with this many nested quotes, round-trips
+    # through Windows' list2cmdline re-escaping and then Git Bash's own MSYS
+    # argv re-parse on the way to the process -- on windows-latest this
+    # produced the *right* exit code for the wrong reason (both cases fell
+    # into install.sh's "Unsupported OS" branch, since the shadowed `uname`
+    # never took effect) and no stderr at all. A script FILE has no argv to
+    # mis-escape. newline="\n" keeps it LF-only even though Python's text
+    # mode would otherwise write CRLF on Windows, which bash does not parse
+    # the way it parses LF.
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".sh", delete=False, newline="\n", encoding="utf-8"
+    ) as fh:
+        fh.write(harness)
+        script_path = fh.name
+    try:
+        return subprocess.run(["bash", script_path], capture_output=True, text=True, timeout=10)
+    finally:
+        Path(script_path).unlink(missing_ok=True)
 
 
 def test_intel_mac_is_refused_with_docker_guidance(sh):

--- a/backend/tests/test_installer_models.py
+++ b/backend/tests/test_installer_models.py
@@ -14,12 +14,21 @@ is silent on the machine that can least afford it.
 """
 
 import re
+import sys
 from pathlib import Path
 
 import pytest
 
 from app import memory_profile
 from app.model_registry import GENERALIST_PREFERENCE, REGISTRY, profile_for
+
+# A bare "bash" on windows-latest resolves to C:\Windows\System32\bash.exe --
+# the WSL launcher stub, present with no distribution installed -- ahead of
+# Git's on PATH. It prints a UTF-16 "wsl.exe --install <Distro>' to install."
+# message to STDOUT (never stderr) and a misleading exit code, which is why
+# both platform-guard cases below looked identical regardless of input: WSL
+# was answering, not install.sh. Git for Windows always installs here.
+_BASH = r"C:\Program Files\Git\bin\bash.exe" if sys.platform == "win32" else "bash"
 
 _REPO = Path(__file__).resolve().parents[2]
 _SCRIPTS = _REPO / "scripts"
@@ -522,7 +531,7 @@ def _run_platform_guard(sh: str, os_name: str, arch: str):
         fh.write(harness)
         script_path = fh.name
     try:
-        return subprocess.run(["bash", script_path], capture_output=True, text=True, timeout=10)
+        return subprocess.run([_BASH, script_path], capture_output=True, text=True, timeout=10)
     finally:
         Path(script_path).unlink(missing_ok=True)
 

--- a/backend/tests/test_installer_models.py
+++ b/backend/tests/test_installer_models.py
@@ -37,12 +37,12 @@ def _assign(text: str, pattern: str) -> str:
 
 @pytest.fixture(scope="module")
 def sh() -> str:
-    return _SH.read_text()
+    return _SH.read_text(encoding="utf-8")
 
 
 @pytest.fixture(scope="module")
 def ps1() -> str:
-    return _PS1.read_text()
+    return _PS1.read_text(encoding="utf-8")
 
 
 def test_the_generalist_is_registered_and_multimodal():
@@ -151,7 +151,7 @@ def test_the_desktop_shell_agrees_about_the_residency_band():
     Read as text for the same reason the installers are: nothing here can call
     Rust. The band is what matters, so the band is what is asserted.
     """
-    rust = _SUPERVISOR.read_text()
+    rust = _SUPERVISOR.read_text(encoding="utf-8")
     start = rust.index("fn ollama_max_loaded_models")
     # To the function's own closing brace at column 0, not to the next `fn`:
     # the following item is `pub fn`, so a `\nfn ` split runs past this body and
@@ -192,10 +192,10 @@ def test_the_serving_width_band_agrees_across_every_install_path(sh, ps1):
     taking two slots -- the value never changed, the band under it did.
     `supervisor.rs` sized from RAM and was the only path that did not drift.
     """
-    rust = _SUPERVISOR.read_text()
+    rust = _SUPERVISOR.read_text(encoding="utf-8")
     start = rust.index("fn ollama_num_parallel")
     shell_of_rust = rust[start : rust.index("\n}\n", start)]
-    bootstrap = _BOOTSTRAP.read_text()
+    bootstrap = _BOOTSTRAP.read_text(encoding="utf-8")
 
     for name, text, pattern in (
         ("supervisor.rs", shell_of_rust, "gb >= 24 => 2"),
@@ -261,7 +261,7 @@ def test_no_launch_path_pulls_a_literal_model_name():
 
     offenders = []
     for path in _LAUNCH_PATHS:
-        for number, line in enumerate(path.read_text().splitlines(), 1):
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
             if line.strip().startswith("#"):
                 continue
             for match in literal.finditer(line):
@@ -276,7 +276,7 @@ def test_no_launch_path_pulls_a_literal_model_name():
 
 def test_bootstrap_resolves_its_model_from_the_profile():
     """It must not fall back to a name: that name reaches the user's .env."""
-    text = _BOOTSTRAP.read_text()
+    text = _BOOTSTRAP.read_text(encoding="utf-8")
     assign = _assign(text, r'^CHAT_MODEL="\$\{LUMINARY_CHAT_MODEL:-(.*)\}"')
     assert assign == "", (
         f"bootstrap.sh defaults CHAT_MODEL to {assign!r}; it writes that into "
@@ -287,15 +287,15 @@ def test_bootstrap_resolves_its_model_from_the_profile():
 
 def test_bootstrap_uses_the_same_memory_bands_as_install_sh():
     """Two installers that band differently give the same laptop two setups."""
-    boot = (_SCRIPTS / "bootstrap.sh").read_text()
+    boot = (_SCRIPTS / "bootstrap.sh").read_text(encoding="utf-8")
     assert re.search(r"MEM_GB.*-gt 24", boot), "bootstrap.sh lost the performance band"
     assert re.search(r"MEM_GB.*-lt 16", boot), "bootstrap.sh lost the 16GB floor warning"
-    for name, source in (("install.sh", _SH.read_text()), ("bootstrap.sh", boot)):
+    for name, source in (("install.sh", _SH.read_text(encoding="utf-8")), ("bootstrap.sh", boot)):
         assert "performance" in source and "standard" in source, f"{name} lost a profile"
 
 def test_start_sh_does_not_assert_a_model_name():
     """A pre-flight warning that names the wrong model sends the user to pull it."""
-    text = _START.read_text()
+    text = _START.read_text(encoding="utf-8")
     assert not re.search(r'CHAT_MODEL="\$\{LUMINARY_CHAT_MODEL:-[a-z]', text), (
         "start.sh hardcodes a model name in its warning"
     )
@@ -303,7 +303,7 @@ def test_start_sh_does_not_assert_a_model_name():
 
 def test_compose_pulls_the_configured_model_without_the_provider_prefix():
     """`ollama pull` rejects the `ollama/` prefix that LiteLLM requires."""
-    text = _COMPOSE.read_text()
+    text = _COMPOSE.read_text(encoding="utf-8")
     assert "LITELLM_DEFAULT_MODEL" in text, "compose pulls a model nothing configures"
     assert "#ollama/" in text, (
         "compose passes the setting to `ollama pull` without stripping `ollama/`"
@@ -323,7 +323,7 @@ def test_compose_escapes_shell_expansions_it_does_not_want_interpolated():
     """A `$` meant for the container's shell must be written `$$`."""
     offenders = [
         line.strip()
-        for line in _COMPOSE.read_text().splitlines()
+        for line in _COMPOSE.read_text(encoding="utf-8").splitlines()
         # Full-line comments only. Matching any line *containing* a `#` would
         # exempt every line this is meant to check, since `#` is the shell
         # expansion operator it looks for.
@@ -363,7 +363,7 @@ def test_no_installer_writes_the_legacy_profile_alias():
     from app.memory_profile import _LEGACY_ALIASES
 
     for path in (_SH, _PS1, _BOOTSTRAP):
-        for number, line in enumerate(path.read_text().splitlines(), 1):
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
             if "LUMINARY_MEMORY_PROFILE" not in line or line.strip().startswith("#"):
                 continue
             for alias in _LEGACY_ALIASES:
@@ -382,7 +382,7 @@ def test_the_large_text_threshold_is_the_measured_feasibility_point():
     """
     from app.model_registry import fits_together, profile_for
 
-    declared = int(_assign(_SH.read_text(), r"^LARGE_TEXT_MIN_RAM_GB=(\d+)"))
+    declared = int(_assign(_SH.read_text(encoding="utf-8"), r"^LARGE_TEXT_MIN_RAM_GB=(\d+)"))
     pair = (profile_for("ollama/qwen2.5:14b-instruct"), profile_for("ollama/qwen3.5:4b"))
     assert all(p is not None for p in pair), "the performance pair left the registry"
 
@@ -401,7 +401,7 @@ def test_the_profile_comment_states_the_bands_the_code_uses():
     split existed -- a reader checking the code against the comment would have
     concluded the code was wrong.
     """
-    text = _SH.read_text()
+    text = _SH.read_text(encoding="utf-8")
     banner = next(
         (line for line in text.splitlines() if "standard=" in line and "performance=" in line),
         None,
@@ -419,7 +419,7 @@ def test_pinning_only_the_chat_model_still_leaves_a_figure_reader():
     vision model, and figures failed quietly -- the mode the profile exists to
     prevent.
     """
-    text = _SH.read_text()
+    text = _SH.read_text(encoding="utf-8")
     chat_block_start = text.index('if [ -z "$CHAT_MODEL" ]; then')
     chat_block_end = text.index("\nfi\n", chat_block_start)
     vision_default = text.index('VISION_MODEL="$PUBLIC_GENERALIST"')
@@ -430,7 +430,7 @@ def test_pinning_only_the_chat_model_still_leaves_a_figure_reader():
 
 def test_an_unknown_profile_is_refused_rather_than_written_to_env():
     """The backend rejects it and re-sizes, so the two silently disagreed."""
-    text = _SH.read_text()
+    text = _SH.read_text(encoding="utf-8")
     assert re.search(r"standard\|performance\)\s*;;", text), (
         "install.sh no longer validates LUMINARY_PROFILE against the known set"
     )
@@ -447,7 +447,7 @@ def test_an_unknown_profile_is_refused_rather_than_written_to_env():
 
 def test_ps1_vision_default_is_not_nested_in_the_chat_model_block():
     """Nested, pinning LUMINARY_CHAT_MODEL left a roomy host with no reader."""
-    text = _PS1.read_text()
+    text = _PS1.read_text(encoding="utf-8")
     block_start = text.index("if (-not $chatModel) {")
     # The block ends at the first line that closes it at column 0.
     block_end = text.index("\n}\n", block_start)
@@ -463,9 +463,9 @@ def test_ps1_gates_the_large_text_model_on_actual_ram():
     `LUMINARY_PROFILE=performance` on an 8GB box is a supported override, so the
     band cannot be the only condition.
     """
-    text = _PS1.read_text()
+    text = _PS1.read_text(encoding="utf-8")
     declared = int(_assign(text, r"^\$LargeTextMinRamGB = (\d+)"))
-    sh_declared = int(_assign(_SH.read_text(), r"^LARGE_TEXT_MIN_RAM_GB=(\d+)"))
+    sh_declared = int(_assign(_SH.read_text(encoding="utf-8"), r"^LARGE_TEXT_MIN_RAM_GB=(\d+)"))
     assert declared == sh_declared, (
         f"install.ps1 gates at {declared}GB and install.sh at {sh_declared}GB"
     )
@@ -479,7 +479,7 @@ def test_ps1_refuses_an_unknown_profile():
     written to backend/.env. PowerShell's `switch` is also case-insensitive, so
     `Performance` installed a performance profile on Windows and exited 1 on
     macOS -- the same input, two different products."""
-    text = _PS1.read_text()
+    text = _PS1.read_text(encoding="utf-8")
     assert "-cin @(" in text, "install.ps1 does not validate LUMINARY_PROFILE case-sensitively"
     assert '"standard", "performance"' in text
 
@@ -488,7 +488,7 @@ def test_ps1_guards_the_vision_pull_on_ollama_being_present():
     """The chat pull is guarded and the vision pull was not, so on the branch the
     script explicitly tolerates -- ollama off the PATH -- it invoked a missing
     command under `$ErrorActionPreference = "Stop"`."""
-    text = _PS1.read_text()
+    text = _PS1.read_text(encoding="utf-8")
     pull = text.index("ollama pull $visionModel")
     guard = text.rindex('Test-CommandExists "ollama"', 0, pull)
     condition = text.rindex("if (", 0, pull)
@@ -580,7 +580,8 @@ def test_every_installer_accepts_the_backends_name_for_the_small_profile(script)
     """`low` and `public` named the retired one-model profile. Both must still be
     ACCEPTED -- an installed .env carries one, and refusing it fails the upgrade --
     and both now resolve to `standard`."""
-    text = {"sh": _SH, "ps1": _PS1, "bootstrap": _SCRIPTS / "bootstrap.sh"}[script].read_text()
+    path = {"sh": _SH, "ps1": _PS1, "bootstrap": _SCRIPTS / "bootstrap.sh"}[script]
+    text = path.read_text(encoding="utf-8")
     assert "low" in text and re.search(r'(-ceq "low"|low\|public\))', text), (
         f"{script} does not accept `low` as a name for the small profile"
     )
@@ -589,18 +590,18 @@ def test_every_installer_accepts_the_backends_name_for_the_small_profile(script)
 def test_bootstrap_gates_the_large_text_model_on_actual_ram():
     """`LUMINARY_PROFILE=performance` is a supported override, so the profile
     alone does not mean the machine can hold the 9.67GB model."""
-    text = (_SCRIPTS / "bootstrap.sh").read_text()
+    text = (_SCRIPTS / "bootstrap.sh").read_text(encoding="utf-8")
     assert "LARGE_TEXT_MIN_RAM_GB" in text, "bootstrap.sh pulls the large model ungated"
     assert re.search(r'MEM_GB" -ge "\$LARGE_TEXT_MIN_RAM_GB', text), (
         "bootstrap.sh names the threshold but does not compare RAM against it"
     )
     assert _assign(text, r"^LARGE_TEXT_MIN_RAM_GB=(\d+)") == _assign(
-        _SH.read_text(), r"^LARGE_TEXT_MIN_RAM_GB=(\d+)"
+        _SH.read_text(encoding="utf-8"), r"^LARGE_TEXT_MIN_RAM_GB=(\d+)"
     ), "bootstrap.sh and install.sh disagree about the band"
 
 
 def test_bootstrap_refuses_an_unknown_profile():
-    text = (_SCRIPTS / "bootstrap.sh").read_text()
+    text = (_SCRIPTS / "bootstrap.sh").read_text(encoding="utf-8")
     assert re.search(r"_die \"LUMINARY_PROFILE=", text), (
         "bootstrap.sh writes an unvalidated profile into .env, where the backend rejects it"
     )
@@ -609,7 +610,7 @@ def test_bootstrap_refuses_an_unknown_profile():
 def test_bootstrap_does_not_write_a_key_the_template_already_sets():
     """The template sets these uncommented, so appending duplicated them and a
     user editing the first occurrence saw no effect."""
-    text = (_SCRIPTS / "bootstrap.sh").read_text()
+    text = (_SCRIPTS / "bootstrap.sh").read_text(encoding="utf-8")
     assert re.search(r"grep -vE '\^\(LITELLM_DEFAULT_MODEL\|VISION_MODEL", text), (
         "bootstrap.sh appends model keys without stripping the template's copies"
     )

--- a/backend/tests/test_launchers_do_not_resolve.py
+++ b/backend/tests/test_launchers_do_not_resolve.py
@@ -45,7 +45,7 @@ def _logical_lines(text: str) -> list[str]:
 
 @pytest.mark.parametrize("relpath", SHIPPED_LAUNCHERS)
 def test_a_shipped_launcher_never_resolves_dependencies(relpath):
-    for line in _logical_lines((REPO / relpath).read_text()):
+    for line in _logical_lines((REPO / relpath).read_text(encoding="utf-8")):
         if line.startswith("#") or "uvicorn" not in line:
             continue
         if not re.search(r"\buv\b", line):
@@ -59,7 +59,9 @@ def test_the_docker_entrypoint_does_not_go_through_uv_at_all():
     """Nothing to resolve and nothing to shell out to: the image was built with
     exactly the dependencies it should run."""
     cmd = [
-        ln for ln in (REPO / "Dockerfile").read_text().splitlines() if ln.startswith("CMD ")
+        ln
+        for ln in (REPO / "Dockerfile").read_text(encoding="utf-8").splitlines()
+        if ln.startswith("CMD ")
     ]
     assert len(cmd) == 1
     assert "uv" not in cmd[0].split()

--- a/backend/tests/test_model_registry.py
+++ b/backend/tests/test_model_registry.py
@@ -46,7 +46,7 @@ def _offenders() -> list[str]:
     for path in _APP.rglob("*.py"):
         if path.name in _MAY_READ_CONFIG:
             continue
-        for i, line in enumerate(path.read_text().splitlines(), start=1):
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
             if _CONFIG_MODEL_READ.search(line):
                 hits.append(f"{path.relative_to(_APP)}:{i}")
     return hits
@@ -194,7 +194,7 @@ def test_no_module_outside_the_registry_writes_a_model_name_down():
     for path in _APP.rglob("*.py"):
         if path.name in _MAY_NAME_A_MODEL:
             continue
-        tree = ast.parse(path.read_text())
+        tree = ast.parse(path.read_text(encoding="utf-8"))
         exempt = _exempt_string_nodes(tree)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Constant) or not isinstance(node.value, str):

--- a/backend/tests/test_prompt_spec.py
+++ b/backend/tests/test_prompt_spec.py
@@ -148,7 +148,7 @@ def _defined_specs() -> set[str]:
     return {
         path.name
         for path in services.glob("*.py")
-        if "PromptSpec(" in path.read_text() and path.name != "prompt_spec.py"
+        if "PromptSpec(" in path.read_text(encoding="utf-8") and path.name != "prompt_spec.py"
     }
 
 
@@ -277,7 +277,7 @@ def test_nothing_renders_a_prompt_against_the_configured_default():
     offenders = [
         f"{path.relative_to(app_dir)}:{i}"
         for path in app_dir.rglob("*.py")
-        for i, line in enumerate(path.read_text().splitlines(), start=1)
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1)
         if pattern.search(line)
     ]
 

--- a/backend/tests/test_single_local_context_window.py
+++ b/backend/tests/test_single_local_context_window.py
@@ -47,7 +47,7 @@ def test_settings_expose_one_local_context_window():
 def test_no_call_site_chooses_a_window():
     offenders: list[str] = []
     for path in _APP.rglob("*.py"):
-        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
             for value in _NUM_CTX_ARG.findall(line):
                 value = value.strip()
                 if value in _PLUMBING:
@@ -70,7 +70,7 @@ def test_only_the_registry_reads_the_global_window():
         f"{path.relative_to(_APP.parent)}:{lineno}"
         for path in _APP.rglob("*.py")
         if path.name not in {"config.py", "model_registry.py"}
-        for lineno, line in enumerate(path.read_text().splitlines(), 1)
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
         if "OLLAMA_NUM_CTX" in line and not line.lstrip().startswith("#")
     ]
     assert not offenders, (

--- a/backend/tests/test_youtube_ingestion.py
+++ b/backend/tests/test_youtube_ingestion.py
@@ -415,13 +415,18 @@ async def test_download_passes_the_resolved_ffmpeg_location(monkeypatch, tmp_pat
         captured.extend(args)
         return _Proc()
 
-    monkeypatch.setattr(yt, "resolve_tool", lambda name: f"/opt/homebrew/bin/{name}")
+    # Built through Path rather than hardcoded, so the expected separator
+    # matches whatever the code under test normalizes to on this platform --
+    # the mac-style prefix is arbitrary, the code's job is a real OS path.
+    monkeypatch.setattr(
+        yt, "resolve_tool", lambda name: str(Path("/opt/homebrew/bin") / name)
+    )
     monkeypatch.setattr(yt.asyncio, "create_subprocess_exec", _fake_exec)
 
     await yt.download_audio("https://youtu.be/x", tmp_path / "out")
 
     assert "--ffmpeg-location" in captured
-    assert captured[captured.index("--ffmpeg-location") + 1] == "/opt/homebrew/bin"
+    assert captured[captured.index("--ffmpeg-location") + 1] == str(Path("/opt/homebrew/bin"))
 
 
 async def test_download_omits_the_flag_when_ffmpeg_is_not_found(monkeypatch, tmp_path):

--- a/scripts/check_manifest_coverage.py
+++ b/scripts/check_manifest_coverage.py
@@ -39,7 +39,7 @@ def manifest_components(data: dict) -> set[str]:
 
 
 def main() -> int:
-    data = json.loads(MANIFEST.read_text())
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
     errors: list[str] = []
 
     covered_routers = manifest_routers(data) | ROUTER_ALLOWLIST

--- a/scripts/check_manifest_schema.py
+++ b/scripts/check_manifest_schema.py
@@ -24,7 +24,7 @@ def component_exists(rel: str) -> bool:
 
 
 def main() -> int:
-    data = json.loads(MANIFEST.read_text())
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
     errors: list[str] = []
 
     if data.get("version") != 2:

--- a/scripts/check_public_surface_calls.py
+++ b/scripts/check_public_surface_calls.py
@@ -56,7 +56,7 @@ def router_prefixes() -> dict[str, str]:
     for f in sorted(ROUTERS.glob("*.py")):
         if f.stem == "__init__":
             continue
-        m = pat.search(f.read_text())
+        m = pat.search(f.read_text(encoding="utf-8"))
         if m:
             out[f.stem] = m.group(1)
     return out
@@ -93,7 +93,7 @@ def resolve_router(path: str, prefixes: dict[str, str]) -> str | None:
 
 
 def main() -> int:
-    data = json.loads(MANIFEST.read_text())
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
     public = enabled_routers(data, "public")
     full = enabled_routers(data, "full")
     full_only = full - public
@@ -108,7 +108,7 @@ def main() -> int:
     for f in sorted([*FRONTEND.rglob("*.ts"), *FRONTEND.rglob("*.tsx")]):
         if f in exempt or f.name.endswith(".test.ts") or f.name.endswith(".test.tsx"):
             continue
-        text = f.read_text()
+        text = f.read_text(encoding="utf-8")
         calls = set(_CALL_RE.findall(text)) | set(_CALL_RE_NOGENERIC.findall(text))
         for call in calls:
             path = call.split("?")[0]

--- a/scripts/check_smoke_paths.py
+++ b/scripts/check_smoke_paths.py
@@ -117,7 +117,7 @@ def main() -> int:
     checked = 0
     scripts = sorted(SMOKE.glob("S*.sh"))
     for script in scripts:
-        text = script.read_text()
+        text = script.read_text(encoding="utf-8")
         absent = {p.rstrip("/") for p in _EXPECTS_ABSENT.findall(text)}
         for raw in _CALL.findall(text):
             path = normalise(raw)


### PR DESCRIPTION
## Summary

0.13.0's exit gate is `make ci` and `make smoke` green on Windows. `windows-host-policy` previously only proved `uv sync`, the app import, and the host-support tests worked there. This widens it to run the same commands `make ci` runs (there is no `make` on `windows-latest`): ruff, the layer linter, the boundary checker, the full pytest suite (3627 tests), and the manifest/public-surface/smoke-path checks.

Getting there took six pushes because each fixed a distinct, previously-invisible Windows defect rather than a flake:

- **`Path.read_text()` with no encoding** defaults to cp1252 on Windows. Four structural tests scanning the whole `app/` tree, plus four of `make ci`'s own lint scripts (`check_manifest_schema.py`, `check_manifest_coverage.py`, `check_public_surface_calls.py`, `check_smoke_paths.py`), hit a real UTF-8 byte cp1252 has no mapping for. All now pin `encoding="utf-8"`.
- **`blog.py` reported repo-relative paths with `str(Path.relative_to(...))`**, backslash-separated on Windows. These paths go over the API and into git commands, so they're now `.as_posix()` throughout.
- **Two tests assumed POSIX-only semantics.** `os.access(path, os.X_OK)` is documented as true for any existing file on Windows (now skipped there, with the mechanism named), and a hardcoded `/opt/homebrew/bin` fixture was compared against a real `Path().parent` normalization (now built through `Path` on both sides).
- **`windows-host-policy` itself needed a Defender exclusion** — 3765 tests doing small-file I/O (SQLite, LanceDB, Kuzu, `tmp_path` churn) is exactly what Defender's real-time scan taxes hardest; excluding the workspace cut wall time from timing out at 35 min to a steady ~25 min.
- **The platform-guard test was talking to the wrong `bash`.** `bash` resolves via PATH on `windows-latest` to `C:\Windows\System32\bash.exe` — the WSL launcher stub, present with no distribution installed — ahead of Git's. Both Darwin/x86_64 and Darwin/arm64 cases were getting WSL's own error message back regardless of input. `_BASH` now resolves to Git's fixed install path on `win32`.

Deliberately still out of scope: `check_public_import.sh` (rebuilds a second uv env at a hardcoded `/tmp/luminary-public-env`, a Linux path under Git Bash's MSYS root) and the frontend build/tsc/eslint/vitest steps (Node's toolchain isn't the platform seam this rung is about — ubuntu's `ci` job already proves those).

## Test plan

- [x] `windows-host-policy` green on `windows-latest`: ruff, layer linter, boundary checker, full pytest (3627 passed, 28 skipped, 108 deselected), manifest schema/coverage, public-surface calls, smoke-path checks.
- [x] `make ci` green locally (macOS).
- [x] All other CI jobs green on this branch: `ci`, `desktop-shell`, `desktop-shell-windows`, `powershell-syntax`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuWUNCbm9DWJeXuP2y3V2T