### PR TITLE
Fix citation highlight showing chunk[:150] instead of the relevant sentence

### DIFF
--- a/backend/app/runtime/chat_nodes/synthesize.py
+++ b/backend/app/runtime/chat_nodes/synthesize.py
@@ -27,6 +27,7 @@ from app.services.qa import (
     CITATION_MIN_SCORE,
     CITATION_REL_RATIO,
     MAX_CITATIONS,
+    _excerpt_from_chunk,
     _should_use_summary,
 )
 from app.services.summarizer import get_summarization_service
@@ -462,7 +463,17 @@ async def synthesize_node(state: ChatState) -> dict:
                     # Seconds into a recording, null for everything else: what a
                     # citation into a lecture points at is a moment, not a page.
                     "start_time": meta.start_time,
-                    "section_preview_snippet": chunk_text[:150],  # hover tooltip preview
+                    # This drives more than a tooltip: the reader's citation-click
+                    # highlight fuzzy-matches these words against the rendered
+                    # prose (frontend/src/lib/citation/target.ts). A chunk is
+                    # sized for the embedder, so the sentence bearing the user's
+                    # answer sits anywhere in it -- chunk_text[:150] used to land
+                    # on whatever came first, which reads as a random highlight
+                    # next to a question about something three sentences later.
+                    # _excerpt_from_chunk (already proven in qa.py's marker
+                    # citations, I-33) scores every sentence by overlap with the
+                    # question and windows around the best one, verbatim.
+                    "section_preview_snippet": _excerpt_from_chunk(chunk_text, hint=question),
                 }
             )
 

--- a/backend/app/services/qa.py
+++ b/backend/app/services/qa.py
@@ -438,7 +438,11 @@ def _excerpt_from_chunk(chunk_text: str, hint: str = "", answer: str = "") -> st
     window = " ".join(sentences[lo : hi + 1]).strip()
     if len(window) > _EXCERPT_MAX_CHARS:
         window = window[:_EXCERPT_MAX_CHARS].rsplit(" ", 1)[0] + "..."
-    return ("..." if lo > 0 else "") + window
+    # A space after the ellipsis, not fused to the window: synthesize_node's
+    # source_citations feed this into word-splitting fuzzy matching
+    # (frontend/src/lib/citation/target.ts), where "...The" is a token "The"
+    # never occurs in.
+    return ("... " if lo > 0 else "") + window
 
 
 def _resolve_marker_citations(

--- a/backend/tests/test_chat_graph_nodes.py
+++ b/backend/tests/test_chat_graph_nodes.py
@@ -778,15 +778,99 @@ async def test_synthesize_node_collects_citations_deduplicated(test_db):
     assert section_id_1 in section_ids_in_citations
     assert section_id_2 in section_ids_in_citations
 
-    # S157: section_preview_snippet must be populated from chunk text (first 150 chars)
+    # S157: section_preview_snippet must be populated from chunk text
     for c in source_citations:
         assert "section_preview_snippet" in c, f"Missing section_preview_snippet in citation: {c}"
         snippet = c["section_preview_snippet"]
         assert isinstance(snippet, str), "section_preview_snippet must be a string"
-        assert len(snippet) <= 150, f"section_preview_snippet exceeds 150 chars: {len(snippet)}"
-    # The first citation (chunk c1, text='text1') has snippet 'text1'
+    # Below _EXCERPT_MAX_CHARS, _excerpt_from_chunk returns the chunk unchanged.
     first_cit = next(c for c in source_citations if c["section_id"] == section_id_1)
     assert first_cit["section_preview_snippet"] == "text1"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_node_snippet_targets_the_question_not_the_chunk_head(test_db):
+    """The highlighted snippet is the sentence the question is about, not chunk[:150].
+
+    Reported live: asking "What is Recall and Precision?" against a chunk whose
+    first sentence is a generic definition of retrieval highlighted that generic
+    sentence in the reader instead of the chunk's actual Recall/Precision
+    sentence three sentences later. A head cut is technically a real quote (I-33
+    is not violated) but reads as a random highlight next to an unrelated
+    question, which is the whole trust argument for citations in the first place.
+    """
+    _engine, factory, _tmp = test_db
+    doc_id = str(uuid.uuid4())
+    await _insert_doc(factory, doc_id)
+
+    section_id = str(uuid.uuid4())
+    chunk_id = str(uuid.uuid4())
+
+    async with factory() as session:
+        session.add(
+            SectionModel(
+                id=section_id,
+                document_id=doc_id,
+                heading="Part 0",
+                level=1,
+                section_order=0,
+            )
+        )
+        session.add(
+            ChunkModel(
+                id=chunk_id,
+                document_id=doc_id,
+                section_id=section_id,
+                text=(
+                    "Retrieval is the task of finding, from a large corpus of documents, "
+                    "the small subset most relevant to a query. "
+                    "Every retrieval system is solving the same optimization problem. "
+                    "Recall measures how many of the relevant items were retrieved, while "
+                    "precision measures how many of the retrieved items were actually relevant. "
+                    "Real systems chain multiple stages together to balance both."
+                ),
+                chunk_index=0,
+                pdf_page_number=5,
+            )
+        )
+        await session.commit()
+
+    chunks = [
+        {
+            "chunk_id": chunk_id,
+            "document_id": doc_id,
+            "text": (
+                "Retrieval is the task of finding, from a large corpus of documents, "
+                "the small subset most relevant to a query. "
+                "Every retrieval system is solving the same optimization problem. "
+                "Recall measures how many of the relevant items were retrieved, while "
+                "precision measures how many of the retrieved items were actually relevant. "
+                "Real systems chain multiple stages together to balance both."
+            ),
+            "section_heading": "Part 0",
+            "page": 5,
+            "score": 0.9,
+            "source": "vector",
+        },
+    ]
+    state = _make_state(
+        question="What is Recall and Precision?",
+        chunks=chunks,
+        doc_ids=[doc_id],
+        intent="factual",
+    )
+
+    result = await synthesize_node(state)
+
+    source_citations = result.get("source_citations", [])
+    assert len(source_citations) == 1
+    snippet = source_citations[0]["section_preview_snippet"]
+    assert "recall measures" in snippet.lower(), (
+        f"snippet did not target the question's own terms: {snippet!r}"
+    )
+    assert not snippet.lower().startswith("retrieval is the task"), (
+        f"snippet regressed to a head cut of the chunk: {snippet!r}"
+    )
 
 
 # S158 AC: synthesize_node emits transparency event; augment_node sets augmented


### PR DESCRIPTION
## Summary

Reported live on the v0.11.2 build: asking "What is Recall and Precision?" in the docked reader's Ask AI panel highlighted a generic sentence about retrieval systems in general — the chunk's actual Recall/Precision content sat three sentences later in the same chunk.

`synthesize_node` built every `source_citation`'s `section_preview_snippet` as `chunk_text[:150]` — a plain head cut with no relation to the question. The reader's citation-click highlight fuzzy-matches those exact words against the rendered prose (`frontend/src/lib/citation/target.ts` → `match.ts`), so the highlight lands wherever the chunk happens to start rather than on the passage that actually answers the question. Confirmed this line is unchanged since the `v0.11.2` tag, so it's the same defect in the shipped build.

The fix already existed in the codebase and was simply never wired in: `qa.py`'s `_excerpt_from_chunk` scores every sentence in a chunk by content-word overlap with the question and windows around the best-scoring one, verbatim — built for exactly this class of bug ("12 of 15 excerpts were head cuts... the citations were right and the window was wrong", per its own docstring). Its module comment even already claims `MAX_CITATIONS`/`CITATION_REL_RATIO`/`CITATION_MIN_SCORE` are "shared with the chunk-derived source_citations in synthesize_node so both lists under one answer obey one policy" — the sentence-scoring function just never made that same trip across the import.

Stays inside invariant I-33: the excerpt is still a verbatim slice of the real retrieved chunk, never model-generated text — only a smarter choice of which slice.

## Changes

- `synthesize.py`: `section_preview_snippet` now calls `_excerpt_from_chunk(chunk_text, hint=question)` instead of `chunk_text[:150]`.
- `qa.py`: minor robustness fix to `_excerpt_from_chunk`'s ellipsis prefix (`"... "` instead of `"..."`) so it doesn't fuse into the following word when this snippet gets space-split for fuzzy word-matching downstream.
- `test_chat_graph_nodes.py`: updated a stale comment/assertion tied to the old 150-char head-cut behavior, and added `test_synthesize_node_snippet_targets_the_question_not_the_chunk_head`, which reproduces the exact reported scenario (a chunk whose first sentence is generic, with the actual Recall/Precision content later) and asserts the snippet targets the relevant sentence rather than the chunk's head.

## Test plan

- [x] New regression test passes, reproducing the reported bug and asserting the fix.
- [x] `tests/test_chat_graph_nodes.py`, `tests/test_qa.py`, `tests/test_context_packer.py` all green (121 tests).
- [x] Full backend suite green (3656 passed, 2 skipped, 108 deselected).
- [x] ruff, layer linter, boundary checker clean on touched files.
- [x] All CI jobs green (`ci`, `desktop-shell`, `desktop-shell-windows`, `windows-host-policy`, `powershell-syntax`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuWUNCbm9DWJeXuP2y3V2T