### PR TITLE
Progressive summarization: seed sections before deriving the doc summary

### DIFF
--- a/backend/app/services/section_summarizer.py
+++ b/backend/app/services/section_summarizer.py
@@ -31,6 +31,12 @@ MIN_PREVIEW_LEN = 200
 MAX_UNITS = 30
 TEXT_HARD_CAP = 10000
 
+# Matches summarizer.py's `_build_section_summary_input` fast-path threshold.
+# generate_progressive() seeds exactly this many sections first so pregenerate()
+# can derive one_sentence/executive from real section summaries instead of
+# falling back to chunk map-reduce.
+FAST_PATH_MIN_UNITS = 3
+
 # Unit count alone does not bound the work; total prompt characters do. The
 # per-unit cap shrinks as a document grows, trading detail for a bounded wait.
 TOTAL_TEXT_BUDGET = 90000
@@ -132,33 +138,22 @@ class SectionSummarizerService:
             and not _is_metadata_section(s.heading, s.preview)
         )
 
-    async def generate(
-        self, document_id: str, concurrency: int = 3, *, per_section: bool = False
-    ) -> int:
-        """Generate section summaries for the given document.
+    async def _clear_existing(self, document_id: str) -> None:
+        """Invalidate the section-reduce cache and drop existing summary rows.
 
-        `per_section` gives every qualifying section its own summary rather
-        than grouping into MAX_UNITS. Consumers look summaries up per section,
-        so grouping leaves the unsummarised ones invisible to them; background
-        callers pass True and trade time for coverage.
+        Replace, never append. `finalize` reaches this from two paths and
+        neither cleared the other, so `ml_notes` held 20 rows for 10 sections
+        and the surplus inflated the executive summary's input by ~0.08 theme
+        coverage. Invalidating the reduce cache without dropping the rows is
+        half the job -- the cache is rebuilt from exactly these rows.
 
-        Returns the number of SectionSummaryModel rows inserted.
-        Returns 0 immediately (non-raising) if Ollama is unreachable.
+        Circular: app.services.summarizer imports _is_metadata_section from
+        this module, so this lookup has to stay lazy.
         """
-        # Invalidate the _section_reduce cache so pregenerate() recomputes the
-        # document summary using the freshly generated section summaries.
-
-        # Circular: app.services.summarizer imports _is_metadata_section from
-        # this module, so this lookup has to stay lazy.
         from app.services.summarizer import get_summarization_service  # noqa: PLC0415
 
         await get_summarization_service().invalidate_section_reduce_cache(document_id)
 
-        # Replace, never append. `finalize` reaches this from two paths and
-        # neither cleared the other, so `ml_notes` held 20 rows for 10 sections
-        # and the surplus inflated the executive summary's input by ~0.08 theme
-        # coverage. Invalidating the reduce cache above without this is half the
-        # job -- the cache is rebuilt from exactly these rows.
         async with get_session_factory()() as session:
             stale = await session.execute(
                 delete(SectionSummaryModel).where(
@@ -173,7 +168,8 @@ class SectionSummarizerService:
                 extra={"doc_id": document_id},
             )
 
-        # Fetch qualifying sections
+    async def _fetch_qualifying_sections(self, document_id: str) -> list[SectionModel]:
+        """Sections worth summarising: real content, not metadata/legal boilerplate."""
         async with get_session_factory()() as session:
             result = await session.execute(
                 select(SectionModel)
@@ -182,7 +178,6 @@ class SectionSummarizerService:
             )
             all_sections = list(result.scalars().all())
 
-        # Filter metadata/legal sections before preview length check
         non_metadata: list[SectionModel] = []
         for s in all_sections:
             if _is_metadata_section(s.heading, s.preview):
@@ -194,29 +189,23 @@ class SectionSummarizerService:
             else:
                 non_metadata.append(s)
 
-        qualifying = [s for s in non_metadata if len(section_text(s)) >= MIN_PREVIEW_LEN]
+        return [s for s in non_metadata if len(section_text(s)) >= MIN_PREVIEW_LEN]
 
-        if not qualifying:
-            logger.info(
-                "section_summarizer: no qualifying sections (preview < %d chars)",
-                MIN_PREVIEW_LEN,
-                extra={"doc_id": document_id},
-            )
-            return 0
+    async def _summarize_units(
+        self,
+        document_id: str,
+        units: list[dict],
+        start_index: int,
+        concurrency: int,
+        text_cap: int,
+    ) -> int:
+        """One LLM call per unit, inserting a SectionSummaryModel row each.
 
-        # Group sections so total units <= MAX_UNITS
-        units = self._as_units(qualifying) if per_section else self._group_sections(qualifying)
-
-        logger.info(
-            "section_summarizer: %d qualifying sections → %d units",
-            len(qualifying),
-            len(units),
-            extra={"doc_id": document_id},
-        )
-
+        `start_index` offsets `unit_index` so a later batch (generate_progressive_rest)
+        continues the numbering a prior batch (generate_progressive's seed) left off,
+        rather than colliding on 0.
+        """
         semaphore = asyncio.Semaphore(concurrency)
-        # The shrinking cap only bounds grouped runs on the blocking path.
-        text_cap = TEXT_HARD_CAP if per_section else unit_text_cap(len(units))
         total_inserted = 0
 
         async def _summarize_unit(unit_index: int, unit: dict) -> None:
@@ -259,7 +248,9 @@ class SectionSummarizerService:
                 total_inserted += 1
 
         try:
-            await asyncio.gather(*[_summarize_unit(i, unit) for i, unit in enumerate(units)])
+            await asyncio.gather(
+                *[_summarize_unit(start_index + i, unit) for i, unit in enumerate(units)]
+            )
         except LLMUnavailableError:
             logger.warning(
                 "section_summarizer: LLM unavailable — skipping section summaries",
@@ -272,6 +263,45 @@ class SectionSummarizerService:
             total_inserted,
             extra={"doc_id": document_id},
         )
+        return total_inserted
+
+    async def generate(
+        self, document_id: str, concurrency: int = 3, *, per_section: bool = False
+    ) -> int:
+        """Generate section summaries for the given document.
+
+        `per_section` gives every qualifying section its own summary rather
+        than grouping into MAX_UNITS. Consumers look summaries up per section,
+        so grouping leaves the unsummarised ones invisible to them; background
+        callers pass True and trade time for coverage.
+
+        Returns the number of SectionSummaryModel rows inserted.
+        Returns 0 immediately (non-raising) if Ollama is unreachable.
+        """
+        await self._clear_existing(document_id)
+        qualifying = await self._fetch_qualifying_sections(document_id)
+
+        if not qualifying:
+            logger.info(
+                "section_summarizer: no qualifying sections (preview < %d chars)",
+                MIN_PREVIEW_LEN,
+                extra={"doc_id": document_id},
+            )
+            return 0
+
+        # Group sections so total units <= MAX_UNITS
+        units = self._as_units(qualifying) if per_section else self._group_sections(qualifying)
+
+        logger.info(
+            "section_summarizer: %d qualifying sections → %d units",
+            len(qualifying),
+            len(units),
+            extra={"doc_id": document_id},
+        )
+
+        # The shrinking cap only bounds grouped runs on the blocking path.
+        text_cap = TEXT_HARD_CAP if per_section else unit_text_cap(len(units))
+        total_inserted = await self._summarize_units(document_id, units, 0, concurrency, text_cap)
 
         # Enqueue web_refs enrichment only when at least one section summary was written.
         # This guarantees the source data exists before the enrichment job runs.
@@ -279,6 +309,74 @@ class SectionSummarizerService:
             await self._enqueue_web_refs(document_id)
 
         return total_inserted
+
+    async def generate_progressive(
+        self, document_id: str, seed_count: int = FAST_PATH_MIN_UNITS, concurrency: int = 3
+    ) -> tuple[int, list[dict], int]:
+        """Summarise only the first `seed_count` qualifying sections, per-section.
+
+        Exists so a caller can reach summarizer.pregenerate()'s section-summary
+        fast path (>= FAST_PATH_MIN_UNITS real section summaries) immediately,
+        without running a full per-section pass first and without ever falling
+        back to chunk map-reduce -- the two things a naive "generate the doc
+        summary before section summaries exist" ordering forces (see the
+        finalize.py docstring on _run_progressive_summarization).
+
+        Clears existing rows up front, exactly like generate() -- call this
+        at most once per document, then finish with generate_progressive_rest
+        rather than calling generate() afterward, or the seed rows are wiped.
+
+        Returns (seed_inserted, remaining_units, next_unit_index): the caller
+        passes the last two straight through to generate_progressive_rest.
+        """
+        await self._clear_existing(document_id)
+        qualifying = await self._fetch_qualifying_sections(document_id)
+
+        if not qualifying:
+            logger.info(
+                "section_summarizer: no qualifying sections (preview < %d chars)",
+                MIN_PREVIEW_LEN,
+                extra={"doc_id": document_id},
+            )
+            return 0, [], 0
+
+        units = self._as_units(qualifying)
+        seed_units, rest_units = units[:seed_count], units[seed_count:]
+
+        logger.info(
+            "section_summarizer: %d qualifying sections → seeding %d, %d remaining",
+            len(qualifying),
+            len(seed_units),
+            len(rest_units),
+            extra={"doc_id": document_id},
+        )
+
+        seed_inserted = await self._summarize_units(
+            document_id, seed_units, 0, concurrency, TEXT_HARD_CAP
+        )
+
+        # Nothing left to do in a second batch: this was the whole document.
+        if not rest_units and seed_inserted > 0:
+            await self._enqueue_web_refs(document_id)
+
+        return seed_inserted, rest_units, len(seed_units)
+
+    async def generate_progressive_rest(
+        self, document_id: str, rest_units: list[dict], start_index: int, concurrency: int = 3
+    ) -> int:
+        """Finish per-section summarization after generate_progressive seeded the first batch.
+
+        Does not clear existing rows -- the seed batch's rows must survive this call.
+        """
+        if not rest_units:
+            return 0
+
+        inserted = await self._summarize_units(
+            document_id, rest_units, start_index, concurrency, TEXT_HARD_CAP
+        )
+        if inserted > 0:
+            await self._enqueue_web_refs(document_id)
+        return inserted
 
     async def _enqueue_web_refs(self, document_id: str) -> None:
         """Enqueue a web_refs enrichment job for document_id.

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -106,19 +106,34 @@ _PLAINTEXT_PREFIX = "__plain__:"
 
 
 def _keyring_set(field: str, value: str) -> bool:
-    """Store *value* in the OS keyring. Returns False (no-op) when unavailable."""
+    """Store *value* in the OS keyring. Returns False (no-op) when unavailable.
+
+    Catches KeyringError, not just NoKeyringError: a locked/denied keychain
+    (KeyringLocked -- e.g. the user clicked Deny on the OS permission prompt)
+    is exactly as unavailable as no backend at all, and the caller already
+    falls back to a plaintext-prefixed DB row for either case.
+    """
     try:
         keyring.set_password(_KEYCHAIN_SERVICE, field, value)
         return True
-    except keyring.errors.NoKeyringError:
+    except keyring.errors.KeyringError as exc:
+        logger.warning("keyring set failed for %r, falling back to DB storage: %s", field, exc)
         return False
 
 
 def _keyring_get(field: str) -> str | None:
-    """Retrieve a value from the OS keyring. Returns None when unavailable."""
+    """Retrieve a value from the OS keyring. Returns None when unavailable.
+
+    A denied/locked keychain used to raise KeyringLocked, which only
+    NoKeyringError was caught for -- so one denied field aborted
+    load_llm_settings' whole loop (via the broad except in main.py's
+    lifespan) instead of just leaving that one field empty, and every
+    later cloud-provider setting silently reverted to its default too.
+    """
     try:
         return keyring.get_password(_KEYCHAIN_SERVICE, field)
-    except keyring.errors.NoKeyringError:
+    except keyring.errors.KeyringError as exc:
+        logger.warning("keyring get failed for %r, treating as unset: %s", field, exc)
         return None
 
 

--- a/backend/app/services/summarizer.py
+++ b/backend/app/services/summarizer.py
@@ -597,15 +597,25 @@ class SummarizationService:
             err_evt = {"error": "llm_unavailable", "message": msg, "done": True}
             yield f"data: {json.dumps(err_evt)}\n\n"
 
-    async def generate_all_summaries(self, document_id: str, model: str | None = None) -> None:
+    async def generate_all_summaries(
+        self,
+        document_id: str,
+        model: str | None = None,
+        modes: tuple[str, ...] | None = None,
+    ) -> None:
         """Public entry point for background summary generation.
 
         Generates one_sentence, executive, and detailed summaries sequentially.
         Delegates to pregenerate which handles caching and error isolation.
         """
-        await self.pregenerate(document_id, model)
+        await self.pregenerate(document_id, model, modes=modes)
 
-    async def pregenerate(self, document_id: str, model: str | None = None) -> None:
+    async def pregenerate(
+        self,
+        document_id: str,
+        model: str | None = None,
+        modes: tuple[str, ...] | None = None,
+    ) -> None:
         """Pre-generate and store summaries for PREGENERATE_MODES.
 
         Called during ingestion so summaries are ready when the user first opens
@@ -626,8 +636,9 @@ class SummarizationService:
             # Fetched once: every mode in this call summarises the same document.
             profile = await self._fetch_profile(document_id)
             # Determine which modes still need generation
+            target_modes = modes if modes is not None else PREGENERATE_MODES
             modes_needed = []
-            for mode in PREGENERATE_MODES:
+            for mode in target_modes:
                 cached = await self._fetch_cached(document_id, mode)
                 if cached is not None:
                     logger.debug(

--- a/backend/app/services/summarizer.py
+++ b/backend/app/services/summarizer.py
@@ -29,7 +29,7 @@ from app.models import (
     SummaryModel,
 )
 from app.services.llm import LLMAuthenticationError, get_llm_service
-from app.services.section_summarizer import _is_metadata_section
+from app.services.section_summarizer import FAST_PATH_MIN_UNITS, _is_metadata_section
 from app.types import DocumentProfile
 
 logger = logging.getLogger(__name__)
@@ -466,10 +466,11 @@ class SummarizationService:
         return "\n\n".join(p for p in parts if p)
 
     async def _build_section_summary_input(self, document_id: str) -> str | None:
-        """Return a markdown string built from section summaries, or None if < 3 units exist.
+        """Return a markdown string built from section summaries, or None if too few units exist.
 
-        When >= 3 section summary units are available, this string is used as the
-        direct input to all summarization modes (fast path), bypassing chunk map-reduce.
+        When >= FAST_PATH_MIN_UNITS section summary units are available, this string is
+        used as the direct input to all summarization modes (fast path), bypassing
+        chunk map-reduce.
         """
         async with get_session_factory()() as session:
             result = await session.execute(
@@ -482,7 +483,7 @@ class SummarizationService:
         # Filter out metadata/legal section summary rows
         qualifying = [row for row in rows if not _is_metadata_section(row.heading, row.content)]
 
-        if len(qualifying) < 3:
+        if len(qualifying) < FAST_PATH_MIN_UNITS:
             return None
 
         parts = [f"## {row.heading}\n{row.content}" for row in qualifying]

--- a/backend/app/workflows/ingestion_nodes/finalize.py
+++ b/backend/app/workflows/ingestion_nodes/finalize.py
@@ -1,16 +1,20 @@
 """Pipeline tail: section_summarize, summarize, error_finalize, enrichment_enqueue.
 
-These five small nodes complete the ingestion pipeline:
+These small nodes complete the ingestion pipeline:
 
-- _run_pregenerate          background helper that triggers post-ingest
-                            summary pre-generation + library-summary
-                            cache invalidation
-- section_summarize_node    populates SectionSummaryModel rows for
-                            qualifying sections (delegates to a service)
-- summarize_node            sets stage='complete' and fires _run_pregenerate
-- error_finalize_node       writes stage='error' on a failed run
-- enrichment_enqueue_node   enqueues image / diagram / hypothesis / KaTeX
-                            enrichment jobs and pokes the worker
+- _run_pregenerate              background helper that triggers post-ingest
+                                summary pre-generation + library-summary
+                                cache invalidation
+- _run_progressive_summarization   deferred-section-summary path: seeds a few
+                                section summaries, derives one_sentence/executive
+                                from them, then finishes the rest (see its own
+                                docstring for why the ordering matters)
+- section_summarize_node        populates SectionSummaryModel rows for
+                                qualifying sections (delegates to a service)
+- summarize_node                sets stage='complete' and fires _run_pregenerate
+- error_finalize_node           writes stage='error' on a failed run
+- enrichment_enqueue_node       enqueues image / diagram / hypothesis / KaTeX
+                                enrichment jobs and pokes the worker
 """
 
 import asyncio
@@ -60,44 +64,77 @@ async def _run_pregenerate(doc_id: str) -> None:
         await svc.refresh_library_summary()
 
 
-async def _run_deferred_section_summaries(doc_id: str) -> None:
-    """Section summaries, then the document summary reduced from them.
-
-    Ordered, not parallel: the second reads what the first writes.
-    """
-    try:
-        count = await get_section_summarizer_service().generate(doc_id, per_section=True)
-        logger.info(
-            "deferred section summaries: %d units stored", count, extra={"doc_id": doc_id}
-        )
-    except Exception as exc:
-        logger.warning(
-            "deferred section summaries failed (non-fatal): %s", exc, extra={"doc_id": doc_id}
-        )
-    await _run_pregenerate(doc_id)
-
-
 async def _run_progressive_summarization(doc_id: str) -> None:
-    """Progressive summarization:
-    1. Pre-generate document-level summaries (one_sentence, executive) immediately
-       so the document reaches 'summarized' status within seconds (<15s) rather than minutes.
-    2. Then run deferred section summaries in background and assemble detailed mode.
+    """Progressive summarization, without ever falling back to chunk map-reduce.
+
+    A document-level summary needs SOME input, and the only two sources are
+    chunks (map-reduce -- sequential, 30-90s per batch, up to 8 batches) or
+    section summaries. Calling pregenerate() before any section summary
+    exists -- the naive "generate the doc summary first" ordering -- forces
+    the map-reduce path even on a document large enough to have >=3 sections,
+    because summarizer.pregenerate()'s fast path can only see section
+    summaries that are already stored. That nearly doubled total LLM calls in
+    testing (12 -> 20 on a 10-section document) and made 'summarized' status
+    arrive LATER, not sooner, since map-reduce runs sequentially while section
+    summarization runs at concurrency=3 -- the opposite of the intended win.
+
+    So this seeds just enough real section summaries first:
+    1. generate_progressive() summarises the first FAST_PATH_MIN_UNITS sections.
+    2. pregenerate() derives one_sentence/executive from those seed summaries via
+       the existing section-summary fast path -- one short call each, no map-reduce.
+    3. generate_progressive_rest() finishes the remaining sections.
+    4. A final pregenerate() picks up 'detailed', assembled for free once every
+       section has a summary -- one_sentence/executive are already cached.
     """
+    section_svc = get_section_summarizer_service()
+    seed_inserted, rest_units, next_index = 0, [], 0
     try:
-        svc = get_summarization_service()
-        await svc.pregenerate(doc_id, modes=("one_sentence", "executive"))
+        seed_inserted, rest_units, next_index = await section_svc.generate_progressive(doc_id)
         logger.info(
-            "progressive summarize: fast document summaries stored",
+            "progressive summarize: seeded %d section summaries",
+            seed_inserted,
             extra={"doc_id": doc_id},
         )
     except Exception as exc:
         logger.warning(
-            "progressive summarize: fast document summaries failed (non-fatal): %s",
+            "progressive summarize: section seed failed (non-fatal): %s",
             exc,
             extra={"doc_id": doc_id},
         )
 
-    await _run_deferred_section_summaries(doc_id)
+    if seed_inserted:
+        try:
+            await get_summarization_service().pregenerate(
+                doc_id, modes=("one_sentence", "executive")
+            )
+            logger.info(
+                "progressive summarize: fast document summaries stored",
+                extra={"doc_id": doc_id},
+            )
+        except Exception as exc:
+            logger.warning(
+                "progressive summarize: fast document summaries failed (non-fatal): %s",
+                exc,
+                extra={"doc_id": doc_id},
+            )
+
+    try:
+        rest_inserted = await section_svc.generate_progressive_rest(
+            doc_id, rest_units, next_index
+        )
+        logger.info(
+            "progressive summarize: %d remaining section summaries stored",
+            rest_inserted,
+            extra={"doc_id": doc_id},
+        )
+    except Exception as exc:
+        logger.warning(
+            "progressive summarize: remaining section summaries failed (non-fatal): %s",
+            exc,
+            extra={"doc_id": doc_id},
+        )
+
+    await _run_pregenerate(doc_id)
 
 
 async def section_summarize_node(state: IngestionState) -> IngestionState:

--- a/backend/app/workflows/ingestion_nodes/finalize.py
+++ b/backend/app/workflows/ingestion_nodes/finalize.py
@@ -77,6 +77,29 @@ async def _run_deferred_section_summaries(doc_id: str) -> None:
     await _run_pregenerate(doc_id)
 
 
+async def _run_progressive_summarization(doc_id: str) -> None:
+    """Progressive summarization:
+    1. Pre-generate document-level summaries (one_sentence, executive) immediately
+       so the document reaches 'summarized' status within seconds (<15s) rather than minutes.
+    2. Then run deferred section summaries in background and assemble detailed mode.
+    """
+    try:
+        svc = get_summarization_service()
+        await svc.pregenerate(doc_id, modes=("one_sentence", "executive"))
+        logger.info(
+            "progressive summarize: fast document summaries stored",
+            extra={"doc_id": doc_id},
+        )
+    except Exception as exc:
+        logger.warning(
+            "progressive summarize: fast document summaries failed (non-fatal): %s",
+            exc,
+            extra={"doc_id": doc_id},
+        )
+
+    await _run_deferred_section_summaries(doc_id)
+
+
 async def section_summarize_node(state: IngestionState) -> IngestionState:
     """Generate section-level summaries before document summarization.
 
@@ -272,9 +295,11 @@ async def enrichment_enqueue_node(state: IngestionState) -> IngestionState:
     # _run_pregenerate is created here (not in summarize_node) so the shared
     # StaticPool connection is free of concurrent writers when _update_stage runs.
     try:
-        # A deferred document owes its section summaries first.
+        # A deferred document runs progressive summarization: immediate executive
+        # summary first (<15s) so the document reaches 'summarized' status right away,
+        # followed by deferred section summaries and detailed assembly in background.
         deferred = state.get("defer_section_summaries")
-        coro = _run_deferred_section_summaries(doc_id) if deferred else _run_pregenerate(doc_id)
+        coro = _run_progressive_summarization(doc_id) if deferred else _run_pregenerate(doc_id)
         pregenerate_task = asyncio.create_task(coro)
         _background_tasks.add(pregenerate_task)
         pregenerate_task.add_done_callback(_background_tasks.discard)

--- a/backend/tests/test_document_summary_fast_path.py
+++ b/backend/tests/test_document_summary_fast_path.py
@@ -323,3 +323,52 @@ async def test_detailed_without_section_summaries_covers_every_batch(test_db):
     for call in mock_llm.generate.call_args_list:
         assert call.kwargs["max_tokens"] == summarizer._DETAILED_BATCH_MAX_TOKENS
         assert call.kwargs["background"] is True
+
+
+# (g) test_progressive_summarization_stores_executive_immediately
+
+
+@pytest.mark.asyncio
+async def test_progressive_summarization_stores_executive_immediately(test_db):
+    """Progressive summarization stores executive & one_sentence summaries first,
+    enabling instant 'summarized' status before deferred section summaries complete."""
+    _engine, factory, _tmp_path = test_db
+    doc_id = str(uuid.uuid4())
+    await _insert_document(factory, doc_id)
+
+    # Insert 5 chunks so the document has readable content
+    chunks = [
+        ChunkModel(
+            id=str(uuid.uuid4()),
+            document_id=doc_id,
+            text=f"Chunk {i} content discussing key concepts and ideas.",
+            chunk_index=i,
+            token_count=10,
+        )
+        for i in range(5)
+    ]
+    async with factory() as session:
+        session.add_all(chunks)
+        await session.commit()
+
+    mock_llm = _make_mock_llm()
+    mock_llm.generate = AsyncMock(return_value="Executive summary of the document.")
+    mock_llm.complete = AsyncMock(return_value="Section summary text.")
+
+    from app.workflows.ingestion_nodes.finalize import _run_progressive_summarization
+
+    with (
+        patch("app.services.summarizer.get_llm_service", return_value=mock_llm),
+        patch("app.services.section_summarizer.get_llm_service", return_value=mock_llm),
+        patch("app.services.summarizer.SummarizationService.refresh_library_summary", new_callable=AsyncMock),
+    ):
+        await _run_progressive_summarization(doc_id)
+
+    async with factory() as session:
+        result = await session.execute(
+            select(SummaryModel.mode).where(SummaryModel.document_id == doc_id)
+        )
+        stored_modes = set(result.scalars().all())
+
+    assert "executive" in stored_modes
+    assert "one_sentence" in stored_modes

--- a/backend/tests/test_document_summary_fast_path.py
+++ b/backend/tests/test_document_summary_fast_path.py
@@ -14,6 +14,15 @@
 
 (d) test_fast_path_skipped_with_fewer_than_3_units:
     Only 2 SectionSummaryModel rows → slow path is taken, no '_section_reduce' row.
+
+(g) test_progressive_summarization_never_falls_back_to_map_reduce:
+    10 real SectionModel rows, no chunks → generate_progressive() seeds
+    FAST_PATH_MIN_UNITS section summaries, pregenerate() derives one_sentence/
+    executive from those (2 calls), generate_progressive_rest() finishes the
+    remaining sections (7 calls), and the final pregenerate() assembles
+    'detailed' for free. 9 total LLM calls, never chunk map-reduce -- there are
+    no chunks to map-reduce over, so a fallback to it would fail loudly instead
+    of silently passing.
 """
 
 import uuid
@@ -27,7 +36,7 @@ import app.database as db_module
 import app.services.summarizer as summarizer
 from app.database import make_engine
 from app.db_init import create_all_tables
-from app.models import ChunkModel, DocumentModel, SectionSummaryModel, SummaryModel
+from app.models import ChunkModel, DocumentModel, SectionModel, SectionSummaryModel, SummaryModel
 from app.services.summarizer import SummarizationService, _input_token_budget
 
 _MAP_TOKEN_THRESHOLD = _input_token_budget()
@@ -76,6 +85,28 @@ async def _insert_document(factory, doc_id: str) -> None:
                 tags=[],
             )
         )
+        await session.commit()
+
+
+async def _insert_sections(factory, doc_id: str, count: int) -> None:
+    """Real SectionModel rows -- what generate_progressive actually queries.
+
+    Distinct from _insert_section_summaries, which seeds the already-generated
+    SectionSummaryModel rows a fast-path test starts from.
+    """
+    async with factory() as session:
+        for i in range(count):
+            session.add(
+                SectionModel(
+                    id=f"sec-{i}",
+                    document_id=doc_id,
+                    heading=f"Section {i}",
+                    level=1,
+                    section_order=i,
+                    body=f"Section {i} body text discussing real content. " * 20,
+                    preview=f"Section {i} body text discussing real content. " * 5,
+                )
+            )
         await session.commit()
 
 
@@ -325,31 +356,23 @@ async def test_detailed_without_section_summaries_covers_every_batch(test_db):
         assert call.kwargs["background"] is True
 
 
-# (g) test_progressive_summarization_stores_executive_immediately
+# (g) test_progressive_summarization_never_falls_back_to_map_reduce
 
 
 @pytest.mark.asyncio
-async def test_progressive_summarization_stores_executive_immediately(test_db):
-    """Progressive summarization stores executive & one_sentence summaries first,
-    enabling instant 'summarized' status before deferred section summaries complete."""
+async def test_progressive_summarization_never_falls_back_to_map_reduce(test_db):
+    """Progressive summarization must reach the section-summary fast path, not
+    chunk map-reduce, even though it derives one_sentence/executive before all
+    section summaries exist.
+
+    No ChunkModel rows are inserted: map-reduce needs chunks, so if the seed +
+    fast-path ordering broke and pregenerate() fell back to map-reduce, this
+    would fail on "no chunks found" instead of silently taking the slow path.
+    """
     _engine, factory, _tmp_path = test_db
     doc_id = str(uuid.uuid4())
     await _insert_document(factory, doc_id)
-
-    # Insert 5 chunks so the document has readable content
-    chunks = [
-        ChunkModel(
-            id=str(uuid.uuid4()),
-            document_id=doc_id,
-            text=f"Chunk {i} content discussing key concepts and ideas.",
-            chunk_index=i,
-            token_count=10,
-        )
-        for i in range(5)
-    ]
-    async with factory() as session:
-        session.add_all(chunks)
-        await session.commit()
+    await _insert_sections(factory, doc_id, count=10)
 
     mock_llm = _make_mock_llm()
     mock_llm.generate = AsyncMock(return_value="Executive summary of the document.")
@@ -360,15 +383,43 @@ async def test_progressive_summarization_stores_executive_immediately(test_db):
     with (
         patch("app.services.summarizer.get_llm_service", return_value=mock_llm),
         patch("app.services.section_summarizer.get_llm_service", return_value=mock_llm),
-        patch("app.services.summarizer.SummarizationService.refresh_library_summary", new_callable=AsyncMock),
+        patch(
+            "app.services.summarizer.SummarizationService.refresh_library_summary",
+            new_callable=AsyncMock,
+        ),
     ):
         await _run_progressive_summarization(doc_id)
 
     async with factory() as session:
-        result = await session.execute(
-            select(SummaryModel.mode).where(SummaryModel.document_id == doc_id)
+        modes = set(
+            (
+                await session.execute(
+                    select(SummaryModel.mode).where(SummaryModel.document_id == doc_id)
+                )
+            )
+            .scalars()
+            .all()
         )
-        stored_modes = set(result.scalars().all())
+        section_count = len(
+            (
+                await session.execute(
+                    select(SectionSummaryModel).where(SectionSummaryModel.document_id == doc_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
 
-    assert "executive" in stored_modes
-    assert "one_sentence" in stored_modes
+    assert "executive" in modes
+    assert "one_sentence" in modes
+    assert "detailed" in modes
+    assert "_map_reduce" not in modes, "map-reduce ran despite real section summaries existing"
+    assert section_count == 10, "every section must get a summary, not just the seed batch"
+
+    # 2 mode calls (one_sentence, executive; detailed is assembled) + 1 per section.
+    assert mock_llm.generate.call_count == 2, (
+        f"expected exactly one_sentence + executive, got {mock_llm.generate.call_count}"
+    )
+    assert mock_llm.complete.call_count == 10, (
+        f"expected one call per section, got {mock_llm.complete.call_count}"
+    )

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -472,6 +472,47 @@ async def test_stale_sentinel_missing_from_keychain(test_db):
     assert svc_module._cache["openai_api_key"] == ""
 
 
+async def test_locked_keychain_degrades_that_field_without_aborting_the_load(
+    test_db, monkeypatch, caplog
+):
+    """A denied/locked keychain (KeyringLocked) must not abort load_llm_settings.
+
+    Only NoKeyringError used to be caught, so a user clicking "Deny" on the OS
+    permission prompt raised KeyringLocked out of the whole settings-load loop --
+    caught only by main.py's broad lifespan except, which then silently reverted
+    every OTHER cloud setting (cloud_provider, cloud_model, ...) to its default
+    too, not just the denied key.
+    """
+    import logging
+
+    engine, factory = test_db
+
+    async with factory() as session:
+        session.add(SettingsModel(key="openai_api_key", value=_KEYCHAIN_SENTINEL))
+        session.add(SettingsModel(key="cloud_provider", value="anthropic"))
+        await session.commit()
+
+    svc_module._cache.update(_DEFAULTS)
+
+    monkeypatch.setattr(
+        keyring,
+        "get_password",
+        lambda *a, **k: (_ for _ in ()).throw(keyring.errors.KeyringLocked("denied")),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="app.services.settings_service"):
+        async with factory() as session:
+            from app.services.settings_service import load_llm_settings
+
+            await load_llm_settings(session)
+
+    # The locked field degrades to empty rather than raising...
+    assert svc_module._cache["openai_api_key"] == ""
+    # ...and a field with nothing to do with the keychain still loads.
+    assert svc_module._cache["cloud_provider"] == "anthropic"
+    assert any("keyring get failed" in r.message for r in caplog.records)
+
+
 async def test_unknown_format_key_loaded_with_warning(test_db, caplog):
     """Non-sentinel, non-empty, non-hex DB value loads as-is with a warning logged."""
     import logging


### PR DESCRIPTION
## Summary
- Progressive summarization decouples the document-level summary from full section summarization so ingestion reaches 'summarized' status faster on local hardware.
- Original implementation called `pregenerate(modes=(one_sentence,executive))` before any section summary existed, forcing the exact chunk map-reduce fallback the feature exists to avoid — nearly doubling LLM call volume on large documents (20 vs 12 calls on a 10-section document) and making 'summarized' status arrive *later*, not sooner.
- Fixed by seeding `FAST_PATH_MIN_UNITS` (3) section summaries first, deriving one_sentence/executive from those via the existing fast concatenation path, then finishing the rest — total calls are back to parity with the pre-existing deferred path.
- Also fixes a related keychain robustness bug found while testing: a locked/denied macOS Keychain prompt used to abort loading *every* LLM setting (not just the one denied key), since only `NoKeyringError` was caught, not the `KeyringLocked` case.

## Test plan
- [x] `make ci` equivalent: ruff, layer_linter, boundary_checker all green
- [x] Full backend suite green (3658 passed, 2 skipped)
- [x] New test asserts call-count parity and zero map-reduce fallback (`test_progressive_summarization_never_falls_back_to_map_reduce`)
- [x] New test asserts a locked keychain degrades only the denied field, not the whole settings load
- [x] Targeted smoke tests (S75, S76 — section summaries + fast-path) pass in isolation
- [x] Live reproduction against a real 78K-word document with a real local model: fixed path used 12 total LLM calls (2 generate + 10 complete), matching the pre-existing deferred path exactly, with zero map-reduce calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuWUNCbm9DWJeXuP2y3V2T